### PR TITLE
feat: 채팅 추가 API 및 앱스토어 정책 대응 기능 구현

### DIFF
--- a/apps/api/src/main/java/com/acnh/api/block/controller/BlockController.java
+++ b/apps/api/src/main/java/com/acnh/api/block/controller/BlockController.java
@@ -1,0 +1,127 @@
+package com.acnh.api.block.controller;
+
+import com.acnh.api.block.dto.BlockListResponse;
+import com.acnh.api.block.dto.BlockRequest;
+import com.acnh.api.block.dto.BlockResponse;
+import com.acnh.api.block.service.BlockService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+/**
+ * 차단 관련 API 컨트롤러
+ * Base Path: /api/blocks
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/blocks")
+@RequiredArgsConstructor
+public class BlockController {
+
+    private final BlockService blockService;
+
+    /**
+     * 사용자 차단
+     * POST /api/blocks
+     */
+    @PostMapping
+    public ResponseEntity<?> blockUser(
+            @AuthenticationPrincipal String visitorId,
+            @Valid @RequestBody BlockRequest request) {
+
+        log.info("차단 요청 - blockedUserId: {}, visitorId: {}", request.getBlockedUserId(), visitorId);
+
+        if (visitorId == null) {
+            return ResponseEntity.status(401).body(Map.of(
+                    "error", "UNAUTHORIZED",
+                    "message", "로그인이 필요합니다"
+            ));
+        }
+
+        try {
+            BlockResponse response = blockService.blockUser(request, visitorId);
+            return ResponseEntity.status(201).body(response);
+        } catch (IllegalArgumentException e) {
+            if (e.getMessage().contains("존재하지 않는")) {
+                return ResponseEntity.status(404).body(Map.of(
+                        "error", "NOT_FOUND",
+                        "message", e.getMessage()
+                ));
+            }
+            return ResponseEntity.badRequest().body(Map.of(
+                    "error", "INVALID_REQUEST",
+                    "message", e.getMessage()
+            ));
+        }
+    }
+
+    /**
+     * 차단 해제
+     * DELETE /api/blocks/{blockedUserId}
+     */
+    @DeleteMapping("/{blockedUserId}")
+    public ResponseEntity<?> unblockUser(
+            @AuthenticationPrincipal String visitorId,
+            @PathVariable Long blockedUserId) {
+
+        log.info("차단 해제 요청 - blockedUserId: {}, visitorId: {}", blockedUserId, visitorId);
+
+        if (visitorId == null) {
+            return ResponseEntity.status(401).body(Map.of(
+                    "error", "UNAUTHORIZED",
+                    "message", "로그인이 필요합니다"
+            ));
+        }
+
+        try {
+            blockService.unblockUser(blockedUserId, visitorId);
+            return ResponseEntity.ok(Map.of(
+                    "message", "차단이 해제되었습니다"
+            ));
+        } catch (IllegalArgumentException e) {
+            if (e.getMessage().contains("존재하지 않는") || e.getMessage().contains("차단 내역")) {
+                return ResponseEntity.status(404).body(Map.of(
+                        "error", "NOT_FOUND",
+                        "message", e.getMessage()
+                ));
+            }
+            return ResponseEntity.badRequest().body(Map.of(
+                    "error", "INVALID_REQUEST",
+                    "message", e.getMessage()
+            ));
+        }
+    }
+
+    /**
+     * 내가 차단한 사용자 목록 조회
+     * GET /api/blocks
+     */
+    @GetMapping
+    public ResponseEntity<?> getBlockedUsers(
+            @AuthenticationPrincipal String visitorId) {
+
+        log.info("차단 목록 조회 요청 - visitorId: {}", visitorId);
+
+        if (visitorId == null) {
+            return ResponseEntity.status(401).body(Map.of(
+                    "error", "UNAUTHORIZED",
+                    "message", "로그인이 필요합니다"
+            ));
+        }
+
+        try {
+            BlockListResponse response = blockService.getBlockedUsers(visitorId);
+            return ResponseEntity.ok(response);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(404).body(Map.of(
+                    "error", "NOT_FOUND",
+                    "message", e.getMessage()
+            ));
+        }
+    }
+}

