### PR TITLE
61 fix sign up redirect page

### DIFF
--- a/apps/api/src/main/java/com/acnh/api/member/dto/MemberProfileResponse.java
+++ b/apps/api/src/main/java/com/acnh/api/member/dto/MemberProfileResponse.java
@@ -24,6 +24,7 @@ public class MemberProfileResponse {
     private Integer totalTradeCount;
     private Long reviewCount;
     private LocalDateTime createdAt;
+    private boolean isProfileComplete;
 
     /**
      * Entity -> DTO 변환
@@ -39,6 +40,7 @@ public class MemberProfileResponse {
                 .totalTradeCount(member.getTotalTradeCount())
                 .reviewCount(reviewCount)
                 .createdAt(member.getCreatedAt())
+                .isProfileComplete(member.isProfileComplete())
                 .build();
     }
 }

--- a/apps/api/src/main/java/com/acnh/api/member/entity/Member.java
+++ b/apps/api/src/main/java/com/acnh/api/member/entity/Member.java
@@ -138,4 +138,12 @@ public class Member extends BaseEntity {
     public void incrementTradeCount() {
         this.totalTradeCount++;
     }
+
+    /**
+     * 프로필 완성 여부 확인
+     * - 기본 닉네임 "섬주민"으로 시작하면 미완성으로 판단
+     */
+    public boolean isProfileComplete() {
+        return nickname != null && !nickname.startsWith("섬주민");
+    }
 }

--- a/apps/web/src/app/profile/edit/page.tsx
+++ b/apps/web/src/app/profile/edit/page.tsx
@@ -2,21 +2,47 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { HomeOutlineIcon } from "@/components/icons";
+import { useAuth } from "@/context/AuthContext";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
 
 // 프로필 수정 페이지 - Figma 디자인 기반 (회원가입 페이지와 동일 스타일)
 export default function ProfileEditPage() {
   const router = useRouter();
+  const { user, accessToken, isLoading } = useAuth();
   const [formData, setFormData] = useState({
     islandName: "",
     name: "",
-    hemisphere: "",
+    hemisphere: "NORTH",
     dreamAddress: "",
   });
   const [isIslandNameValid, setIsIslandNameValid] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  // 기존 프로필 정보 불러오기
+  useEffect(() => {
+    if (user) {
+      setFormData({
+        islandName: user.islandName || "",
+        name: user.nickname || "",
+        hemisphere: user.hemisphere || "NORTH",
+        dreamAddress: user.dreamCode || "",
+      });
+      setIsIslandNameValid((user.islandName?.length || 0) >= 2);
+    }
+  }, [user]);
+
+  // 로그인 확인
+  useEffect(() => {
+    if (!isLoading && !accessToken) {
+      router.push("/login");
+    }
+  }, [isLoading, accessToken, router]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
     const { name, value } = e.target;
     setFormData((prev) => ({ ...prev, [name]: value }));
 
@@ -26,11 +52,52 @@ export default function ProfileEditPage() {
     }
   };
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    // TODO: API 호출로 프로필 업데이트
-    router.push("/profile");
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      // 신규 유저(프로필 미완성)는 profile-setup, 기존 유저는 update API 호출
+      const isNewUser = !user?.isProfileComplete;
+      const endpoint = isNewUser ? "/api/users/me/profile-setup" : "/api/users/me/update";
+
+      const res = await fetch(`${API_URL}${endpoint}`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${accessToken}`,
+        },
+        body: JSON.stringify({
+          nickname: formData.name,
+          islandName: formData.islandName,
+          dreamAddress: formData.dreamAddress || null,
+          ...(isNewUser && { hemisphere: formData.hemisphere }),
+        }),
+      });
+
+      if (res.ok) {
+        router.push("/");
+      } else {
+        const errorData = await res.json().catch(() => null);
+        setError(errorData?.message || "프로필 저장에 실패했습니다.");
+      }
+    } catch (err) {
+      console.error("프로필 저장 실패:", err);
+      setError("네트워크 오류가 발생했습니다.");
+    } finally {
+      setIsSubmitting(false);
+    }
   };
+
+  // 로딩 중
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-primary flex items-center justify-center">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-white"></div>
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen bg-primary flex flex-col">
@@ -86,17 +153,22 @@ export default function ProfileEditPage() {
             />
           </div>
 
-          {/* 반구 */}
+          {/* 반구 - 신규 유저만 수정 가능 */}
           <div>
             <label className="block text-white font-medium mb-1">반구</label>
-            <input
-              type="text"
+            <select
               name="hemisphere"
               value={formData.hemisphere}
               onChange={handleChange}
-              placeholder="북반구 / 남반구"
-              className="w-full px-4 py-3 rounded-lg border-2 border-white/50 bg-transparent text-white placeholder-white/70 focus:outline-none focus:border-white"
-            />
+              disabled={user?.isProfileComplete}
+              className="w-full px-4 py-3 rounded-lg border-2 border-white/50 bg-transparent text-white focus:outline-none focus:border-white disabled:opacity-50"
+            >
+              <option value="NORTH" className="text-gray-900">북반구</option>
+              <option value="SOUTH" className="text-gray-900">남반구</option>
+            </select>
+            {user?.isProfileComplete && (
+              <p className="text-sm mt-1 text-white/70">* 반구는 변경할 수 없습니다.</p>
+            )}
           </div>
 
           {/* 꿈번지 */}
@@ -112,13 +184,20 @@ export default function ProfileEditPage() {
             />
           </div>
 
-          {/* 수정 완료 버튼 */}
+          {/* 에러 메시지 */}
+          {error && (
+            <div className="p-3 rounded-lg bg-red-500/20 border border-red-300/50">
+              <p className="text-red-200 text-sm">{error}</p>
+            </div>
+          )}
+
+          {/* 저장 버튼 */}
           <button
             type="submit"
-            disabled={!isIslandNameValid || !formData.name}
+            disabled={!isIslandNameValid || !formData.name || isSubmitting}
             className="w-full py-3 rounded-lg bg-white text-primary font-semibold hover:bg-gray-100 transition-colors disabled:opacity-50 disabled:cursor-not-allowed mt-6"
           >
-            수정 완료
+            {isSubmitting ? "저장 중..." : user?.isProfileComplete ? "수정 완료" : "프로필 설정 완료"}
           </button>
         </form>
       </div>

--- a/apps/web/src/context/AuthContext.tsx
+++ b/apps/web/src/context/AuthContext.tsx
@@ -11,6 +11,7 @@ interface User {
   islandName?: string;
   hemisphere?: 'NORTH' | 'SOUTH';
   dreamCode?: string;
+  isProfileComplete?: boolean;
 }
 
 // AuthContext 타입


### PR DESCRIPTION
구글 로그인 → OAuth 콜백 페이지
콜백에서 /api/users/me 호출하여 isProfileComplete 확인
신규 유저 (isProfileComplete: false) → /profile/edit으로 리다이렉트
기존 유저 (isProfileComplete: true) → /(홈)으로 리다이렉트
/profile/edit에서 프로필 저장 시:
신규 유저: POST /api/users/me/profile-setup
기존 유저: POST /api/users/me/update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 프로필 완성도 추적 기능 추가: 사용자 인증 후 프로필 완성 여부를 자동으로 확인하여 미완성 시 프로필 편집 페이지로 자동 이동
  * 프로필 편집 페이지 개선: 섬 정보 입력 폼 강화, 기존 데이터 자동 로드, 실시간 유효성 검사 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->