### PR TITLE
feat: Swagger/OpenAPI 문서화 연동 (#47)

### DIFF
--- a/apps/api/build.gradle
+++ b/apps/api/build.gradle
@@ -48,6 +48,9 @@ dependencies {
 	implementation platform('software.amazon.awssdk:bom:2.25.16')
 	implementation 'software.amazon.awssdk:s3'
 
+	// Swagger/OpenAPI (springdoc-openapi)
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+
 	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/apps/api/src/main/java/com/acnh/api/config/OpenApiConfig.java
+++ b/apps/api/src/main/java/com/acnh/api/config/OpenApiConfig.java
@@ -1,0 +1,56 @@
+package com.acnh.api.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+/**
+ * OpenAPI(Swagger) 설정
+ * API 문서 자동 생성 및 Swagger UI 제공
+ */
+@Configuration
+public class OpenApiConfig {
+
+    @Value("${springdoc.server-url:http://localhost:8080}")
+    private String serverUrl;
+
+    @Bean
+    public OpenAPI openAPI() {
+        // JWT Bearer 인증 스키마 정의
+        SecurityScheme securityScheme = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER)
+                .name("Authorization")
+                .description("JWT 액세스 토큰을 입력하세요. (Bearer 접두사 불필요)");
+
+        SecurityRequirement securityRequirement = new SecurityRequirement()
+                .addList("bearerAuth");
+
+        return new OpenAPI()
+                .info(apiInfo())
+                .servers(List.of(new Server().url(serverUrl).description("API Server")))
+                .components(new Components().addSecuritySchemes("bearerAuth", securityScheme))
+                .addSecurityItem(securityRequirement);
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("AC Trading API")
+                .description("모여봐요 동물의 숲 아이템 거래 플랫폼 API")
+                .version("1.0.0")
+                .contact(new Contact()
+                        .name("AC Trading Team")
+                        .url("https://github.com/AC-trading/ac-trading"));
+    }
+}

--- a/apps/api/src/main/java/com/acnh/api/config/SecurityConfig.java
+++ b/apps/api/src/main/java/com/acnh/api/config/SecurityConfig.java
@@ -65,7 +65,12 @@ public class SecurityConfig {
                     "/ws/**",             // WebSocket 연결 (STOMP 인증은 별도 처리)
                     "/health",            // 헬스체크
                     "/",                  // 루트
-                    "/error"              // 에러 페이지
+                    "/error",             // 에러 페이지
+                    // Swagger UI
+                    "/swagger-ui/**",
+                    "/swagger-ui.html",
+                    "/v3/api-docs/**",
+                    "/swagger-resources/**"
                 ).permitAll()
 
                 // 그 외 모든 요청은 인증 필요

--- a/apps/api/src/main/resources/application.yml
+++ b/apps/api/src/main/resources/application.yml
@@ -68,3 +68,15 @@ image:
   max-count:
     post: ${IMAGE_MAX_COUNT_POST:10}
     chat: ${IMAGE_MAX_COUNT_CHAT:10}
+
+# Swagger/OpenAPI 설정
+springdoc:
+  api-docs:
+    enabled: ${SWAGGER_ENABLED:true}
+    path: /v3/api-docs
+  swagger-ui:
+    enabled: ${SWAGGER_ENABLED:true}
+    path: /swagger-ui.html
+    tags-sorter: alpha
+    operations-sorter: alpha
+  server-url: ${SWAGGER_SERVER_URL:http://localhost:8080}


### PR DESCRIPTION
- springdoc-openapi-starter-webmvc-ui 2.3.0 의존성 추가
- OpenApiConfig: JWT Bearer 인증 스키마 설정
- SecurityConfig: Swagger UI 경로 인증 제외
- application.yml: Swagger 설정 (환경변수로 on/off 가능)

접근 경로:
- Swagger UI: /swagger-ui.html
- API Docs: /v3/api-docs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * API 문서를 위한 Swagger UI 제공 추가
  * 인터랙티브 API 탐색 및 테스트 기능 활성화
  * JWT 기반 보안 스키마 문서화
  * 인증 없이 API 문서 접근 가능하도록 설정

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->