--- a/apps/api/src/main/java/com/acnh/api/block/dto/BlockListResponse.java
+++ b/apps/api/src/main/java/com/acnh/api/block/dto/BlockListResponse.java
@@ -1,0 +1,24 @@
+package com.acnh.api.block.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * 차단 목록 응답 DTO
+ */
+@Getter
+@Builder
+public class BlockListResponse {
+
+    private List<BlockResponse> blocks;
+    private int totalCount;
+
+    public static BlockListResponse from(List<BlockResponse> blocks) {
+        return BlockListResponse.builder()
+                .blocks(blocks)
+                .totalCount(blocks.size())
+                .build();
+    }
+}

--- a/apps/api/src/main/java/com/acnh/api/block/dto/BlockRequest.java
+++ b/apps/api/src/main/java/com/acnh/api/block/dto/BlockRequest.java
@@ -1,0 +1,19 @@
+package com.acnh.api.block.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 차단 요청 DTO
+ */
+@Getter
+@NoArgsConstructor
+public class BlockRequest {
+
+    @NotNull(message = "차단할 사용자 ID는 필수입니다")
+    private Long blockedUserId;
+
+    // 차단 사유 (선택)
+    private String reason;
+}

--- a/apps/api/src/main/java/com/acnh/api/block/dto/BlockResponse.java
+++ b/apps/api/src/main/java/com/acnh/api/block/dto/BlockResponse.java
@@ -1,0 +1,31 @@
+package com.acnh.api.block.dto;
+
+import com.acnh.api.block.entity.Block;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * 차단 응답 DTO
+ */
+@Getter
+@Builder
+public class BlockResponse {
+
+    private Long id;
+    private Long blockedUserId;
+    private String blockedUserNickname;
+    private String reason;
+    private LocalDateTime createdAt;
+
+    public static BlockResponse from(Block block, String blockedUserNickname) {
+        return BlockResponse.builder()
+                .id(block.getId())
+                .blockedUserId(block.getBlockedId())
+                .blockedUserNickname(blockedUserNickname)
+                .reason(block.getReason())
+                .createdAt(block.getCreatedAt())
+                .build();
+    }
+}

--- a/apps/api/src/main/java/com/acnh/api/block/entity/Block.java
+++ b/apps/api/src/main/java/com/acnh/api/block/entity/Block.java
@@ -1,0 +1,45 @@
+package com.acnh.api.block.entity;
+
+import com.acnh.api.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 차단 Entity
+ * - blocks 테이블 매핑
+ * - 사용자 간 차단 관계 저장
+ */
+@Entity
+@Table(name = "blocks", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"blocker_id", "blocked_id"})
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Block extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 차단한 사용자 ID
+    @Column(name = "blocker_id", nullable = false)
+    private Long blockerId;
+
+    // 차단당한 사용자 ID
+    @Column(name = "blocked_id", nullable = false)
+    private Long blockedId;
+
+    // 차단 사유 (선택)
+    @Column(name = "reason", length = 500)
+    private String reason;
+
+    @Builder
+    public Block(Long blockerId, Long blockedId, String reason) {
+        this.blockerId = blockerId;
+        this.blockedId = blockedId;
+        this.reason = reason;
+    }
+}

--- a/apps/api/src/main/java/com/acnh/api/block/repository/BlockRepository.java
+++ b/apps/api/src/main/java/com/acnh/api/block/repository/BlockRepository.java
@@ -1,0 +1,33 @@
+package com.acnh.api.block.repository;
+
+import com.acnh.api.block.entity.Block;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 차단 Repository
+ */
+public interface BlockRepository extends JpaRepository<Block, Long> {
+
+    /**
+     * 차단 관계 존재 여부 확인
+     */
+    boolean existsByBlockerIdAndBlockedIdAndDeletedAtIsNull(Long blockerId, Long blockedId);
+
+    /**
+     * 차단 관계 조회
+     */
+    Optional<Block> findByBlockerIdAndBlockedIdAndDeletedAtIsNull(Long blockerId, Long blockedId);
+
+    /**
+     * 내가 차단한 사용자 목록 조회
+     */
+    List<Block> findByBlockerIdAndDeletedAtIsNullOrderByCreatedAtDesc(Long blockerId);
+
+    /**
+     * 내가 차단한 사용자 ID 목록 조회 (필터링용)
+     */
+    List<Block> findByBlockerIdAndDeletedAtIsNull(Long blockerId);
+}

