### PR TITLE
fix: 비인증 사용자의 공개 API 접근 시 anonymousUser UUID 파싱 오류 수정

### DIFF
--- a/apps/api/src/main/java/com/acnh/api/block/service/BlockService.java
+++ b/apps/api/src/main/java/com/acnh/api/block/service/BlockService.java
@@ -154,8 +154,12 @@ public class BlockService {
 
     // ========== Private Helper Methods ==========
 
+    /**
+     * Before: visitorId == null 만 체크하여 "anonymousUser"가 UUID 파싱 시도됨
+     * After: "anonymousUser" 문자열도 비인증 상태로 처리
+     */
     private Member findMemberByUuid(String visitorId) {
-        if (visitorId == null) {
+        if (visitorId == null || "anonymousUser".equals(visitorId)) {
             throw new IllegalArgumentException("로그인이 필요합니다");
         }
         return memberRepository.findByUuidAndDeletedAtIsNull(UUID.fromString(visitorId))

--- a/apps/api/src/main/java/com/acnh/api/chat/service/ChatService.java
+++ b/apps/api/src/main/java/com/acnh/api/chat/service/ChatService.java
@@ -422,9 +422,11 @@ public class ChatService {
 
     /**
      * UUID로 회원 조회
+     * Before: visitorId == null 만 체크하여 "anonymousUser"가 UUID 파싱 시도됨
+     * After: "anonymousUser" 문자열도 비인증 상태로 처리
      */
     private Member findMemberByUuid(String visitorId) {
-        if (visitorId == null) {
+        if (visitorId == null || "anonymousUser".equals(visitorId)) {
             throw new IllegalArgumentException("로그인이 필요합니다");
         }
         return memberRepository.findByUuidAndDeletedAtIsNull(UUID.fromString(visitorId))

--- a/apps/api/src/main/java/com/acnh/api/image/service/ImageService.java
+++ b/apps/api/src/main/java/com/acnh/api/image/service/ImageService.java
@@ -289,9 +289,11 @@ public class ImageService {
 
     /**
      * UUID로 회원 조회
+     * Before: visitorId == null 만 체크하여 "anonymousUser"가 UUID 파싱 시도됨
+     * After: "anonymousUser" 문자열도 비인증 상태로 처리
      */
     private Member findMemberByUuid(String visitorId) {
-        if (visitorId == null) {
+        if (visitorId == null || "anonymousUser".equals(visitorId)) {
             throw new IllegalArgumentException("로그인이 필요합니다");
         }
         return memberRepository.findByUuidAndDeletedAtIsNull(UUID.fromString(visitorId))

--- a/apps/api/src/main/java/com/acnh/api/member/service/MemberService.java
+++ b/apps/api/src/main/java/com/acnh/api/member/service/MemberService.java
@@ -111,8 +111,13 @@ public class MemberService {
 
     /**
      * UUID로 회원 조회 (공통 메서드)
+     * Before: visitorId == null 체크 없이 바로 UUID 파싱 시도됨
+     * After: "anonymousUser" 문자열도 비인증 상태로 처리
      */
     private Member findMemberByUuid(String visitorId) {
+        if (visitorId == null || "anonymousUser".equals(visitorId)) {
+            throw new IllegalArgumentException("로그인이 필요합니다");
+        }
         return memberRepository.findByUuidAndDeletedAtIsNull(UUID.fromString(visitorId))
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다"));
     }

--- a/apps/api/src/main/java/com/acnh/api/post/service/LikeService.java
+++ b/apps/api/src/main/java/com/acnh/api/post/service/LikeService.java
@@ -125,9 +125,11 @@ public class LikeService {
 
     /**
      * UUID로 회원 조회
+     * Before: visitorId == null 만 체크하여 "anonymousUser"가 UUID 파싱 시도됨
+     * After: "anonymousUser" 문자열도 비인증 상태로 처리
      */
     private Member findMemberByUuid(String visitorId) {
-        if (visitorId == null) {
+        if (visitorId == null || "anonymousUser".equals(visitorId)) {
             throw new IllegalArgumentException("로그인이 필요합니다");
         }
         return memberRepository.findByUuidAndDeletedAtIsNull(UUID.fromString(visitorId))

--- a/apps/api/src/main/java/com/acnh/api/post/service/PostService.java
+++ b/apps/api/src/main/java/com/acnh/api/post/service/PostService.java
@@ -245,9 +245,11 @@ public class PostService {
 
     /**
      * UUID로 회원 조회
+     * Before: visitorId == null 만 체크하여 "anonymousUser"가 UUID 파싱 시도됨
+     * After: "anonymousUser" 문자열도 비인증 상태로 처리
      */
     private Member findMemberByUuid(String visitorId) {
-        if (visitorId == null) {
+        if (visitorId == null || "anonymousUser".equals(visitorId)) {
             throw new IllegalArgumentException("로그인이 필요합니다");
         }
         return memberRepository.findByUuidAndDeletedAtIsNull(UUID.fromString(visitorId))
@@ -264,9 +266,11 @@ public class PostService {
 
     /**
      * 현재 로그인한 사용자 ID 조회 (null 허용)
+     * Before: visitorId == null 만 체크하여 "anonymousUser"가 UUID 파싱 시도됨
+     * After: "anonymousUser" 문자열도 비인증 상태로 처리
      */
     private Long getCurrentUserId(String visitorId) {
-        if (visitorId == null) {
+        if (visitorId == null || "anonymousUser".equals(visitorId)) {
             return null;
         }
         return memberRepository.findByUuidAndDeletedAtIsNull(UUID.fromString(visitorId))

--- a/apps/api/src/main/java/com/acnh/api/priceoffer/service/PriceOfferService.java
+++ b/apps/api/src/main/java/com/acnh/api/priceoffer/service/PriceOfferService.java
@@ -199,9 +199,11 @@ public class PriceOfferService {
 
     /**
      * UUID로 회원 조회
+     * Before: visitorId == null 만 체크하여 "anonymousUser"가 UUID 파싱 시도됨
+     * After: "anonymousUser" 문자열도 비인증 상태로 처리
      */
     private Member findMemberByUuid(String visitorId) {
-        if (visitorId == null) {
+        if (visitorId == null || "anonymousUser".equals(visitorId)) {
             throw new IllegalArgumentException("로그인이 필요합니다");
         }
 

--- a/apps/api/src/main/java/com/acnh/api/report/service/ReportService.java
+++ b/apps/api/src/main/java/com/acnh/api/report/service/ReportService.java
@@ -78,9 +78,11 @@ public class ReportService {
 
     /**
      * UUID로 회원 조회
+     * Before: visitorId == null 만 체크하여 "anonymousUser"가 UUID 파싱 시도됨
+     * After: "anonymousUser" 문자열도 비인증 상태로 처리
      */
     private Member findMemberByUuid(String visitorId) {
-        if (visitorId == null) {
+        if (visitorId == null || "anonymousUser".equals(visitorId)) {
             throw new IllegalArgumentException("로그인이 필요합니다");
         }
         return memberRepository.findByUuidAndDeletedAtIsNull(UUID.fromString(visitorId))

--- a/apps/api/src/main/java/com/acnh/api/review/service/ReviewService.java
+++ b/apps/api/src/main/java/com/acnh/api/review/service/ReviewService.java
@@ -191,9 +191,11 @@ public class ReviewService {
 
     /**
      * UUID로 회원 조회
+     * Before: visitorId == null 만 체크하여 "anonymousUser"가 UUID 파싱 시도됨
+     * After: "anonymousUser" 문자열도 비인증 상태로 처리
      */
     private Member findMemberByUuid(String visitorId) {
-        if (visitorId == null) {
+        if (visitorId == null || "anonymousUser".equals(visitorId)) {
             throw new IllegalArgumentException("로그인이 필요합니다");
         }
 


### PR DESCRIPTION
- 문제: permitAll() 경로에서 @AuthenticationPrincipal이 "anonymousUser" 반환
- 원인: visitorId == null 만 체크하여 UUID.fromString("anonymousUser") 시도
- 해결: "anonymousUser".equals(visitorId) 조건 추가

수정된 파일:
- PostService: getCurrentUserId(), findMemberByUuid()
- LikeService, BlockService, ChatService, ImageService
- MemberService, ReportService, ReviewService, PriceOfferService

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* 익명 사용자 인증 처리 일관성 강화 - 블록, 채팅, 이미지, 회원, 게시물, 가격 제안, 신고, 리뷰 기능에서 익명 사용자가 접근할 수 없는 기능 사용 시 로그인 요청 메시지를 일관되게 표시하도록 개선했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->