### PR TITLE
9 post r2 image upload

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -24,7 +24,8 @@
       "Bash(gh pr edit:*)",
       "Bash(move:*)",
       "Bash(git checkout:*)",
-      "Bash(git branch:*)"
+      "Bash(git branch:*)",
+      "Bash(gh issue create:*)"
     ]
   }
 }

--- a/apps/api/build.gradle
+++ b/apps/api/build.gradle
@@ -44,6 +44,10 @@ dependencies {
 	// Database
 	runtimeOnly 'org.postgresql:postgresql'
 
+	// AWS S3 SDK (Cloudflare R2 호환)
+	implementation platform('software.amazon.awssdk:bom:2.25.16')
+	implementation 'software.amazon.awssdk:s3'
+
 	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/apps/api/src/main/java/com/acnh/api/common/exception/GlobalExceptionHandler.java
+++ b/apps/api/src/main/java/com/acnh/api/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,48 @@
+package com.acnh.api.common.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+
+import java.util.Map;
+
+/**
+ * 전역 예외 처리
+ */
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    /**
+     * 파일 크기 초과 예외 처리
+     */
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<Map<String, String>> handleMaxSizeException(MaxUploadSizeExceededException e) {
+        log.warn("파일 크기 초과: {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.PAYLOAD_TOO_LARGE)
+                .body(Map.of("error", "파일 크기가 너무 큽니다. (최대 5MB)"));
+    }
+
+    /**
+     * 잘못된 인자 예외 처리
+     */
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Map<String, String>> handleIllegalArgumentException(IllegalArgumentException e) {
+        log.warn("잘못된 요청: {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(Map.of("error", e.getMessage()));
+    }
+
+    /**
+     * 런타임 예외 처리
+     */
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<Map<String, String>> handleRuntimeException(RuntimeException e) {
+        log.error("서버 오류: {}", e.getMessage(), e);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(Map.of("error", "서버 오류가 발생했습니다."));
+    }
+}

--- a/apps/api/src/main/java/com/acnh/api/common/exception/GlobalExceptionHandler.java
+++ b/apps/api/src/main/java/com/acnh/api/common/exception/GlobalExceptionHandler.java
@@ -23,7 +23,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<Map<String, String>> handleMaxSizeException(MaxUploadSizeExceededException e) {
         log.warn("파일 크기 초과: {}", e.getMessage());
         return ResponseEntity.status(HttpStatus.PAYLOAD_TOO_LARGE)
-                .body(Map.of("error", "파일 크기가 너무 큽니다. (최대 5MB)"));
+                .body(Map.of("error", "파일 크기가 너무 큽니다. (최대 10MB)"));
     }
 
     /**

--- a/apps/api/src/main/java/com/acnh/api/common/exception/GlobalExceptionHandler.java
+++ b/apps/api/src/main/java/com/acnh/api/common/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.acnh.api.common.exception;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
@@ -33,6 +34,16 @@ public class GlobalExceptionHandler {
     public ResponseEntity<Map<String, String>> handleIllegalArgumentException(IllegalArgumentException e) {
         log.warn("잘못된 요청: {}", e.getMessage());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(Map.of("error", e.getMessage()));
+    }
+
+    /**
+     * 접근 권한 없음 예외 처리
+     */
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<Map<String, String>> handleAccessDeniedException(AccessDeniedException e) {
+        log.warn("접근 권한 없음: {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
                 .body(Map.of("error", e.getMessage()));
     }
 

--- a/apps/api/src/main/java/com/acnh/api/config/R2Config.java
+++ b/apps/api/src/main/java/com/acnh/api/config/R2Config.java
@@ -26,6 +26,9 @@ public class R2Config {
     @Value("${r2.endpoint}")
     private String endpoint;
 
+    @Value("${r2.region:auto}")
+    private String region;
+
     @Bean
     public S3Client s3Client() {
         AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
@@ -33,8 +36,7 @@ public class R2Config {
         return S3Client.builder()
                 .endpointOverride(URI.create(endpoint))
                 .credentialsProvider(StaticCredentialsProvider.create(credentials))
-                // R2는 리전이 auto이지만, SDK에서는 임의의 리전 설정 필요
-                .region(Region.of("auto"))
+                .region(Region.of(region))
                 .forcePathStyle(true)
                 .build();
     }

--- a/apps/api/src/main/java/com/acnh/api/config/R2Config.java
+++ b/apps/api/src/main/java/com/acnh/api/config/R2Config.java
@@ -1,0 +1,41 @@
+package com.acnh.api.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+import java.net.URI;
+
+/**
+ * Cloudflare R2 설정
+ * R2는 S3 호환 API를 사용하므로 AWS S3 SDK로 연동
+ */
+@Configuration
+public class R2Config {
+
+    @Value("${r2.access-key}")
+    private String accessKey;
+
+    @Value("${r2.secret-key}")
+    private String secretKey;
+
+    @Value("${r2.endpoint}")
+    private String endpoint;
+
+    @Bean
+    public S3Client s3Client() {
+        AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
+
+        return S3Client.builder()
+                .endpointOverride(URI.create(endpoint))
+                .credentialsProvider(StaticCredentialsProvider.create(credentials))
+                // R2는 리전이 auto이지만, SDK에서는 임의의 리전 설정 필요
+                .region(Region.of("auto"))
+                .forcePathStyle(true)
+                .build();
+    }
+}

--- a/apps/api/src/main/java/com/acnh/api/image/controller/ImageController.java
+++ b/apps/api/src/main/java/com/acnh/api/image/controller/ImageController.java
@@ -1,0 +1,65 @@
+package com.acnh.api.image.controller;
+
+import com.acnh.api.image.dto.ImageUploadResponse;
+import com.acnh.api.image.service.ImageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+/**
+ * 이미지 업로드 API
+ * 게시글, 채팅, 프로필 이미지 업로드 엔드포인트 제공
+ */
+@RestController
+@RequestMapping("/api/images")
+@RequiredArgsConstructor
+public class ImageController {
+
+    private final ImageService imageService;
+
+    /**
+     * 게시글 이미지 업로드 (최대 10개)
+     * POST /api/images/posts
+     */
+    @PostMapping("/posts")
+    public ResponseEntity<ImageUploadResponse> uploadPostImages(
+            @RequestParam("files") List<MultipartFile> files) {
+        List<String> urls = imageService.uploadPostImages(files);
+        return ResponseEntity.ok(ImageUploadResponse.of(urls));
+    }
+
+    /**
+     * 채팅 이미지 업로드 (최대 10개)
+     * POST /api/images/chat
+     */
+    @PostMapping("/chat")
+    public ResponseEntity<ImageUploadResponse> uploadChatImages(
+            @RequestParam("files") List<MultipartFile> files) {
+        List<String> urls = imageService.uploadChatImages(files);
+        return ResponseEntity.ok(ImageUploadResponse.of(urls));
+    }
+
+    /**
+     * 프로필 이미지 업로드 (단일)
+     * POST /api/images/profile
+     */
+    @PostMapping("/profile")
+    public ResponseEntity<ImageUploadResponse> uploadProfileImage(
+            @RequestParam("file") MultipartFile file) {
+        String url = imageService.uploadProfileImage(file);
+        return ResponseEntity.ok(ImageUploadResponse.of(List.of(url)));
+    }
+
+    /**
+     * 이미지 삭제
+     * DELETE /api/images?url={imageUrl}
+     */
+    @DeleteMapping
+    public ResponseEntity<Void> deleteImage(@RequestParam("url") String imageUrl) {
+        imageService.deleteImage(imageUrl);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/apps/api/src/main/java/com/acnh/api/image/controller/ImageController.java
+++ b/apps/api/src/main/java/com/acnh/api/image/controller/ImageController.java
@@ -4,6 +4,7 @@ import com.acnh.api.image.dto.ImageUploadResponse;
 import com.acnh.api.image.service.ImageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -26,8 +27,9 @@ public class ImageController {
      */
     @PostMapping("/posts")
     public ResponseEntity<ImageUploadResponse> uploadPostImages(
+            @AuthenticationPrincipal String visitorId,
             @RequestParam("files") List<MultipartFile> files) {
-        List<String> urls = imageService.uploadPostImages(files);
+        List<String> urls = imageService.uploadPostImages(files, visitorId);
         return ResponseEntity.ok(ImageUploadResponse.of(urls));
     }
 
@@ -37,8 +39,9 @@ public class ImageController {
      */
     @PostMapping("/chat")
     public ResponseEntity<ImageUploadResponse> uploadChatImages(
+            @AuthenticationPrincipal String visitorId,
             @RequestParam("files") List<MultipartFile> files) {
-        List<String> urls = imageService.uploadChatImages(files);
+        List<String> urls = imageService.uploadChatImages(files, visitorId);
         return ResponseEntity.ok(ImageUploadResponse.of(urls));
     }
 
@@ -48,18 +51,21 @@ public class ImageController {
      */
     @PostMapping("/profile")
     public ResponseEntity<ImageUploadResponse> uploadProfileImage(
+            @AuthenticationPrincipal String visitorId,
             @RequestParam("file") MultipartFile file) {
-        String url = imageService.uploadProfileImage(file);
+        String url = imageService.uploadProfileImage(file, visitorId);
         return ResponseEntity.ok(ImageUploadResponse.of(List.of(url)));
     }
 
     /**
-     * 이미지 삭제
+     * 이미지 삭제 (본인 이미지만 삭제 가능)
      * DELETE /api/images?url={imageUrl}
      */
     @DeleteMapping
-    public ResponseEntity<Void> deleteImage(@RequestParam("url") String imageUrl) {
-        imageService.deleteImage(imageUrl);
+    public ResponseEntity<Void> deleteImage(
+            @AuthenticationPrincipal String visitorId,
+            @RequestParam("url") String imageUrl) {
+        imageService.deleteImage(imageUrl, visitorId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/apps/api/src/main/java/com/acnh/api/image/dto/ImageUploadResponse.java
+++ b/apps/api/src/main/java/com/acnh/api/image/dto/ImageUploadResponse.java
@@ -1,0 +1,28 @@
+package com.acnh.api.image.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * 이미지 업로드 응답 DTO
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ImageUploadResponse {
+
+    private List<String> urls;
+    private int uploadedCount;
+
+    public static ImageUploadResponse of(List<String> urls) {
+        return ImageUploadResponse.builder()
+                .urls(urls)
+                .uploadedCount(urls.size())
+                .build();
+    }
+}

--- a/apps/api/src/main/java/com/acnh/api/image/service/ImageService.java
+++ b/apps/api/src/main/java/com/acnh/api/image/service/ImageService.java
@@ -1,0 +1,181 @@
+package com.acnh.api.image.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * 이미지 업로드/삭제 서비스
+ * Cloudflare R2에 이미지를 저장하고 관리
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+
+    private final S3Client s3Client;
+
+    @Value("${r2.bucket-name}")
+    private String bucketName;
+
+    @Value("${r2.public-url}")
+    private String publicUrl;
+
+    @Value("${image.allowed-types}")
+    private String allowedTypes;
+
+    @Value("${image.max-count.post}")
+    private int maxPostImages;
+
+    @Value("${image.max-count.chat}")
+    private int maxChatImages;
+
+    /**
+     * 게시글용 이미지 업로드 (최대 10개)
+     */
+    public List<String> uploadPostImages(List<MultipartFile> files) {
+        validateFileCount(files, maxPostImages, "게시글");
+        return uploadImages(files, "posts");
+    }
+
+    /**
+     * 채팅용 이미지 업로드 (최대 10개)
+     */
+    public List<String> uploadChatImages(List<MultipartFile> files) {
+        validateFileCount(files, maxChatImages, "채팅");
+        return uploadImages(files, "chat");
+    }
+
+    /**
+     * 프로필 이미지 업로드 (단일)
+     */
+    public String uploadProfileImage(MultipartFile file) {
+        validateFile(file);
+        return uploadImage(file, "profiles");
+    }
+
+    /**
+     * 이미지 삭제
+     * @param imageUrl 삭제할 이미지의 전체 URL
+     */
+    public void deleteImage(String imageUrl) {
+        try {
+            // URL에서 키 추출 (publicUrl 이후 부분)
+            String key = imageUrl.replace(publicUrl + "/", "");
+
+            DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(key)
+                    .build();
+
+            s3Client.deleteObject(deleteRequest);
+            log.info("이미지 삭제 완료: {}", key);
+        } catch (Exception e) {
+            log.error("이미지 삭제 실패: {}", imageUrl, e);
+            throw new RuntimeException("이미지 삭제에 실패했습니다.");
+        }
+    }
+
+    /**
+     * 여러 이미지 업로드 공통 로직
+     */
+    private List<String> uploadImages(List<MultipartFile> files, String folder) {
+        List<String> uploadedUrls = new ArrayList<>();
+
+        for (MultipartFile file : files) {
+            if (!file.isEmpty()) {
+                String url = uploadImage(file, folder);
+                uploadedUrls.add(url);
+            }
+        }
+
+        return uploadedUrls;
+    }
+
+    /**
+     * 단일 이미지 업로드
+     */
+    private String uploadImage(MultipartFile file, String folder) {
+        validateFile(file);
+
+        try {
+            // UUID + 타임스탬프로 고유한 파일명 생성
+            String originalFilename = file.getOriginalFilename();
+            String extension = getFileExtension(originalFilename);
+            String key = String.format("%s/%d_%s%s",
+                    folder,
+                    System.currentTimeMillis(),
+                    UUID.randomUUID().toString().substring(0, 8),
+                    extension);
+
+            // Content-Type 설정하여 브라우저에서 이미지로 인식
+            PutObjectRequest putRequest = PutObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(key)
+                    .contentType(file.getContentType())
+                    .build();
+
+            s3Client.putObject(putRequest, RequestBody.fromBytes(file.getBytes()));
+
+            String imageUrl = publicUrl + "/" + key;
+            log.info("이미지 업로드 완료: {}", imageUrl);
+
+            return imageUrl;
+        } catch (IOException e) {
+            log.error("이미지 업로드 실패: {}", file.getOriginalFilename(), e);
+            throw new RuntimeException("이미지 업로드에 실패했습니다.");
+        }
+    }
+
+    /**
+     * 파일 개수 검증
+     */
+    private void validateFileCount(List<MultipartFile> files, int maxCount, String type) {
+        if (files == null || files.isEmpty()) {
+            throw new IllegalArgumentException("업로드할 이미지가 없습니다.");
+        }
+        if (files.size() > maxCount) {
+            throw new IllegalArgumentException(
+                    String.format("%s 이미지는 최대 %d개까지 업로드할 수 있습니다.", type, maxCount));
+        }
+    }
+
+    /**
+     * 파일 유효성 검증
+     */
+    private void validateFile(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new IllegalArgumentException("업로드할 파일이 없습니다.");
+        }
+
+        String contentType = file.getContentType();
+        List<String> allowed = Arrays.asList(allowedTypes.split(","));
+
+        if (contentType == null || !allowed.contains(contentType)) {
+            throw new IllegalArgumentException(
+                    "지원하지 않는 파일 형식입니다. (허용: JPEG, PNG, GIF, WebP)");
+        }
+    }
+
+    /**
+     * 파일 확장자 추출
+     */
+    private String getFileExtension(String filename) {
+        if (filename == null || !filename.contains(".")) {
+            return "";
+        }
+        return filename.substring(filename.lastIndexOf("."));
+    }
+}

--- a/apps/api/src/main/java/com/acnh/api/image/service/ImageService.java
+++ b/apps/api/src/main/java/com/acnh/api/image/service/ImageService.java
@@ -15,8 +15,8 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -39,9 +39,6 @@ public class ImageService {
     @Value("${r2.public-url}")
     private String publicUrl;
 
-    @Value("${image.allowed-types}")
-    private String allowedTypes;
-
     @Value("${image.max-count.post}")
     private int maxPostImages;
 
@@ -50,6 +47,27 @@ public class ImageService {
 
     // 이미지 경로에서 사용자 ID 추출용 패턴: {folder}/{userId}/{timestamp}_{uuid}.{ext}
     private static final Pattern IMAGE_PATH_PATTERN = Pattern.compile("^(posts|chat|profiles)/(\\d+)/.*$");
+
+    // 파일 매직 바이트로 실제 MIME 타입 감지 (클라이언트 제공값 신뢰하지 않음)
+    private static final Map<String, byte[]> MAGIC_BYTES = Map.of(
+            "image/jpeg", new byte[]{(byte) 0xFF, (byte) 0xD8, (byte) 0xFF},
+            "image/png", new byte[]{(byte) 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A},
+            "image/gif", new byte[]{0x47, 0x49, 0x46, 0x38},  // GIF87a or GIF89a
+            "image/webp", new byte[]{0x52, 0x49, 0x46, 0x46}   // RIFF (WebP는 추가 검증 필요)
+    );
+
+    // MIME 타입별 표준 확장자
+    private static final Map<String, String> MIME_TO_EXTENSION = Map.of(
+            "image/jpeg", ".jpg",
+            "image/png", ".png",
+            "image/gif", ".gif",
+            "image/webp", ".webp"
+    );
+
+    // 허용된 MIME 타입 목록
+    private static final List<String> ALLOWED_MIME_TYPES = List.of(
+            "image/jpeg", "image/png", "image/gif", "image/webp"
+    );
 
     /**
      * 게시글용 이미지 업로드 (최대 10개)
@@ -150,14 +168,28 @@ public class ImageService {
     /**
      * 단일 이미지 업로드
      * 경로 형식: {folder}/{userId}/{timestamp}_{uuid}.{ext}
+     * 파일 바이트에서 실제 MIME 타입을 감지하여 확장자 결정
      */
     private String uploadImage(MultipartFile file, String folder, Long userId) {
+        // 기본 파일 검증 (null, empty)
         validateFile(file);
 
         try {
+            byte[] fileBytes = file.getBytes();
+
+            // 파일 바이트에서 실제 MIME 타입 감지 (클라이언트 제공값 신뢰하지 않음)
+            String detectedMime = detectMimeType(fileBytes);
+            if (detectedMime == null || !ALLOWED_MIME_TYPES.contains(detectedMime)) {
+                log.warn("지원하지 않는 파일 형식 감지: detectedMime={}, originalName={}",
+                        detectedMime, file.getOriginalFilename());
+                throw new IllegalArgumentException(
+                        "지원하지 않는 파일 형식입니다. (허용: JPEG, PNG, GIF, WebP)");
+            }
+
+            // 감지된 MIME 타입에서 확장자 결정 (원본 파일명 확장자 무시)
+            String extension = MIME_TO_EXTENSION.get(detectedMime);
+
             // UUID + 타임스탬프로 고유한 파일명 생성 (사용자 ID 포함)
-            String originalFilename = file.getOriginalFilename();
-            String extension = getFileExtension(originalFilename);
             String key = String.format("%s/%d/%d_%s%s",
                     folder,
                     userId,
@@ -165,17 +197,17 @@ public class ImageService {
                     UUID.randomUUID().toString().substring(0, 8),
                     extension);
 
-            // Content-Type 설정하여 브라우저에서 이미지로 인식
+            // 감지된 MIME 타입으로 Content-Type 설정
             PutObjectRequest putRequest = PutObjectRequest.builder()
                     .bucket(bucketName)
                     .key(key)
-                    .contentType(file.getContentType())
+                    .contentType(detectedMime)
                     .build();
 
-            s3Client.putObject(putRequest, RequestBody.fromBytes(file.getBytes()));
+            s3Client.putObject(putRequest, RequestBody.fromBytes(fileBytes));
 
             String imageUrl = publicUrl + "/" + key;
-            log.info("이미지 업로드 완료: {}", imageUrl);
+            log.info("이미지 업로드 완료: url={}, detectedMime={}", imageUrl, detectedMime);
 
             return imageUrl;
         } catch (IOException e) {
@@ -198,30 +230,61 @@ public class ImageService {
     }
 
     /**
-     * 파일 유효성 검증
+     * 파일 기본 유효성 검증 (null, empty 체크)
      */
     private void validateFile(MultipartFile file) {
         if (file == null || file.isEmpty()) {
             throw new IllegalArgumentException("업로드할 파일이 없습니다.");
         }
-
-        String contentType = file.getContentType();
-        List<String> allowed = Arrays.asList(allowedTypes.split(","));
-
-        if (contentType == null || !allowed.contains(contentType)) {
-            throw new IllegalArgumentException(
-                    "지원하지 않는 파일 형식입니다. (허용: JPEG, PNG, GIF, WebP)");
-        }
     }
 
     /**
-     * 파일 확장자 추출
+     * 파일 바이트에서 실제 MIME 타입 감지 (매직 바이트 기반)
+     * 클라이언트가 제공한 Content-Type이나 확장자를 신뢰하지 않음
      */
-    private String getFileExtension(String filename) {
-        if (filename == null || !filename.contains(".")) {
-            return "";
+    private String detectMimeType(byte[] fileBytes) {
+        if (fileBytes == null || fileBytes.length < 12) {
+            return null;
         }
-        return filename.substring(filename.lastIndexOf("."));
+
+        // JPEG: FF D8 FF
+        if (startsWith(fileBytes, MAGIC_BYTES.get("image/jpeg"))) {
+            return "image/jpeg";
+        }
+
+        // PNG: 89 50 4E 47 0D 0A 1A 0A
+        if (startsWith(fileBytes, MAGIC_BYTES.get("image/png"))) {
+            return "image/png";
+        }
+
+        // GIF: 47 49 46 38 (GIF8)
+        if (startsWith(fileBytes, MAGIC_BYTES.get("image/gif"))) {
+            return "image/gif";
+        }
+
+        // WebP: RIFF....WEBP (바이트 0-3: RIFF, 바이트 8-11: WEBP)
+        if (startsWith(fileBytes, MAGIC_BYTES.get("image/webp")) && fileBytes.length >= 12) {
+            if (fileBytes[8] == 'W' && fileBytes[9] == 'E' && fileBytes[10] == 'B' && fileBytes[11] == 'P') {
+                return "image/webp";
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * 바이트 배열이 특정 시그니처로 시작하는지 확인
+     */
+    private boolean startsWith(byte[] data, byte[] signature) {
+        if (data.length < signature.length) {
+            return false;
+        }
+        for (int i = 0; i < signature.length; i++) {
+            if (data[i] != signature[i]) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**

--- a/apps/api/src/main/resources/application.yml
+++ b/apps/api/src/main/resources/application.yml
@@ -49,10 +49,10 @@ app:
   cors:
     allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:3000,https://ac-trading.vercel.app}
 
-# 파일 업로드 크기 제한
+# 파일 업로드 크기 제한 (스크린샷 기준 개별 10MB)
 spring.servlet.multipart:
-  max-file-size: 5MB
-  max-request-size: 50MB
+  max-file-size: 10MB
+  max-request-size: 100MB
 
 # Cloudflare R2 설정
 r2:

--- a/apps/api/src/main/resources/application.yml
+++ b/apps/api/src/main/resources/application.yml
@@ -49,10 +49,10 @@ app:
   cors:
     allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:3000,https://ac-trading.vercel.app}
 
-# 파일 업로드 크기 제한 (스크린샷 기준 개별 10MB)
+# 파일 업로드 크기 제한 (환경변수로 오버라이드 가능)
 spring.servlet.multipart:
-  max-file-size: 10MB
-  max-request-size: 30MB
+  max-file-size: ${MULTIPART_MAX_FILE_SIZE:10MB}
+  max-request-size: ${MULTIPART_MAX_REQUEST_SIZE:30MB}
 
 # Cloudflare R2 설정
 r2:
@@ -63,9 +63,8 @@ r2:
   public-url: ${R2_PUBLIC_URL}
   region: ${R2_REGION:auto}
 
-# 이미지 업로드 설정
+# 이미지 업로드 설정 (환경변수로 오버라이드 가능)
 image:
   max-count:
-    post: 10
-    chat: 10
-  allowed-types: image/jpeg,image/png,image/gif,image/webp
+    post: ${IMAGE_MAX_COUNT_POST:10}
+    chat: ${IMAGE_MAX_COUNT_CHAT:10}

--- a/apps/api/src/main/resources/application.yml
+++ b/apps/api/src/main/resources/application.yml
@@ -61,6 +61,7 @@ r2:
   bucket-name: ${R2_BUCKET_NAME}
   endpoint: ${R2_ENDPOINT}
   public-url: ${R2_PUBLIC_URL}
+  region: ${R2_REGION:auto}
 
 # 이미지 업로드 설정
 image:

--- a/apps/api/src/main/resources/application.yml
+++ b/apps/api/src/main/resources/application.yml
@@ -52,7 +52,7 @@ app:
 # 파일 업로드 크기 제한 (스크린샷 기준 개별 10MB)
 spring.servlet.multipart:
   max-file-size: 10MB
-  max-request-size: 100MB
+  max-request-size: 30MB
 
 # Cloudflare R2 설정
 r2:

--- a/apps/api/src/main/resources/application.yml
+++ b/apps/api/src/main/resources/application.yml
@@ -48,3 +48,23 @@ cookie:
 app:
   cors:
     allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:3000,https://ac-trading.vercel.app}
+
+# 파일 업로드 크기 제한
+spring.servlet.multipart:
+  max-file-size: 5MB
+  max-request-size: 50MB
+
+# Cloudflare R2 설정
+r2:
+  access-key: ${R2_ACCESS_KEY}
+  secret-key: ${R2_SECRET_KEY}
+  bucket-name: ${R2_BUCKET_NAME}
+  endpoint: ${R2_ENDPOINT}
+  public-url: ${R2_PUBLIC_URL}
+
+# 이미지 업로드 설정
+image:
+  max-count:
+    post: 10
+    chat: 10
+  allowed-types: image/jpeg,image/png,image/gif,image/webp


### PR DESCRIPTION
API 엔드포인트

POST   /api/images/posts    - 게시글 이미지 (최대 10개)
POST   /api/images/chat     - 채팅 이미지 (최대 10개)
POST   /api/images/profile  - 프로필 이미지 (1개)
DELETE /api/images?url=     - 이미지 삭제


개별 파일 크기 | 10MB
총 요청 크기 | 30MB
허용 타입 | JPEG, PNG, GIF, WebP
게시글/채팅 최대 | 각 10개
파일명 형식 | {folder}/{timestamp}_{uuid}.{ext}


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 게시물·채팅·프로필용 이미지 업로드 및 이미지 삭제 API 추가
  * 업로드 결과를 통일된 응답 포맷으로 반환

* **버그 수정**
  * 전역 예외 처리 도입으로 파일 크기 초과(10MB), 잘못된 요청, 권한 문제 및 서버 오류에 대해 명확한 HTTP 응답 제공

* **Chores**
  * 클라우드 스토리지(R2/S3) 연동 지원 및 관련 SDK 의존성 추가
  * 멀티파트 업로드 제한(파일/요청 크기), 타입 및 최대 개수 구성 추가
  * 내부 설정 권한 목록 소폭 확장

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->