--- a/apps/api/src/main/java/com/acnh/api/block/service/BlockService.java
+++ b/apps/api/src/main/java/com/acnh/api/block/service/BlockService.java
@@ -1,0 +1,169 @@
+package com.acnh.api.block.service;
+
+import com.acnh.api.block.dto.BlockListResponse;
+import com.acnh.api.block.dto.BlockRequest;
+import com.acnh.api.block.dto.BlockResponse;
+import com.acnh.api.block.entity.Block;
+import com.acnh.api.block.repository.BlockRepository;
+import com.acnh.api.member.entity.Member;
+import com.acnh.api.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * 차단 관련 비즈니스 로직 서비스
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BlockService {
+
+    private final BlockRepository blockRepository;
+    private final MemberRepository memberRepository;
+
+    /**
+     * 사용자 차단
+     */
+    @Transactional
+    public BlockResponse blockUser(BlockRequest request, String visitorId) {
+        Member blocker = findMemberByUuid(visitorId);
+        Member blocked = findMemberById(request.getBlockedUserId());
+
+        // 자기 자신 차단 불가
+        if (blocker.getId().equals(blocked.getId())) {
+            throw new IllegalArgumentException("자기 자신을 차단할 수 없습니다");
+        }
+
+        // 이미 차단된 사용자인지 확인
+        if (blockRepository.existsByBlockerIdAndBlockedIdAndDeletedAtIsNull(blocker.getId(), blocked.getId())) {
+            throw new IllegalArgumentException("이미 차단한 사용자입니다");
+        }
+
+        Block block = Block.builder()
+                .blockerId(blocker.getId())
+                .blockedId(blocked.getId())
+                .reason(request.getReason())
+                .build();
+
+        Block savedBlock = blockRepository.save(block);
+        log.info("사용자 차단 - blockerId: {}, blockedId: {}", blocker.getId(), blocked.getId());
+
+        return BlockResponse.from(savedBlock, blocked.getNickname());
+    }
+
+    /**
+     * 사용자 ID로 직접 차단 (신고 후 차단용)
+     */
+    @Transactional
+    public BlockResponse blockUserById(Long blockedUserId, String reason, String visitorId) {
+        Member blocker = findMemberByUuid(visitorId);
+        Member blocked = findMemberById(blockedUserId);
+
+        // 자기 자신 차단 불가
+        if (blocker.getId().equals(blocked.getId())) {
+            throw new IllegalArgumentException("자기 자신을 차단할 수 없습니다");
+        }
+
+        // 이미 차단된 사용자인지 확인 - 이미 차단된 경우 그냥 반환
+        var existingBlock = blockRepository.findByBlockerIdAndBlockedIdAndDeletedAtIsNull(blocker.getId(), blocked.getId());
+        if (existingBlock.isPresent()) {
+            return BlockResponse.from(existingBlock.get(), blocked.getNickname());
+        }
+
+        Block block = Block.builder()
+                .blockerId(blocker.getId())
+                .blockedId(blocked.getId())
+                .reason(reason)
+                .build();
+
+        Block savedBlock = blockRepository.save(block);
+        log.info("신고 후 차단 - blockerId: {}, blockedId: {}", blocker.getId(), blocked.getId());
+
+        return BlockResponse.from(savedBlock, blocked.getNickname());
+    }
+
+    /**
+     * 차단 해제
+     */
+    @Transactional
+    public void unblockUser(Long blockedUserId, String visitorId) {
+        Member blocker = findMemberByUuid(visitorId);
+
+        Block block = blockRepository.findByBlockerIdAndBlockedIdAndDeletedAtIsNull(blocker.getId(), blockedUserId)
+                .orElseThrow(() -> new IllegalArgumentException("차단 내역이 존재하지 않습니다"));
+
+        block.delete();
+        log.info("차단 해제 - blockerId: {}, blockedId: {}", blocker.getId(), blockedUserId);
+    }
+
+    /**
+     * 내가 차단한 사용자 목록 조회
+     */
+    public BlockListResponse getBlockedUsers(String visitorId) {
+        Member member = findMemberByUuid(visitorId);
+
+        List<Block> blocks = blockRepository.findByBlockerIdAndDeletedAtIsNullOrderByCreatedAtDesc(member.getId());
+
+        if (blocks.isEmpty()) {
+            return BlockListResponse.from(List.of());
+        }
+
+        // 차단된 사용자 정보 일괄 조회
+        List<Long> blockedIds = blocks.stream().map(Block::getBlockedId).toList();
+        Map<Long, Member> memberMap = memberRepository.findByIdInAndDeletedAtIsNull(blockedIds)
+                .stream()
+                .collect(Collectors.toMap(Member::getId, Function.identity()));
+
+        List<BlockResponse> responses = blocks.stream()
+                .map(block -> {
+                    Member blocked = memberMap.get(block.getBlockedId());
+                    String nickname = blocked != null ? blocked.getNickname() : "탈퇴한 사용자";
+                    return BlockResponse.from(block, nickname);
+                })
+                .toList();
+
+        return BlockListResponse.from(responses);
+    }
+
+    /**
+     * 특정 사용자가 차단되었는지 확인
+     */
+    public boolean isBlocked(Long blockerId, Long blockedId) {
+        return blockRepository.existsByBlockerIdAndBlockedIdAndDeletedAtIsNull(blockerId, blockedId);
+    }
+
+    /**
+     * 내가 차단한 사용자 ID 목록 조회 (필터링용)
+     */
+    public Set<Long> getBlockedUserIds(Long userId) {
+        return blockRepository.findByBlockerIdAndDeletedAtIsNull(userId)
+                .stream()
+                .map(Block::getBlockedId)
+                .collect(Collectors.toSet());
+    }
+
+    // ========== Private Helper Methods ==========
+
+    private Member findMemberByUuid(String visitorId) {
+        if (visitorId == null) {
+            throw new IllegalArgumentException("로그인이 필요합니다");
+        }
+        return memberRepository.findByUuidAndDeletedAtIsNull(UUID.fromString(visitorId))
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다"));
+    }
+
+    private Member findMemberById(Long memberId) {
+        return memberRepository.findByIdAndDeletedAtIsNull(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다"));
+    }
+}

--- a/apps/api/src/main/java/com/acnh/api/chat/controller/ChatController.java
+++ b/apps/api/src/main/java/com/acnh/api/chat/controller/ChatController.java
@@ -165,4 +165,148 @@ public class ChatController {
             ));
         }
     }
