### PR TITLE
feat: 리뷰 API 구현 (GET /users/{userId}/reviews, POST /reviews)

### DIFF
--- a/apps/api/src/main/java/com/acnh/api/review/controller/ReviewController.java
+++ b/apps/api/src/main/java/com/acnh/api/review/controller/ReviewController.java
@@ -1,0 +1,111 @@
+package com.acnh.api.review.controller;
+
+import com.acnh.api.review.dto.ReviewCreateRequest;
+import com.acnh.api.review.dto.ReviewListResponse;
+import com.acnh.api.review.dto.ReviewResponse;
+import com.acnh.api.review.service.ReviewService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+/**
+ * 리뷰 관련 API 컨트롤러
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class ReviewController {
+
+    private final ReviewService reviewService;
+
+    private static final int DEFAULT_PAGE_SIZE = 20;
+
+    /**
+     * 유저가 받은 리뷰 목록 조회
+     * GET /api/users/{userId}/reviews
+     */
+    @GetMapping("/users/{userId}/reviews")
+    public ResponseEntity<?> getReviewsByUserId(
+            @PathVariable Long userId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+
+        log.info("유저 리뷰 목록 조회 요청 - userId: {}, page: {}, size: {}", userId, page, size);
+
+        try {
+            Pageable pageable = PageRequest.of(page, Math.min(size, DEFAULT_PAGE_SIZE));
+            ReviewListResponse response = reviewService.getReviewsByUserId(userId, pageable);
+            return ResponseEntity.ok(response);
+        } catch (IllegalArgumentException e) {
+            if (e.getMessage().contains("존재하지 않는")) {
+                return ResponseEntity.status(404).body(Map.of(
+                        "error", "NOT_FOUND",
+                        "message", e.getMessage()
+                ));
+            }
+            return ResponseEntity.badRequest().body(Map.of(
+                    "error", "INVALID_REQUEST",
+                    "message", e.getMessage()
+            ));
+        }
+    }
+
+    /**
+     * 리뷰 작성
+     * POST /api/reviews
+     */
+    @PostMapping("/reviews")
+    public ResponseEntity<?> createReview(
+            @AuthenticationPrincipal String visitorId,
+            @Valid @RequestBody ReviewCreateRequest request) {
+
+        log.info("리뷰 작성 요청 - visitorId: {}, postId: {}, revieweeId: {}",
+                visitorId, request.getPostId(), request.getRevieweeId());
+
+        if (visitorId == null) {
+            return ResponseEntity.status(401).body(Map.of(
+                    "error", "UNAUTHORIZED",
+                    "message", "로그인이 필요합니다"
+            ));
+        }
+
+        try {
+            ReviewResponse response = reviewService.createReview(request, visitorId);
+            return ResponseEntity.status(201).body(response);
+        } catch (IllegalArgumentException e) {
+            if (e.getMessage().contains("존재하지 않는")) {
+                return ResponseEntity.status(404).body(Map.of(
+                        "error", "NOT_FOUND",
+                        "message", e.getMessage()
+                ));
+            }
+            return ResponseEntity.badRequest().body(Map.of(
+                    "error", "INVALID_REQUEST",
+                    "message", e.getMessage()
+            ));
+        }
+    }
+
+    /**
+     * 리뷰 작성 가능 여부 확인
+     * GET /api/posts/{postId}/can-review
+     */
+    @GetMapping("/posts/{postId}/can-review")
+    public ResponseEntity<?> canWriteReview(
+            @AuthenticationPrincipal String visitorId,
+            @PathVariable Long postId) {
+
+        log.info("리뷰 작성 가능 여부 확인 요청 - visitorId: {}, postId: {}", visitorId, postId);
+
+        boolean canReview = reviewService.canWriteReview(postId, visitorId);
+        return ResponseEntity.ok(Map.of("canReview", canReview));
+    }
+}

