### PR TITLE
fix: OAuth 로그인 시 백엔드를 통해 시작하도록 변경

### DIFF
--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -11,7 +11,16 @@ import { useAuth } from "@/context/AuthContext";
 // 백엔드 OAuth 시작 URL 생성
 function getBackendLoginUrl(provider: "google" | "kakao") {
   const apiUrl = process.env.NEXT_PUBLIC_API_URL;
-  return `${apiUrl}/api/auth/login/${provider}`;
+
+  // 환경 변수 검증
+  if (!apiUrl) {
+    throw new Error("NEXT_PUBLIC_API_URL 환경 변수가 설정되지 않았습니다.");
+  }
+
+  // trailing slash 제거하여 URL 정규화
+  const cleanedApiUrl = apiUrl.replace(/\/+$/, "");
+
+  return `${cleanedApiUrl}/api/auth/login/${provider}`;
 }
 
 // 로그인 폼 컴포넌트 (소셜 로그인만)

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -6,22 +6,12 @@ import { useEffect, Suspense } from "react";
 import { HomeOutlineIcon } from "@/components/icons";
 import { useAuth } from "@/context/AuthContext";
 
-// Cognito OAuth URL 생성
-function getCognitoLoginUrl(provider: "Google" | "Kakao") {
-  const cognitoDomain = process.env.NEXT_PUBLIC_COGNITO_DOMAIN;
-  const clientId = process.env.NEXT_PUBLIC_COGNITO_CLIENT_ID;
-  // 백엔드로 콜백 (토큰 교환은 백엔드에서 처리)
-  const redirectUri = process.env.NEXT_PUBLIC_COGNITO_REDIRECT_URI || `${process.env.NEXT_PUBLIC_API_URL}/api/auth/callback`;
-
-  const params = new URLSearchParams({
-    client_id: clientId!,
-    response_type: "code",
-    scope: "openid email profile",
-    redirect_uri: redirectUri,
-    identity_provider: provider,
-  });
-
-  return `https://${cognitoDomain}/oauth2/authorize?${params.toString()}`;
+// Before: 프론트에서 Cognito로 직접 리다이렉트 - 백엔드 state 쿠키 미설정
+// After: 백엔드 /api/auth/login/{provider}로 리다이렉트 - state 쿠키 설정됨
+// 백엔드 OAuth 시작 URL 생성
+function getBackendLoginUrl(provider: "google" | "kakao") {
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+  return `${apiUrl}/api/auth/login/${provider}`;
 }
 
 // 로그인 폼 컴포넌트 (소셜 로그인만)
@@ -41,14 +31,14 @@ function LoginForm() {
   const error = searchParams.get("error");
   const errorMessage = error ? getErrorMessage(error) : null;
 
-  // 구글 로그인
+  // 구글 로그인 - 백엔드로 리다이렉트하여 state 쿠키 설정
   const handleGoogleLogin = () => {
-    window.location.href = getCognitoLoginUrl("Google");
+    window.location.href = getBackendLoginUrl("google");
   };
 
-  // 카카오 로그인
+  // 카카오 로그인 - 백엔드로 리다이렉트하여 state 쿠키 설정
   const handleKakaoLogin = () => {
-    window.location.href = getCognitoLoginUrl("Kakao");
+    window.location.href = getBackendLoginUrl("kakao");
   };
 
   if (isLoading) {


### PR DESCRIPTION
- Before: 프론트에서 Cognito로 직접 리다이렉트 - state 쿠키가 백엔드 도메인에 설정 안됨
- After: 백엔드 /api/auth/login/{provider}로 먼저 리다이렉트
- 백엔드에서 state 쿠키 설정 후 Cognito로 리다이렉트
- 콜백 시 같은 도메인(백엔드)이므로 쿠키 전달됨

크로스 도메인 쿠키 문제 해결 (Vercel ↔ Railway)

변경 내용:

프론트엔드 로그인 버튼 클릭 시 Cognito로 직접 가는 대신 백엔드 /api/auth/login/{provider}로 먼저 이동
백엔드에서 state 쿠키 설정 후 Cognito로 리다이렉트
Cognito 인증 후 백엔드 callback으로 돌아올 때 같은 도메인이므로 쿠키 전달됨
플로우:

프론트(vercel.app) → 백엔드(railway.app) /api/auth/login/google
백엔드가 state 쿠키 설정 (railway.app 도메인)
백엔드 → Cognito 리다이렉트
Cognito 인증 완료
Cognito → 백엔드(railway.app) /api/auth/callback
쿠키 전달됨 (같은 railway.app 도메인)
state 검증 성공 → 토큰 발급 → 프론트로 리다이렉트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **리팩터**
  * 구글·카카오 소셜 로그인 흐름을 클라이언트에서 백엔드 주도 방식으로 전환
  * 클라이언트에서 직접 인증 URL을 생성하지 않고 백엔드 로그인 엔드포인트로 리디렉션하도록 변경
  * 로그인 UI 구조는 유지하되 백엔드의 상태 쿠키 및 OAuth 초기화가 사용되도록 업데이트

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->