+
+    /**
+     * 예약자 지정
+     * POST /api/chat/rooms/{roomId}/reserve
+     */
+    @PostMapping("/{roomId}/reserve")
+    public ResponseEntity<?> reserveChatRoom(
+            @AuthenticationPrincipal String visitorId,
+            @PathVariable Long roomId,
+            @RequestBody(required = false) ReserveRequest request) {
+
+        log.info("예약자 지정 요청 - roomId: {}, visitorId: {}", roomId, visitorId);
+
+        if (visitorId == null) {
+            return ResponseEntity.status(401).body(Map.of(
+                    "error", "UNAUTHORIZED",
+                    "message", "로그인이 필요합니다"
+            ));
+        }
+
+        try {
+            var scheduledAt = request != null ? request.getScheduledTradeAt() : null;
+            ChatRoomResponse response = chatService.reserveChatRoom(roomId, visitorId, scheduledAt);
+            return ResponseEntity.ok(response);
+        } catch (IllegalArgumentException e) {
+            if (e.getMessage().contains("존재하지 않는")) {
+                return ResponseEntity.status(404).body(Map.of(
+                        "error", "NOT_FOUND",
+                        "message", e.getMessage()
+                ));
+            }
+            return ResponseEntity.badRequest().body(Map.of(
+                    "error", "INVALID_REQUEST",
+                    "message", e.getMessage()
+            ));
+        }
+    }
+
+    /**
+     * 예약 해제
+     * POST /api/chat/rooms/{roomId}/unreserve
+     */
+    @PostMapping("/{roomId}/unreserve")
+    public ResponseEntity<?> unreserveChatRoom(
+            @AuthenticationPrincipal String visitorId,
+            @PathVariable Long roomId) {
+
+        log.info("예약 해제 요청 - roomId: {}, visitorId: {}", roomId, visitorId);
+
+        if (visitorId == null) {
+            return ResponseEntity.status(401).body(Map.of(
+                    "error", "UNAUTHORIZED",
+                    "message", "로그인이 필요합니다"
+            ));
+        }
+
+        try {
+            ChatRoomResponse response = chatService.unreserveChatRoom(roomId, visitorId);
+            return ResponseEntity.ok(response);
+        } catch (IllegalArgumentException e) {
+            if (e.getMessage().contains("존재하지 않는")) {
+                return ResponseEntity.status(404).body(Map.of(
+                        "error", "NOT_FOUND",
+                        "message", e.getMessage()
+                ));
+            }
+            return ResponseEntity.badRequest().body(Map.of(
+                    "error", "INVALID_REQUEST",
+                    "message", e.getMessage()
+            ));
+        }
+    }
+
+    /**
+     * 거래 완료 처리
+     * POST /api/chat/rooms/{roomId}/complete
+     */
+    @PostMapping("/{roomId}/complete")
+    public ResponseEntity<?> completeTrade(
+            @AuthenticationPrincipal String visitorId,
+            @PathVariable Long roomId) {
+
+        log.info("거래 완료 요청 - roomId: {}, visitorId: {}", roomId, visitorId);
+
+        if (visitorId == null) {
+            return ResponseEntity.status(401).body(Map.of(
+                    "error", "UNAUTHORIZED",
+                    "message", "로그인이 필요합니다"
+            ));
+        }
+
+        try {
+            ChatRoomResponse response = chatService.completeTrade(roomId, visitorId);
+            return ResponseEntity.ok(response);
+        } catch (IllegalArgumentException e) {
+            if (e.getMessage().contains("존재하지 않는")) {
+                return ResponseEntity.status(404).body(Map.of(
+                        "error", "NOT_FOUND",
+                        "message", e.getMessage()
+                ));
+            }
+            return ResponseEntity.badRequest().body(Map.of(
+                    "error", "INVALID_REQUEST",
+                    "message", e.getMessage()
+            ));
+        }
+    }
+
+    /**
+     * 채팅방 나가기
+     * POST /api/chat/rooms/{roomId}/leave
+     */
+    @PostMapping("/{roomId}/leave")
+    public ResponseEntity<?> leaveChatRoom(
+            @AuthenticationPrincipal String visitorId,
+            @PathVariable Long roomId) {
+
+        log.info("채팅방 나가기 요청 - roomId: {}, visitorId: {}", roomId, visitorId);
+
+        if (visitorId == null) {
+            return ResponseEntity.status(401).body(Map.of(
+                    "error", "UNAUTHORIZED",
+                    "message", "로그인이 필요합니다"
+            ));
+        }
+
+        try {
+            chatService.leaveChatRoom(roomId, visitorId);
+            return ResponseEntity.ok(Map.of(
+                    "message", "채팅방을 나갔습니다"
+            ));
+        } catch (IllegalArgumentException e) {
+            if (e.getMessage().contains("존재하지 않는") || e.getMessage().contains("접근 권한")) {
+                return ResponseEntity.status(404).body(Map.of(
+                        "error", "NOT_FOUND",
+                        "message", e.getMessage()
+                ));
+            }
+            return ResponseEntity.badRequest().body(Map.of(
+                    "error", "INVALID_REQUEST",
+                    "message", e.getMessage()
+            ));
+        }
+    }
 }