--- a/apps/api/src/main/java/com/acnh/api/review/dto/ReviewCreateRequest.java
+++ b/apps/api/src/main/java/com/acnh/api/review/dto/ReviewCreateRequest.java
@@ -1,0 +1,30 @@
+package com.acnh.api.review.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 리뷰 작성 요청 DTO
+ */
+@Getter
+@NoArgsConstructor
+public class ReviewCreateRequest {
+
+    @NotNull(message = "게시글 ID는 필수입니다")
+    private Long postId;
+
+    @NotNull(message = "리뷰 대상자 ID는 필수입니다")
+    private Long revieweeId;
+
+    @NotNull(message = "별점은 필수입니다")
+    @Min(value = 0, message = "별점은 0점 이상이어야 합니다")
+    @Max(value = 5, message = "별점은 5점 이하여야 합니다")
+    private Integer rating;
+
+    @Size(max = 500, message = "후기는 500자 이하여야 합니다")
+    private String comment;
+}

--- a/apps/api/src/main/java/com/acnh/api/review/dto/ReviewListResponse.java
+++ b/apps/api/src/main/java/com/acnh/api/review/dto/ReviewListResponse.java
@@ -1,0 +1,56 @@
+package com.acnh.api.review.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+/**
+ * 리뷰 목록 페이징 응답 DTO
+ */
+@Getter
+@Builder
+public class ReviewListResponse {
+
+    private List<ReviewResponse> reviews;
+    private int currentPage;
+    private int totalPages;
+    private long totalElements;
+    private boolean hasNext;
+    private boolean hasPrevious;
+
+    // 리뷰 통계 정보
+    private Double averageRating;
+    private Long reviewCount;
+
+    /**
+     * Page -> DTO 변환
+     */
+    public static ReviewListResponse from(Page<ReviewResponse> page) {
+        return ReviewListResponse.builder()
+                .reviews(page.getContent())
+                .currentPage(page.getNumber())
+                .totalPages(page.getTotalPages())
+                .totalElements(page.getTotalElements())
+                .hasNext(page.hasNext())
+                .hasPrevious(page.hasPrevious())
+                .build();
+    }
+
+    /**
+     * Page -> DTO 변환 (통계 정보 포함)
+     */
+    public static ReviewListResponse from(Page<ReviewResponse> page, Double averageRating, Long reviewCount) {
+        return ReviewListResponse.builder()
+                .reviews(page.getContent())
+                .currentPage(page.getNumber())
+                .totalPages(page.getTotalPages())
+                .totalElements(page.getTotalElements())
+                .hasNext(page.hasNext())
+                .hasPrevious(page.hasPrevious())
+                .averageRating(averageRating)
+                .reviewCount(reviewCount)
+                .build();
+    }
+}

--- a/apps/api/src/main/java/com/acnh/api/review/dto/ReviewResponse.java
+++ b/apps/api/src/main/java/com/acnh/api/review/dto/ReviewResponse.java
@@ -1,0 +1,71 @@
+package com.acnh.api.review.dto;
+
+import com.acnh.api.review.entity.Review;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * 리뷰 응답 DTO
+ */
+@Getter
+@Builder
+public class ReviewResponse {
+
+    private Long id;
+    private Long postId;
+    private String postItemName;
+
+    // 리뷰 작성자 정보
+    private Long reviewerId;
+    private String reviewerNickname;
+    private String reviewerIslandName;
+
+    // 리뷰 대상자 정보
+    private Long revieweeId;
+    private String revieweeNickname;
+
+    private Integer rating;
+    private String comment;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    /**
+     * Entity -> DTO 변환 (기본)
+     */
+    public static ReviewResponse from(Review review) {
+        return ReviewResponse.builder()
+                .id(review.getId())
+                .postId(review.getPostId())
+                .reviewerId(review.getReviewerId())
+                .revieweeId(review.getRevieweeId())
+                .rating(review.getRating())
+                .comment(review.getComment())
+                .createdAt(review.getCreatedAt())
+                .updatedAt(review.getUpdatedAt())
+                .build();
+    }
+
+    /**
+     * Entity -> DTO 변환 (유저 정보 포함)
+     */
+    public static ReviewResponse from(Review review, String reviewerNickname, String reviewerIslandName,
+                                      String revieweeNickname, String postItemName) {
+        return ReviewResponse.builder()
+                .id(review.getId())
+                .postId(review.getPostId())
+                .postItemName(postItemName)
+                .reviewerId(review.getReviewerId())
+                .reviewerNickname(reviewerNickname)
+                .reviewerIslandName(reviewerIslandName)
+                .revieweeId(review.getRevieweeId())
+                .revieweeNickname(revieweeNickname)
+                .rating(review.getRating())
+                .comment(review.getComment())
+                .createdAt(review.getCreatedAt())
+                .updatedAt(review.getUpdatedAt())
+                .build();
+    }
+}