--- a/apps/api/src/main/java/com/acnh/api/chat/dto/ReserveRequest.java
+++ b/apps/api/src/main/java/com/acnh/api/chat/dto/ReserveRequest.java
@@ -1,0 +1,17 @@
+package com.acnh.api.chat.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 예약자 지정 요청 DTO
+ */
+@Getter
+@NoArgsConstructor
+public class ReserveRequest {
+
+    // 거래 예정 일시 (선택)
+    private LocalDateTime scheduledTradeAt;
+}

--- a/apps/api/src/main/java/com/acnh/api/filter/ProfanityFilter.java
+++ b/apps/api/src/main/java/com/acnh/api/filter/ProfanityFilter.java
@@ -1,0 +1,120 @@
+package com.acnh.api.filter;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * 금칙어 필터링 서비스
+ * - 채팅 메시지, 게시글 등에서 금칙어 검사
+ * - 앱스토어 정책 대응 (욕설/비방 필터링)
+ */
+@Slf4j
+@Component
+public class ProfanityFilter {
+
+    // 금칙어 목록 (실제 서비스에서는 DB나 외부 설정에서 관리)
+    private static final Set<String> PROFANITY_WORDS = new HashSet<>(Arrays.asList(
+            // 욕설/비방
+            "시발", "씨발", "ㅅㅂ", "ㅆㅂ", "병신", "ㅂㅅ", "지랄", "ㅈㄹ",
+            "개새끼", "개세끼", "새끼", "ㅅㄲ", "미친", "ㅁㅊ", "존나", "ㅈㄴ",
+            "꺼져", "닥쳐", "죽어", "뒤져",
+            // 실거래 유도
+            "현금", "현거래", "입금", "계좌", "송금", "페이팔", "paypal",
+            // 외부 메신저 유도
+            "카톡", "카카오톡", "라인", "디코", "디스코드", "텔레그램",
+            // 사기 관련
+            "선입금", "먼저입금", "선결제"
+    ));
+
+    // 우회 표현 패턴 (자음만, 초성 등)
+    private static final Pattern BYPASS_PATTERN = Pattern.compile(
+            "(시[ㅡ\\-_.*]+발)|(씨[ㅡ\\-_.*]+발)|(ㅅ[ㅡ\\-_.*]+ㅂ)|" +
+            "(병[ㅡ\\-_.*]+신)|(ㅂ[ㅡ\\-_.*]+ㅅ)|" +
+            "(새[ㅡ\\-_.*]+끼)|(ㅅ[ㅡ\\-_.*]+ㄲ)",
+            Pattern.CASE_INSENSITIVE
+    );
+
+    /**
+     * 금칙어 포함 여부 검사
+     * @param text 검사할 텍스트
+     * @return 금칙어 포함 시 true
+     */
+    public boolean containsProfanity(String text) {
+        if (text == null || text.isBlank()) {
+            return false;
+        }
+
+        String normalizedText = normalizeText(text);
+
+        // 금칙어 목록 검사
+        for (String word : PROFANITY_WORDS) {
+            if (normalizedText.contains(word.toLowerCase())) {
+                log.warn("금칙어 감지: {} (원문: {})", word, text);
+                return true;
+            }
+        }
+
+        // 우회 표현 패턴 검사
+        Matcher matcher = BYPASS_PATTERN.matcher(normalizedText);
+        if (matcher.find()) {
+            log.warn("우회 금칙어 감지: {} (원문: {})", matcher.group(), text);
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * 금칙어 마스킹 처리
+     * @param text 원본 텍스트
+     * @return 금칙어가 ***로 대체된 텍스트
+     */
+    public String maskProfanity(String text) {
+        if (text == null || text.isBlank()) {
+            return text;
+        }
+
+        String result = text;
+
+        // 금칙어 목록 마스킹
+        for (String word : PROFANITY_WORDS) {
+            String replacement = "*".repeat(word.length());
+            result = result.replaceAll("(?i)" + Pattern.quote(word), replacement);
+        }
+
+        // 우회 표현 마스킹
+        Matcher matcher = BYPASS_PATTERN.matcher(result);
+        StringBuffer sb = new StringBuffer();
+        while (matcher.find()) {
+            matcher.appendReplacement(sb, "*".repeat(matcher.group().length()));
+        }
+        matcher.appendTail(sb);
+
+        return sb.toString();
+    }
+
+    /**
+     * 텍스트 정규화 (공백, 특수문자 제거 등)
+     */
+    private String normalizeText(String text) {
+        return text.toLowerCase()
+                .replaceAll("[\\s\\p{Punct}]", ""); // 공백, 구두점 제거
+    }
+
+    /**
+     * 금칙어 검사 후 예외 발생
+     * @param text 검사할 텍스트
+     * @throws IllegalArgumentException 금칙어 포함 시
+     */
+    public void validateText(String text) {
+        if (containsProfanity(text)) {
+            throw new IllegalArgumentException("부적절한 표현이 포함되어 있습니다");
+        }
+    }
+}

--- a/apps/api/src/main/java/com/acnh/api/report/dto/ReportCreateRequest.java
+++ b/apps/api/src/main/java/com/acnh/api/report/dto/ReportCreateRequest.java
@@ -24,4 +24,7 @@ public class ReportCreateRequest {
 
     @Size(max = 1000, message = "상세 설명은 1000자 이내로 입력해주세요")
     private String description;
+
+    // 신고 후 해당 사용자 차단 여부 (프론트에서 "차단하시겠습니까?" 응답)
+    private Boolean blockUser;
 }

--- a/apps/api/src/main/java/com/acnh/api/report/dto/ReportResponse.java
+++ b/apps/api/src/main/java/com/acnh/api/report/dto/ReportResponse.java
@@ -17,6 +17,11 @@ public class ReportResponse {
     private String status;
     private LocalDateTime createdAt;
 
+    // 차단 처리 여부 (신고 시 차단도 함께 했는지)
+    private Boolean blocked;
+    // 피신고자 ID (프론트에서 차단 확인용)
+    private Long reportedUserId;
+
     /**
      * Entity -> DTO 변환
      */
@@ -25,6 +30,21 @@ public class ReportResponse {
                 .id(report.getId())
                 .status(report.getStatus())
                 .createdAt(report.getCreatedAt())
+                .blocked(false)
+                .reportedUserId(report.getReportedUserId())
+                .build();
+    }
+
+    /**
+     * Entity -> DTO 변환 (차단 여부 포함)
+     */
+    public static ReportResponse from(Report report, boolean blocked) {
+        return ReportResponse.builder()
+                .id(report.getId())
+                .status(report.getStatus())
+                .createdAt(report.getCreatedAt())
+                .blocked(blocked)
+                .reportedUserId(report.getReportedUserId())
                 .build();
     }
 }

--- a/apps/api/src/main/java/com/acnh/api/report/entity/Report.java
+++ b/apps/api/src/main/java/com/acnh/api/report/entity/Report.java
@@ -27,6 +27,10 @@ public class Report extends BaseEntity {
     @Column(name = "post_id", nullable = false)
     private Long postId;
 
+    // 피신고자 ID (게시글 작성자)
+    @Column(name = "reported_user_id", nullable = false)
+    private Long reportedUserId;
+
     @Column(name = "reason_code", nullable = false, length = 50)
     private String reasonCode;
 
@@ -37,10 +41,11 @@ public class Report extends BaseEntity {
     private String status;
 
     @Builder
-    public Report(Long reporterId, Long postId, String reasonCode,
+    public Report(Long reporterId, Long postId, Long reportedUserId, String reasonCode,
                   String description, String status) {
         this.reporterId = reporterId;
         this.postId = postId;
+        this.reportedUserId = reportedUserId;
         this.reasonCode = reasonCode;
         this.description = description;
         this.status = status != null ? status : "PENDING";


### PR DESCRIPTION
1. 채팅 API 추가
- POST /api/chat/rooms/{roomId}/reserve - 예약자 지정
- POST /api/chat/rooms/{roomId}/unreserve - 예약 해제
- POST /api/chat/rooms/{roomId}/complete - 거래 완료
- POST /api/chat/rooms/{roomId}/leave - 채팅방 나가기
- GET /api/posts/{postId}/chat-rooms - 게시글별 채팅 목록 (작성자용)

2. 차단 기능 구현 (앱스토어 정책 대응)
- Block 엔티티, Repository, Service, Controller
- POST /api/blocks - 사용자 차단
- DELETE /api/blocks/{blockedUserId} - 차단 해제
- GET /api/blocks - 차단 목록 조회

3. 신고 후 차단 연동
- ReportCreateRequest에 blockUser 필드 추가
- 신고 시 blockUser=true면 자동 차단
- ReportResponse에 blocked, reportedUserId 필드 추가
- Report 엔티티에 reportedUserId 필드 추가

4. 금칙어 필터링 구현 (앱스토어 정책 대응)
- ProfanityFilter 컴포넌트 생성
- 욕설/비방, 실거래 유도, 외부 메신저 유도 등 필터링
- 우회 표현 패턴 검사
- 채팅 메시지 저장 시 자동 마스킹 처리

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 사용자 차단 기능 추가 - 특정 사용자를 차단하고 차단 해제 가능
  * 차단된 사용자 목록 조회 기능
  * 채팅 거래 예약 및 완료 기능 추가
  * 채팅방 나가기 기능 추가
  * 메시지 욕설 필터링 시스템 구현
  * 신고 시 사용자 자동 차단 옵션 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->