--- a/apps/api/src/main/java/com/acnh/api/review/entity/Review.java
+++ b/apps/api/src/main/java/com/acnh/api/review/entity/Review.java
@@ -12,7 +12,9 @@ import lombok.NoArgsConstructor;
  * - reviews 테이블 매핑
  */
 @Entity
-@Table(name = "reviews")
+@Table(name = "reviews", uniqueConstraints = {
+        @UniqueConstraint(name = "uk_review_post_reviewer", columnNames = {"post_id", "reviewer_id"})
+})
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Review extends BaseEntity {

--- a/apps/api/src/main/java/com/acnh/api/review/service/ReviewService.java
+++ b/apps/api/src/main/java/com/acnh/api/review/service/ReviewService.java
@@ -13,6 +13,7 @@ import com.acnh.api.review.entity.Review;
 import com.acnh.api.review.repository.ReviewRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -80,7 +81,14 @@ public class ReviewService {
                 .comment(request.getComment())
                 .build();
 
-        Review savedReview = reviewRepository.save(review);
+        // DB 유니크 제약조건 위반 시 예외 처리 (동시성 문제 대응)
+        Review savedReview;
+        try {
+            savedReview = reviewRepository.save(review);
+        } catch (DataIntegrityViolationException e) {
+            throw new IllegalArgumentException("이미 해당 게시글에 리뷰를 작성하였습니다");
+        }
+
         log.info("리뷰 작성 완료 - reviewId: {}, postId: {}, reviewerId: {}, revieweeId: {}",
                 savedReview.getId(), post.getId(), reviewer.getId(), reviewee.getId());
 

--- a/apps/api/src/main/java/com/acnh/api/review/service/ReviewService.java
+++ b/apps/api/src/main/java/com/acnh/api/review/service/ReviewService.java
@@ -139,7 +139,15 @@ public class ReviewService {
             return false;
         }
 
-        Member member = memberRepository.findByUuidAndDeletedAtIsNull(UUID.fromString(visitorId))
+        // UUID 파싱 실패 시 false 반환
+        UUID uuid;
+        try {
+            uuid = UUID.fromString(visitorId);
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+
+        Member member = memberRepository.findByUuidAndDeletedAtIsNull(uuid)
                 .orElse(null);
         if (member == null) {
             return false;

--- a/apps/api/src/main/java/com/acnh/api/review/service/ReviewService.java
+++ b/apps/api/src/main/java/com/acnh/api/review/service/ReviewService.java
@@ -196,7 +196,16 @@ public class ReviewService {
         if (visitorId == null) {
             throw new IllegalArgumentException("로그인이 필요합니다");
         }
-        return memberRepository.findByUuidAndDeletedAtIsNull(UUID.fromString(visitorId))
+
+        // UUID 파싱 실패 시 원본 예외 메시지 노출 방지
+        UUID uuid;
+        try {
+            uuid = UUID.fromString(visitorId);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("로그인이 필요합니다");
+        }
+
+        return memberRepository.findByUuidAndDeletedAtIsNull(uuid)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다"));
     }
 

--- a/apps/api/src/main/java/com/acnh/api/review/service/ReviewService.java
+++ b/apps/api/src/main/java/com/acnh/api/review/service/ReviewService.java
@@ -1,6 +1,5 @@
 package com.acnh.api.review.service;
 
-import com.acnh.api.chat.entity.ChatRoom;
 import com.acnh.api.chat.repository.ChatRoomRepository;
 import com.acnh.api.filter.ProfanityFilter;
 import com.acnh.api.member.entity.Member;
@@ -226,7 +225,7 @@ public class ReviewService {
     /**
      * 리뷰 대상자 유효성 검증
      * - 채팅 요청자 → 게시글 작성자에게만 리뷰 가능
-     * - 게시글 작성자 → 확정된 거래자(reservedUserId)에게만 리뷰 가능
+     * - 게시글 작성자 → 채팅 요청자에게만 리뷰 가능
      */
     private void validateRevieweeEligibility(Post post, Member reviewer, Member reviewee) {
         // 채팅 요청자가 리뷰하는 경우: 게시글 작성자에게만 리뷰 가능
@@ -237,14 +236,9 @@ public class ReviewService {
             return;
         }
 
-        // 게시글 작성자가 리뷰하는 경우: 확정된 거래자에게만 리뷰 가능
-        ChatRoom chatRoom = chatRoomRepository
-                .findByPostIdAndApplicantIdAndDeletedAtIsNull(post.getId(), reviewee.getId())
-                .orElseThrow(() -> new IllegalArgumentException("해당 게시글에 채팅을 요청한 유저에게만 리뷰를 작성할 수 있습니다"));
-
-        // 예약된 거래자인지 확인 (reservedUserId가 설정되어 있어야 함)
-        if (chatRoom.getReservedUserId() == null || !chatRoom.getReservedUserId().equals(reviewee.getId())) {
-            throw new IllegalArgumentException("확정된 거래자에게만 리뷰를 작성할 수 있습니다");
+        // 게시글 작성자가 리뷰하는 경우: 해당 게시글에 채팅을 요청한 유저에게만 리뷰 가능
+        if (!chatRoomRepository.existsByPostIdAndApplicantIdAndDeletedAtIsNull(post.getId(), reviewee.getId())) {
+            throw new IllegalArgumentException("해당 게시글에 채팅을 요청한 유저에게만 리뷰를 작성할 수 있습니다");
         }
     }
 

--- a/apps/api/src/main/java/com/acnh/api/review/service/ReviewService.java
+++ b/apps/api/src/main/java/com/acnh/api/review/service/ReviewService.java
@@ -18,6 +18,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -99,13 +100,18 @@ public class ReviewService {
         List<Long> reviewerIds = reviews.stream().map(Review::getReviewerId).distinct().toList();
         List<Long> postIds = reviews.stream().map(Review::getPostId).distinct().toList();
 
-        Map<Long, Member> memberMap = memberRepository.findByIdInAndDeletedAtIsNull(reviewerIds)
-                .stream()
-                .collect(Collectors.toMap(Member::getId, Function.identity()));
+        // 빈 리스트일 경우 불필요한 DB 조회 방지
+        Map<Long, Member> memberMap = reviewerIds.isEmpty()
+                ? Collections.emptyMap()
+                : memberRepository.findByIdInAndDeletedAtIsNull(reviewerIds)
+                        .stream()
+                        .collect(Collectors.toMap(Member::getId, Function.identity()));
 
-        Map<Long, Post> postMap = postRepository.findByIdInAndDeletedAtIsNull(postIds)
-                .stream()
-                .collect(Collectors.toMap(Post::getId, Function.identity()));
+        Map<Long, Post> postMap = postIds.isEmpty()
+                ? Collections.emptyMap()
+                : postRepository.findByIdInAndDeletedAtIsNull(postIds)
+                        .stream()
+                        .collect(Collectors.toMap(Post::getId, Function.identity()));
 
         // 리뷰 대상자 정보 조회
         Member reviewee = memberRepository.findByIdAndDeletedAtIsNull(userId).orElse(null);

--- a/apps/api/src/main/java/com/acnh/api/review/service/ReviewService.java
+++ b/apps/api/src/main/java/com/acnh/api/review/service/ReviewService.java
@@ -1,0 +1,253 @@
+package com.acnh.api.review.service;
+
+import com.acnh.api.chat.repository.ChatRoomRepository;
+import com.acnh.api.filter.ProfanityFilter;
+import com.acnh.api.member.entity.Member;
+import com.acnh.api.member.repository.MemberRepository;
+import com.acnh.api.post.entity.Post;
+import com.acnh.api.post.repository.PostRepository;
+import com.acnh.api.review.dto.ReviewCreateRequest;
+import com.acnh.api.review.dto.ReviewListResponse;
+import com.acnh.api.review.dto.ReviewResponse;
+import com.acnh.api.review.entity.Review;
+import com.acnh.api.review.repository.ReviewRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * 리뷰 관련 비즈니스 로직 서비스
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReviewService {
+
+    private final ReviewRepository reviewRepository;
+    private final MemberRepository memberRepository;
+    private final PostRepository postRepository;
+    private final ChatRoomRepository chatRoomRepository;
+    private final ProfanityFilter profanityFilter;
+
+    /**
+     * 리뷰 작성
+     * - 해당 게시글에 채팅 기록이 있는 경우만 평가 가능
+     * - (post_id, reviewer_id) 조합으로 1회만 리뷰 가능
+     */
+    @Transactional
+    public ReviewResponse createReview(ReviewCreateRequest request, String visitorId) {
+        Member reviewer = findMemberByUuid(visitorId);
+        Post post = findPostById(request.getPostId());
+        Member reviewee = findMemberById(request.getRevieweeId());
+
+        // 자기 자신에게 리뷰 불가
+        if (reviewer.getId().equals(reviewee.getId())) {
+            throw new IllegalArgumentException("자기 자신에게 리뷰를 작성할 수 없습니다");
+        }
+
+        // 채팅 기록 확인 (리뷰어가 해당 게시글에 채팅방이 있는지)
+        validateChatHistory(post, reviewer);
+
+        // 리뷰 대상자 유효성 검증
+        validateRevieweeEligibility(post, reviewer, reviewee);
+
+        // 중복 리뷰 검사 (post_id + reviewer_id 기준)
+        if (reviewRepository.existsByPostIdAndReviewerIdAndDeletedAtIsNull(post.getId(), reviewer.getId())) {
+            throw new IllegalArgumentException("이미 해당 게시글에 리뷰를 작성하였습니다");
+        }
+
+        // 금칙어 검사
+        if (request.getComment() != null && !request.getComment().isBlank()) {
+            profanityFilter.validateText(request.getComment());
+        }
+
+        Review review = Review.builder()
+                .postId(post.getId())
+                .reviewerId(reviewer.getId())
+                .revieweeId(reviewee.getId())
+                .rating(request.getRating())
+                .comment(request.getComment())
+                .build();
+
+        Review savedReview = reviewRepository.save(review);
+        log.info("리뷰 작성 완료 - reviewId: {}, postId: {}, reviewerId: {}, revieweeId: {}",
+                savedReview.getId(), post.getId(), reviewer.getId(), reviewee.getId());
+
+        return toReviewResponse(savedReview);
+    }
+
+    /**
+     * 유저가 받은 리뷰 목록 조회
+     */
+    public ReviewListResponse getReviewsByUserId(Long userId, Pageable pageable) {
+        // 유저 존재 확인
+        findMemberById(userId);
+
+        Page<Review> reviews = reviewRepository.findByRevieweeIdAndDeletedAtIsNull(userId, pageable);
+
+        // 관련 데이터 일괄 조회
+        List<Long> reviewerIds = reviews.stream().map(Review::getReviewerId).distinct().toList();
+        List<Long> postIds = reviews.stream().map(Review::getPostId).distinct().toList();
+
+        Map<Long, Member> memberMap = memberRepository.findByIdInAndDeletedAtIsNull(reviewerIds)
+                .stream()
+                .collect(Collectors.toMap(Member::getId, Function.identity()));
+
+        Map<Long, Post> postMap = postRepository.findByIdInAndDeletedAtIsNull(postIds)
+                .stream()
+                .collect(Collectors.toMap(Post::getId, Function.identity()));
+
+        // 리뷰 대상자 정보 조회
+        Member reviewee = memberRepository.findByIdAndDeletedAtIsNull(userId).orElse(null);
+        String revieweeNickname = reviewee != null ? reviewee.getNickname() : "알 수 없음";
+
+        Page<ReviewResponse> responsePage = reviews.map(review -> {
+            Member reviewer = memberMap.get(review.getReviewerId());
+            Post post = postMap.get(review.getPostId());
+
+            String reviewerNickname = reviewer != null ? reviewer.getNickname() : "알 수 없음";
+            String reviewerIslandName = reviewer != null ? reviewer.getIslandName() : null;
+            String postItemName = post != null ? post.getItemName() : null;
+
+            return ReviewResponse.from(review, reviewerNickname, reviewerIslandName,
+                    revieweeNickname, postItemName);
+        });
+
+        // 통계 정보 조회
+        Double averageRating = reviewRepository.calculateAverageRatingByRevieweeId(userId);
+        long reviewCount = reviewRepository.countByRevieweeIdAndDeletedAtIsNull(userId);
+
+        return ReviewListResponse.from(responsePage, averageRating, reviewCount);
+    }
+
+    /**
+     * 리뷰 작성 가능 여부 확인
+     * - 해당 게시글에 채팅 기록이 있고, 아직 리뷰를 작성하지 않았는지 확인
+     */
+    public boolean canWriteReview(Long postId, String visitorId) {
+        if (visitorId == null) {
+            return false;
+        }
+
+        Member member = memberRepository.findByUuidAndDeletedAtIsNull(UUID.fromString(visitorId))
+                .orElse(null);
+        if (member == null) {
+            return false;
+        }
+
+        Post post = postRepository.findByIdAndDeletedAtIsNull(postId).orElse(null);
+        if (post == null) {
+            return false;
+        }
+
+        // 이미 리뷰 작성했는지 확인
+        if (reviewRepository.existsByPostIdAndReviewerIdAndDeletedAtIsNull(postId, member.getId())) {
+            return false;
+        }
+
+        // 채팅 기록 확인
+        // 게시글 작성자인 경우: 해당 게시글에 채팅방이 있으면 리뷰 가능
+        if (post.getUserId().equals(member.getId())) {
+            return !chatRoomRepository.findByPostIdAndDeletedAtIsNull(postId).isEmpty();
+        }
+
+        // 채팅 요청자인 경우: 해당 게시글에 본인이 신청한 채팅방이 있으면 리뷰 가능
+        return chatRoomRepository.existsByPostIdAndApplicantIdAndDeletedAtIsNull(postId, member.getId());
+    }
+
+    // ========== Private Helper Methods ==========
+
+    /**
+     * UUID로 회원 조회
+     */
+    private Member findMemberByUuid(String visitorId) {
+        if (visitorId == null) {
+            throw new IllegalArgumentException("로그인이 필요합니다");
+        }
+        return memberRepository.findByUuidAndDeletedAtIsNull(UUID.fromString(visitorId))
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다"));
+    }
+
+    /**
+     * ID로 회원 조회
+     */
+    private Member findMemberById(Long memberId) {
+        return memberRepository.findByIdAndDeletedAtIsNull(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다"));
+    }
+
+    /**
+     * 게시글 ID로 조회
+     */
+    private Post findPostById(Long postId) {
+        return postRepository.findByIdAndDeletedAtIsNull(postId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글입니다"));
+    }
+
+    /**
+     * 채팅 기록 검증
+     * - 게시글 작성자: 해당 게시글에 채팅방이 존재해야 함
+     * - 채팅 요청자: 해당 게시글에 본인이 신청한 채팅방이 존재해야 함
+     */
+    private void validateChatHistory(Post post, Member reviewer) {
+        // 게시글 작성자인 경우
+        if (post.getUserId().equals(reviewer.getId())) {
+            if (chatRoomRepository.findByPostIdAndDeletedAtIsNull(post.getId()).isEmpty()) {
+                throw new IllegalArgumentException("해당 게시글에 채팅 기록이 없습니다");
+            }
+            return;
+        }
+
+        // 채팅 요청자인 경우
+        if (!chatRoomRepository.existsByPostIdAndApplicantIdAndDeletedAtIsNull(post.getId(), reviewer.getId())) {
+            throw new IllegalArgumentException("해당 게시글에 채팅 기록이 없습니다");
+        }
+    }
+
+    /**
+     * 리뷰 대상자 유효성 검증
+     * - 채팅 요청자 → 게시글 작성자에게만 리뷰 가능
+     * - 게시글 작성자 → 채팅 요청자에게만 리뷰 가능
+     */
+    private void validateRevieweeEligibility(Post post, Member reviewer, Member reviewee) {
+        // 채팅 요청자가 리뷰하는 경우: 게시글 작성자에게만 리뷰 가능
+        if (!post.getUserId().equals(reviewer.getId())) {
+            if (!post.getUserId().equals(reviewee.getId())) {
+                throw new IllegalArgumentException("게시글 작성자에게만 리뷰를 작성할 수 있습니다");
+            }
+            return;
+        }
+
+        // 게시글 작성자가 리뷰하는 경우: 해당 게시글에 채팅을 요청한 유저에게만 리뷰 가능
+        if (!chatRoomRepository.existsByPostIdAndApplicantIdAndDeletedAtIsNull(post.getId(), reviewee.getId())) {
+            throw new IllegalArgumentException("해당 게시글에 채팅을 요청한 유저에게만 리뷰를 작성할 수 있습니다");
+        }
+    }
+
+    /**
+     * Review -> ReviewResponse 변환
+     */
+    private ReviewResponse toReviewResponse(Review review) {
+        Member reviewer = memberRepository.findByIdAndDeletedAtIsNull(review.getReviewerId()).orElse(null);
+        Member reviewee = memberRepository.findByIdAndDeletedAtIsNull(review.getRevieweeId()).orElse(null);
+        Post post = postRepository.findByIdAndDeletedAtIsNull(review.getPostId()).orElse(null);
+
+        String reviewerNickname = reviewer != null ? reviewer.getNickname() : "알 수 없음";
+        String reviewerIslandName = reviewer != null ? reviewer.getIslandName() : null;
+        String revieweeNickname = reviewee != null ? reviewee.getNickname() : "알 수 없음";
+        String postItemName = post != null ? post.getItemName() : null;
+
+        return ReviewResponse.from(review, reviewerNickname, reviewerIslandName,
+                revieweeNickname, postItemName);
+    }
+}


### PR DESCRIPTION
- ReviewCreateRequest, ReviewResponse, ReviewListResponse DTO 생성
- ReviewService: 리뷰 작성, 목록 조회, 작성 가능 여부 확인 로직 구현
- ReviewController: REST API 엔드포인트 구현
- 채팅 기록 기반 리뷰 권한 검증 (post_id + reviewer_id 유니크)
- 금칙어 필터링 적용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 리뷰 시스템 추가: 리뷰 작성·조회, 페이징, 게시물별 리뷰 작성 가능 여부 확인, 평균 평점·리뷰 수 통계 제공.
  * 리뷰 작성 시 입력 유효성 검사(평점 범위·댓글 길이 등) 적용.

* **버그 수정·개선**
  * 콘텐츠 필터링 개선: 욕설 및 회피 표현을 더 정확히 탐지해 원문 형태와 공백을 보존하며 안전하게 마스킹하고, 로그는 개인정보 노출을 줄이도록 개선되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

[seulhuioh](https://github.com/seulhuioh)
[5 days ago](https://github.com/AC-trading/ac-trading/issues/36#issuecomment-3753508417)
Member
Author
평가 시나리오에서 게시글 하나에 여러번의 거래가 성립될 수 있고 게시글 작성자는 마지막 유저에게만, 게시글에 채팅을 건 사람은 (거래를 한 사람)은 모두 후기를 남길수 있음. 따라서 DB 현재 스키마의 (post_id, reviewer_id) 조합으로 구분 가능

각 채팅 요청자는 해당 게시글에서 작성자에게 1번만 리뷰 가능
게시글 작성자도 해당 게시글에서 1번만 리뷰 가능 (마지막 거래자에게)

reviewee_id는 리뷰 대상을 지정하는 용도일 뿐, 유니크 제약에 포함될 필요 없음

채팅 요청자 입장: 어차피 게시글 작성자 한 명에게만 리뷰 -> reviewee_id가 항상 동일
게시글 작성자 입장: 한 게시글에서 한 번만 리뷰 가능 -> 대상이 누구든 1회로 제한됨