### PR TITLE
32 feat remain page

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,4 +1,13 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "**",
+      },
+    ],
+  },
+};
 
 export default nextConfig;

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,12 +1,32 @@
 /** @type {import('next').NextConfig} */
+
+// 환경 변수에서 허용된 이미지 호스트 목록 가져오기
+// 예: ALLOWED_IMAGE_HOSTS="cdn.example.com,images.example.com,*.cloudflare.com"
+const allowedImageHosts = process.env.ALLOWED_IMAGE_HOSTS;
+
+// 허용된 호스트를 remotePatterns 형식으로 변환
+const getRemotePatterns = () => {
+  if (!allowedImageHosts || allowedImageHosts.trim() === "") {
+    // 환경 변수가 설정되지 않은 경우 빈 배열 반환 (로컬 이미지만 허용)
+    console.warn(
+      "ALLOWED_IMAGE_HOSTS 환경 변수가 설정되지 않았습니다. 외부 이미지가 차단됩니다."
+    );
+    return [];
+  }
+
+  return allowedImageHosts
+    .split(",")
+    .map((host) => host.trim())
+    .filter((host) => host.length > 0)
+    .map((hostname) => ({
+      protocol: "https",
+      hostname,
+    }));
+};
+
 const nextConfig = {
   images: {
-    remotePatterns: [
-      {
-        protocol: "https",
-        hostname: "**",
-      },
-    ],
+    remotePatterns: getRemotePatterns(),
   },
 };
 

--- a/apps/web/src/app/chat/[id]/page.tsx
+++ b/apps/web/src/app/chat/[id]/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef } from "react";
 import { useRouter, useParams } from "next/navigation";
 import Link from "next/link";
+import Image from "next/image";
 import { ChevronLeftIcon, CameraIcon, MoreVerticalIcon, FlagIcon, BlockIcon, ExitIcon, BellOffIcon, StarIcon } from "@/components/icons";
 import { useAuth } from "@/context/AuthContext";
 import { webSocketClient, ChatMessage } from "@/lib/websocket";
@@ -29,10 +30,12 @@ function MessageBubble({ message }: { message: DisplayMessage }) {
   return (
     <div className={`flex ${message.isMe ? "justify-end" : "justify-start"} mb-3`}>
       {!message.isMe && (
-        <img
+        <Image
           src="/images/defaults/raccoon.png"
           alt="프로필"
-          className="w-10 h-10 rounded-full bg-gray-200 flex-shrink-0 mr-2 object-cover"
+          width={40}
+          height={40}
+          className="rounded-full bg-gray-200 flex-shrink-0 mr-2 object-cover"
         />
       )}
       <div className={`flex flex-col ${message.isMe ? "items-end" : "items-start"}`}>
@@ -44,7 +47,7 @@ function MessageBubble({ message }: { message: DisplayMessage }) {
           }`}
         >
           {message.imageUrl ? (
-            <img src={message.imageUrl} alt="이미지" className="max-w-full rounded" />
+            <Image src={message.imageUrl} alt="이미지" width={200} height={200} className="max-w-full rounded object-contain" />
           ) : (
             message.content
           )}
@@ -382,9 +385,11 @@ export default function ChatRoomPage() {
             >
               <div className="w-12 h-12 bg-gray-200 rounded-lg flex-shrink-0 overflow-hidden">
                 {chatRoom.postImageUrl ? (
-                  <img
+                  <Image
                     src={chatRoom.postImageUrl}
                     alt={chatRoom.postItemName}
+                    width={48}
+                    height={48}
                     className="w-full h-full object-cover"
                   />
                 ) : (

--- a/apps/web/src/app/chat/page.tsx
+++ b/apps/web/src/app/chat/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import Link from "next/link";
+import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { MobileLayout, Header } from "@/components/common";
 import { RefreshIcon, BellIcon } from "@/components/icons";
@@ -16,10 +17,12 @@ function ChatItem({ chat }: { chat: ChatRoom }) {
       className="flex items-center gap-3 p-4 hover:bg-gray-50 transition-colors border-b border-gray-100 relative"
     >
       {/* 프로필 이미지 */}
-      <img
+      <Image
         src="/images/defaults/raccoon.png"
         alt="프로필"
-        className="w-12 h-12 rounded-full bg-gray-200 flex-shrink-0 object-cover"
+        width={48}
+        height={48}
+        className="rounded-full bg-gray-200 flex-shrink-0 object-cover"
       />
 
       {/* 채팅 정보 */}

--- a/apps/web/src/app/chat/page.tsx
+++ b/apps/web/src/app/chat/page.tsx
@@ -18,7 +18,7 @@ function ChatItem({ chat }: { chat: ChatRoom }) {
     >
       {/* 프로필 이미지 */}
       <Image
-        src="/images/defaults/raccoon.png"
+        src={process.env.NEXT_PUBLIC_DEFAULT_PROFILE_IMAGE || "/images/defaults/raccoon.png"}
         alt="프로필"
         width={48}
         height={48}

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import Image from "next/image";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, Suspense } from "react";
 import { HomeOutlineIcon } from "@/components/icons";
@@ -157,10 +158,12 @@ export default function LoginPage() {
       <div className="flex-1 flex flex-col items-center justify-center px-8">
         <div className="mb-8 text-center">
           {/* 너굴 아이콘 */}
-          <img
+          <Image
             src="/images/defaults/raccoon.png"
             alt="AC Trading"
-            className="w-24 h-24 mx-auto mb-2 rounded-full"
+            width={96}
+            height={96}
+            className="mx-auto mb-2 rounded-full"
           />
           <h1 className="text-4xl font-bold text-white" style={{ fontFamily: "cursive" }}>
             AC Trading

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -86,7 +86,7 @@ export default function HomePage() {
 
   return (
     <MobileLayout>
-      <Header showLocation showSearch showBell />
+      <Header showLocation showSearch showBell showAuth={false} />
 
       {/* 비로그인 사용자 안내 배너 */}
       {!authLoading && !isAuthenticated && (

--- a/apps/web/src/app/post/[id]/page.tsx
+++ b/apps/web/src/app/post/[id]/page.tsx
@@ -260,7 +260,10 @@ export default function PostDetailPage() {
       </div>
 
       {/* 판매자 정보 */}
-      <div className="flex items-center gap-3 p-4 border-b border-gray-100">
+      <Link
+        href={`/user/${post.userId}`}
+        className="flex items-center gap-3 p-4 border-b border-gray-100 hover:bg-gray-50 transition-colors"
+      >
         <div className="w-12 h-12 rounded-full bg-primary-light flex items-center justify-center text-2xl">
           🐰
         </div>
@@ -274,7 +277,7 @@ export default function PostDetailPage() {
             <p className="text-xs text-gray-400">매너온도</p>
           </div>
         )}
-      </div>
+      </Link>
 
       {/* 상품 정보 */}
       <div className="p-4 space-y-4">

--- a/apps/web/src/app/post/[id]/page.tsx
+++ b/apps/web/src/app/post/[id]/page.tsx
@@ -278,14 +278,26 @@ export default function PostDetailPage() {
 
       {/* 상품 정보 */}
       <div className="p-4 space-y-4">
-        {/* 상태 배지 */}
-        {post.status !== "AVAILABLE" && (
-          <span className={`inline-block px-2 py-1 text-xs font-medium rounded ${
-            post.status === "RESERVED" ? "bg-yellow-100 text-yellow-800" : "bg-gray-100 text-gray-600"
+        {/* 거래 유형 & 상태 배지 */}
+        <div className="flex items-center gap-2">
+          {/* 거래 유형 칩 */}
+          <span className={`inline-block px-3 py-1.5 text-sm font-medium rounded-full border ${
+            post.postType === "SELL"
+              ? "border-primary bg-primary/10 text-primary"
+              : "border-[#5BBFB3] bg-[#5BBFB3]/10 text-[#5BBFB3]"
           }`}>
-            {getStatusLabel(post.status)}
+            {post.postType === "SELL" ? "팔아요" : "구해요"}
           </span>
-        )}
+
+          {/* 상태 배지 */}
+          {post.status !== "AVAILABLE" && (
+            <span className={`inline-block px-3 py-1.5 text-sm font-medium rounded-full ${
+              post.status === "RESERVED" ? "bg-yellow-100 text-yellow-800" : "bg-gray-100 text-gray-600"
+            }`}>
+              {getStatusLabel(post.status)}
+            </span>
+          )}
+        </div>
 
         {/* 제목 */}
         <h2 className="text-xl font-bold text-gray-900">{post.itemName}</h2>

--- a/apps/web/src/app/profile/edit/page.tsx
+++ b/apps/web/src/app/profile/edit/page.tsx
@@ -133,9 +133,9 @@ export default function ProfileEditPage() {
               placeholder="섬 이름을 입력하세요"
               className="w-full px-4 py-3 rounded-lg border-2 border-white/50 bg-transparent text-white placeholder-white/70 focus:outline-none focus:border-white"
             />
-            {formData.islandName && (
-              <p className={`text-sm mt-1 ${isIslandNameValid ? "text-green-200" : "text-red-200"}`}>
-                * {isIslandNameValid ? "사용 가능한 섬 이름입니다." : "2자 이상 입력해주세요."}
+            {formData.islandName && !isIslandNameValid && (
+              <p className="text-sm mt-1 text-red-200">
+                * 2자 이상 입력해주세요.
               </p>
             )}
           </div>

--- a/apps/web/src/app/profile/edit/page.tsx
+++ b/apps/web/src/app/profile/edit/page.tsx
@@ -112,9 +112,11 @@ export default function ProfileEditPage() {
       <div className="flex-1 flex flex-col items-center px-8 pt-4">
         {/* 프로필 이미지 */}
         <div className="mb-4">
-          <div className="w-28 h-28 rounded-full bg-gray-200 flex items-center justify-center text-6xl border-4 border-white/50">
-            🐰
-          </div>
+          <img
+            src={user?.profileImage || "/images/defaults/raccoon.png"}
+            alt="프로필 이미지"
+            className="w-28 h-28 rounded-full object-cover border-4 border-white/50"
+          />
           <button className="mt-2 px-4 py-1 bg-white/20 text-white text-sm rounded-full hover:bg-white/30 transition-colors">
             사진 수정
           </button>
@@ -173,7 +175,7 @@ export default function ProfileEditPage() {
 
           {/* 꿈번지 */}
           <div>
-            <label className="block text-white font-medium mb-1">꿈번지</label>
+            <label className="block text-white font-medium mb-1">꿈번지 (선택)</label>
             <input
               type="text"
               name="dreamAddress"

--- a/apps/web/src/app/profile/edit/page.tsx
+++ b/apps/web/src/app/profile/edit/page.tsx
@@ -114,7 +114,7 @@ export default function ProfileEditPage() {
         {/* 프로필 이미지 */}
         <div className="mb-4 flex flex-col items-center">
           <Image
-            src="/images/defaults/raccoon.png"
+            src={process.env.NEXT_PUBLIC_DEFAULT_PROFILE_IMAGE || "/images/defaults/raccoon.png"}
             alt="프로필 이미지"
             width={112}
             height={112}

--- a/apps/web/src/app/profile/edit/page.tsx
+++ b/apps/web/src/app/profile/edit/page.tsx
@@ -93,17 +93,17 @@ export default function ProfileEditPage() {
   // 로딩 중
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-primary flex items-center justify-center">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-white"></div>
+      <div className="min-h-screen bg-white flex items-center justify-center">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
       </div>
     );
   }
 
   return (
-    <div className="min-h-screen bg-primary flex flex-col">
+    <div className="min-h-screen bg-white flex flex-col">
       {/* 홈 버튼 */}
       <div className="p-4">
-        <Link href="/profile" className="inline-block text-white">
+        <Link href="/profile" className="inline-block text-gray-800">
           <HomeOutlineIcon />
         </Link>
       </div>
@@ -111,13 +111,13 @@ export default function ProfileEditPage() {
       {/* 프로필 수정 폼 */}
       <div className="flex-1 flex flex-col items-center px-8 pt-4">
         {/* 프로필 이미지 */}
-        <div className="mb-4">
+        <div className="mb-4 flex flex-col items-center">
           <img
             src={user?.profileImage || "/images/defaults/raccoon.png"}
             alt="프로필 이미지"
-            className="w-28 h-28 rounded-full object-cover border-4 border-white/50"
+            className="w-28 h-28 rounded-full object-cover border-4 border-gray-200"
           />
-          <button className="mt-2 px-4 py-1 bg-white/20 text-white text-sm rounded-full hover:bg-white/30 transition-colors">
+          <button className="mt-2 px-4 py-1 bg-gray-100 text-gray-700 text-sm rounded-full hover:bg-gray-200 transition-colors">
             사진 수정
           </button>
         </div>
@@ -126,17 +126,17 @@ export default function ProfileEditPage() {
         <form onSubmit={handleSubmit} className="w-full max-w-sm space-y-4">
           {/* 섬 이름 */}
           <div>
-            <label className="block text-white font-medium mb-1">섬 이름</label>
+            <label className="block text-gray-800 font-medium mb-1">섬 이름</label>
             <input
               type="text"
               name="islandName"
               value={formData.islandName}
               onChange={handleChange}
               placeholder="섬 이름을 입력하세요"
-              className="w-full px-4 py-3 rounded-lg border-2 border-white/50 bg-transparent text-white placeholder-white/70 focus:outline-none focus:border-white"
+              className="w-full px-4 py-3 rounded-lg border border-gray-300 bg-white text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
             />
             {formData.islandName && !isIslandNameValid && (
-              <p className="text-sm mt-1 text-red-200">
+              <p className="text-sm mt-1 text-red-500">
                 * 2자 이상 입력해주세요.
               </p>
             )}
@@ -144,52 +144,68 @@ export default function ProfileEditPage() {
 
           {/* 이름 */}
           <div>
-            <label className="block text-white font-medium mb-1">이름</label>
+            <label className="block text-gray-800 font-medium mb-1">이름</label>
             <input
               type="text"
               name="name"
               value={formData.name}
               onChange={handleChange}
               placeholder="이름을 입력하세요"
-              className="w-full px-4 py-3 rounded-lg border-2 border-white/50 bg-transparent text-white placeholder-white/70 focus:outline-none focus:border-white"
+              className="w-full px-4 py-3 rounded-lg border border-gray-300 bg-white text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
             />
           </div>
 
           {/* 반구 - 신규 유저만 수정 가능 */}
           <div>
-            <label className="block text-white font-medium mb-1">반구</label>
-            <select
-              name="hemisphere"
-              value={formData.hemisphere}
-              onChange={handleChange}
-              disabled={user?.isProfileComplete}
-              className="w-full px-4 py-3 rounded-lg border-2 border-white/50 bg-transparent text-white focus:outline-none focus:border-white disabled:opacity-50"
-            >
-              <option value="NORTH" className="text-gray-900">북반구</option>
-              <option value="SOUTH" className="text-gray-900">남반구</option>
-            </select>
+            <label className="block text-gray-800 font-medium mb-1">반구</label>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={() => !user?.isProfileComplete && setFormData((prev) => ({ ...prev, hemisphere: "NORTH" }))}
+                disabled={user?.isProfileComplete}
+                className={`flex-1 py-3 rounded-lg text-sm font-medium border transition-colors ${
+                  formData.hemisphere === "NORTH"
+                    ? "border-primary bg-primary/10 text-primary"
+                    : "border-gray-300 text-gray-700 hover:border-gray-400"
+                } disabled:opacity-50 disabled:cursor-not-allowed`}
+              >
+                북반구
+              </button>
+              <button
+                type="button"
+                onClick={() => !user?.isProfileComplete && setFormData((prev) => ({ ...prev, hemisphere: "SOUTH" }))}
+                disabled={user?.isProfileComplete}
+                className={`flex-1 py-3 rounded-lg text-sm font-medium border transition-colors ${
+                  formData.hemisphere === "SOUTH"
+                    ? "border-primary bg-primary/10 text-primary"
+                    : "border-gray-300 text-gray-700 hover:border-gray-400"
+                } disabled:opacity-50 disabled:cursor-not-allowed`}
+              >
+                남반구
+              </button>
+            </div>
             {user?.isProfileComplete && (
-              <p className="text-sm mt-1 text-white/70">* 반구는 변경할 수 없습니다.</p>
+              <p className="text-sm mt-1 text-gray-500">* 반구는 변경할 수 없습니다.</p>
             )}
           </div>
 
           {/* 꿈번지 */}
           <div>
-            <label className="block text-white font-medium mb-1">꿈번지 (선택)</label>
+            <label className="block text-gray-800 font-medium mb-1">꿈번지 (선택)</label>
             <input
               type="text"
               name="dreamAddress"
               value={formData.dreamAddress}
               onChange={handleChange}
               placeholder="DA-0000-0000-0000"
-              className="w-full px-4 py-3 rounded-lg border-2 border-white/50 bg-transparent text-white placeholder-white/70 focus:outline-none focus:border-white"
+              className="w-full px-4 py-3 rounded-lg border border-gray-300 bg-white text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
             />
           </div>
 
           {/* 에러 메시지 */}
           {error && (
-            <div className="p-3 rounded-lg bg-red-500/20 border border-red-300/50">
-              <p className="text-red-200 text-sm">{error}</p>
+            <div className="p-3 rounded-lg bg-red-50 border border-red-200">
+              <p className="text-red-600 text-sm">{error}</p>
             </div>
           )}
 
@@ -197,7 +213,7 @@ export default function ProfileEditPage() {
           <button
             type="submit"
             disabled={!isIslandNameValid || !formData.name || isSubmitting}
-            className="w-full py-3 rounded-lg bg-white text-primary font-semibold hover:bg-gray-100 transition-colors disabled:opacity-50 disabled:cursor-not-allowed mt-6"
+            className="w-full py-3 rounded-lg bg-primary text-white font-semibold hover:bg-primary-dark transition-colors disabled:opacity-50 disabled:cursor-not-allowed mt-6"
           >
             {isSubmitting ? "저장 중..." : user?.isProfileComplete ? "수정 완료" : "프로필 설정 완료"}
           </button>

--- a/apps/web/src/app/profile/edit/page.tsx
+++ b/apps/web/src/app/profile/edit/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { useState, useEffect } from "react";
 import { HomeOutlineIcon } from "@/components/icons";
@@ -112,10 +113,12 @@ export default function ProfileEditPage() {
       <div className="flex-1 flex flex-col items-center px-8 pt-4">
         {/* 프로필 이미지 */}
         <div className="mb-4 flex flex-col items-center">
-          <img
+          <Image
             src={user?.profileImage || "/images/defaults/raccoon.png"}
             alt="프로필 이미지"
-            className="w-28 h-28 rounded-full object-cover border-4 border-gray-200"
+            width={112}
+            height={112}
+            className="rounded-full object-cover border-4 border-gray-200"
           />
           <button className="mt-2 px-4 py-1 bg-gray-100 text-gray-700 text-sm rounded-full hover:bg-gray-200 transition-colors">
             사진 수정

--- a/apps/web/src/app/profile/edit/page.tsx
+++ b/apps/web/src/app/profile/edit/page.tsx
@@ -114,15 +114,12 @@ export default function ProfileEditPage() {
         {/* 프로필 이미지 */}
         <div className="mb-4 flex flex-col items-center">
           <Image
-            src={user?.profileImage || "/images/defaults/raccoon.png"}
+            src="/images/defaults/raccoon.png"
             alt="프로필 이미지"
             width={112}
             height={112}
             className="rounded-full object-cover border-4 border-gray-200"
           />
-          <button className="mt-2 px-4 py-1 bg-gray-100 text-gray-700 text-sm rounded-full hover:bg-gray-200 transition-colors">
-            사진 수정
-          </button>
         </div>
 
         {/* 입력 폼 */}

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -83,9 +83,11 @@ export default function ProfilePage() {
         className="flex items-center gap-4 p-4 hover:bg-gray-50 transition-colors"
       >
         {/* 프로필 이미지 */}
-        <div className="w-14 h-14 rounded-full bg-[#BAE8E7] flex items-center justify-center text-2xl">
-          {user?.nickname?.charAt(0) || "👤"}
-        </div>
+        <img
+          src={user?.profileImage || "/images/defaults/raccoon.png"}
+          alt="프로필 이미지"
+          className="w-14 h-14 rounded-full object-cover"
+        />
         <div className="flex-1">
           <h2 className="font-semibold text-lg">{user?.nickname || "닉네임 없음"}</h2>
           <p className="text-sm text-gray-500">
@@ -94,6 +96,20 @@ export default function ProfilePage() {
         </div>
         <ChevronRightIcon className="text-gray-400" />
       </Link>
+
+      {/* 나의 무 가격 (매너 점수) */}
+      <div className="mx-4 p-4 bg-gray-50 rounded-lg">
+        <div className="flex items-center gap-2 mb-2">
+          <span className="text-sm text-gray-600">나의 무 가격</span>
+          <span className="text-xs text-gray-400 cursor-pointer">ⓘ</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="text-2xl font-bold text-red-500">
+            {user?.mannerScore != null ? `${user.mannerScore.toFixed(1)}점` : "-"}
+          </span>
+          <img src="/icons/radish.png" alt="무" className="w-8 h-8" />
+        </div>
+      </div>
 
 
       {/* 거래 관련 메뉴 */}

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -7,31 +7,8 @@ import {
   ChevronRightIcon,
   ShoppingBagIcon,
   HeartIcon,
-  ListIcon,
 } from "@/components/icons";
 import { useAuth } from "@/context/AuthContext";
-
-// 프로필 메뉴 아이템 컴포넌트
-function MenuItem({
-  icon,
-  label,
-  href,
-}: {
-  icon: React.ReactNode;
-  label: string;
-  href: string;
-}) {
-  return (
-    <Link
-      href={href}
-      className="flex items-center gap-3 px-4 py-3 hover:bg-gray-50 transition-colors"
-    >
-      <span className="text-gray-500">{icon}</span>
-      <span className="flex-1 text-gray-800">{label}</span>
-      <ChevronRightIcon className="text-gray-400" />
-    </Link>
-  );
-}
 
 // 프로필 페이지 - Figma 디자인 기반
 export default function ProfilePage() {
@@ -97,21 +74,6 @@ export default function ProfilePage() {
         <ChevronRightIcon className="text-gray-400" />
       </Link>
 
-      {/* 나의 무 가격 (매너 점수) */}
-      <div className="mx-4 p-4 bg-gray-50 rounded-lg">
-        <div className="flex items-center gap-2 mb-2">
-          <span className="text-sm text-gray-600">나의 무 가격</span>
-          <span className="text-xs text-gray-400 cursor-pointer">ⓘ</span>
-        </div>
-        <div className="flex items-center gap-2">
-          <span className="text-2xl font-bold text-red-500">
-            {user?.mannerScore != null ? `${user.mannerScore.toFixed(1)}점` : "-"}
-          </span>
-          <img src="/icons/radish.png" alt="무" className="w-8 h-8" />
-        </div>
-      </div>
-
-
       {/* 거래 관련 메뉴 */}
       <div className="flex justify-around py-4 border-b border-gray-100">
         <Link
@@ -143,12 +105,31 @@ export default function ProfilePage() {
         </Link>
       </div>
 
-      {/* 나의 활동 섹션 */}
-      <div className="mt-4">
-        <h3 className="px-4 py-2 font-semibold text-gray-800">나의 활동</h3>
-        <MenuItem icon={<ListIcon />} label="키워드 알림" href="/profile/keywords" />
-        <MenuItem icon={<ListIcon />} label="모아보기" href="/profile/collection" />
-        <MenuItem icon={<ListIcon />} label="거동숲 가계부" href="/profile/ledger" />
+      {/* 나의 무 가격 (매너 점수) - 당근마켓 스타일 */}
+      <div className="mx-4 mt-4 p-4 bg-gray-50 rounded-xl">
+        <div className="flex items-center gap-1 mb-3">
+          <span className="font-semibold text-gray-800">나의 무 가격</span>
+          <span className="text-xs text-gray-400 cursor-pointer">ⓘ</span>
+        </div>
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <span className="text-3xl font-bold text-red-500">
+              {user?.mannerScore != null ? `${user.mannerScore.toFixed(1)}` : "-"}
+            </span>
+            <img src="/icons/radish.png" alt="무" className="w-10 h-10" />
+          </div>
+        </div>
+        {/* 온도 바 */}
+        {user?.mannerScore != null && (
+          <div className="mt-3">
+            <div className="w-full h-2 bg-gray-200 rounded-full overflow-hidden">
+              <div
+                className="h-full bg-gradient-to-r from-blue-400 via-green-400 to-red-500 rounded-full"
+                style={{ width: `${Math.min(Math.max(user.mannerScore, 0), 100)}%` }}
+              />
+            </div>
+          </div>
+        )}
       </div>
     </MobileLayout>
   );

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import Image from "next/image";
 import { MobileLayout, Header } from "@/components/common";
 import {
   SettingsIcon,
@@ -60,10 +61,12 @@ export default function ProfilePage() {
         className="flex items-center gap-4 p-4 hover:bg-gray-50 transition-colors"
       >
         {/* 프로필 이미지 */}
-        <img
+        <Image
           src={user?.profileImage || "/images/defaults/raccoon.png"}
           alt="프로필 이미지"
-          className="w-14 h-14 rounded-full object-cover"
+          width={56}
+          height={56}
+          className="rounded-full object-cover"
         />
         <div className="flex-1">
           <h2 className="font-semibold text-lg">{user?.nickname || "닉네임 없음"}</h2>
@@ -116,7 +119,7 @@ export default function ProfilePage() {
             <span className="text-3xl font-bold text-red-500">
               {user?.mannerScore != null ? `${user.mannerScore.toFixed(1)}` : "-"}
             </span>
-            <img src="/icons/radish.png" alt="무" className="w-10 h-10" />
+            <Image src="/icons/radish.png" alt="무" width={40} height={40} />
           </div>
         </div>
         {/* 온도 바 */}

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -112,14 +112,26 @@ export default function ProfilePage() {
       <div className="mx-4 mt-4 p-4 bg-gray-50 rounded-xl">
         <div className="flex items-center gap-1 mb-3">
           <span className="font-semibold text-gray-800">나의 무 가격</span>
-          <span className="text-xs text-gray-400 cursor-pointer">ⓘ</span>
+          <span
+            className="text-xs text-gray-400"
+            aria-label="무 가격은 거래 매너를 나타내는 지표입니다"
+            title="무 가격은 거래 매너를 나타내는 지표입니다"
+          >
+            ⓘ
+          </span>
         </div>
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
             <span className="text-3xl font-bold text-red-500">
               {user?.mannerScore != null ? `${user.mannerScore.toFixed(1)}` : "-"}
             </span>
-            <Image src="/icons/radish.png" alt="무" width={40} height={40} />
+            <Image
+              src={process.env.NEXT_PUBLIC_ICON_BASE ? `${process.env.NEXT_PUBLIC_ICON_BASE}/radish.png` : "/icons/radish.png"}
+              alt="무 가격 아이콘"
+              title="무 가격"
+              width={40}
+              height={40}
+            />
           </div>
         </div>
         {/* 온도 바 */}

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -62,7 +62,7 @@ export default function ProfilePage() {
       >
         {/* 프로필 이미지 */}
         <Image
-          src={user?.profileImage || "/images/defaults/raccoon.png"}
+          src="/images/defaults/raccoon.png"
           alt="프로필 이미지"
           width={56}
           height={56}

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -62,7 +62,7 @@ export default function ProfilePage() {
       >
         {/* 프로필 이미지 */}
         <Image
-          src="/images/defaults/raccoon.png"
+          src={process.env.NEXT_PUBLIC_DEFAULT_PROFILE_IMAGE || "/images/defaults/raccoon.png"}
           alt="프로필 이미지"
           width={56}
           height={56}

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -122,9 +122,9 @@ export default function ProfilePage() {
         {/* 온도 바 */}
         {user?.mannerScore != null && (
           <div className="mt-3">
-            <div className="w-full h-2 bg-gray-200 rounded-full overflow-hidden">
+            <div className="w-full h-2 bg-[#FFFFF0] rounded-full overflow-hidden">
               <div
-                className="h-full bg-gradient-to-r from-blue-400 via-green-400 to-red-500 rounded-full"
+                className="h-full bg-gradient-to-r from-[#BAE8E7] via-[#7ECEC5] to-[#5BBFB3] rounded-full"
                 style={{ width: `${Math.min(Math.max(user.mannerScore, 0), 100)}%` }}
               />
             </div>

--- a/apps/web/src/app/user/[id]/page.tsx
+++ b/apps/web/src/app/user/[id]/page.tsx
@@ -6,7 +6,17 @@ import { useState, useEffect } from "react";
 import { MobileLayout, Header } from "@/components/common";
 import { useAuth } from "@/context/AuthContext";
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
+// API URL 검증 - 개발 환경에서만 localhost 폴백 허용
+const API_URL = (() => {
+  const url = process.env.NEXT_PUBLIC_API_URL;
+  if (!url) {
+    if (process.env.NODE_ENV === "development") {
+      return "http://localhost:8080";
+    }
+    throw new Error("NEXT_PUBLIC_API_URL 환경 변수가 설정되지 않았습니다.");
+  }
+  return url;
+})();
 
 // 유저 프로필 타입
 interface UserProfile {

--- a/apps/web/src/app/user/[id]/page.tsx
+++ b/apps/web/src/app/user/[id]/page.tsx
@@ -123,7 +123,7 @@ export default function UserProfilePage() {
       <div className="flex items-center gap-4 p-4">
         {/* 프로필 이미지 */}
         <Image
-          src="/images/defaults/raccoon.png"
+          src={process.env.NEXT_PUBLIC_DEFAULT_PROFILE_IMAGE || "/images/defaults/raccoon.png"}
           alt="프로필 이미지"
           width={56}
           height={56}

--- a/apps/web/src/app/user/[id]/page.tsx
+++ b/apps/web/src/app/user/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useParams, useRouter } from "next/navigation";
+import { useParams, useRouter, notFound } from "next/navigation";
 import Image from "next/image";
 import { useState, useEffect } from "react";
 import { MobileLayout, Header } from "@/components/common";
@@ -31,7 +31,14 @@ export default function UserProfilePage() {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const userId = params.id as string;
+  // params.id가 string[] 일 수 있으므로 처리
+  const rawId = params.id;
+  const userId = Array.isArray(rawId) ? rawId[0] : rawId;
+
+  // userId가 없으면 404
+  if (!userId) {
+    notFound();
+  }
 
   // 유저 프로필 로드
   useEffect(() => {

--- a/apps/web/src/app/user/[id]/page.tsx
+++ b/apps/web/src/app/user/[id]/page.tsx
@@ -141,14 +141,26 @@ export default function UserProfilePage() {
       <div className="mx-4 mt-2 p-4 bg-gray-50 rounded-xl">
         <div className="flex items-center gap-1 mb-3">
           <span className="font-semibold text-gray-800">무 가격</span>
-          <span className="text-xs text-gray-400 cursor-pointer">ⓘ</span>
+          <span
+            className="text-xs text-gray-400"
+            aria-label="무 가격은 거래 매너를 나타내는 지표입니다"
+            title="무 가격은 거래 매너를 나타내는 지표입니다"
+          >
+            ⓘ
+          </span>
         </div>
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
             <span className="text-3xl font-bold text-red-500">
               {userProfile.mannerScore != null ? `${userProfile.mannerScore.toFixed(1)}` : "-"}
             </span>
-            <Image src="/icons/radish.png" alt="무" width={40} height={40} />
+            <Image
+              src={process.env.NEXT_PUBLIC_ICON_BASE ? `${process.env.NEXT_PUBLIC_ICON_BASE}/radish.png` : "/icons/radish.png"}
+              alt="무 가격 아이콘"
+              title="무 가격"
+              width={40}
+              height={40}
+            />
           </div>
         </div>
         {/* 온도 바 */}

--- a/apps/web/src/app/user/[id]/page.tsx
+++ b/apps/web/src/app/user/[id]/page.tsx
@@ -53,7 +53,17 @@ export default function UserProfilePage() {
   // 유저 프로필 로드
   useEffect(() => {
     async function loadUserProfile() {
-      if (!accessToken || !userId) return;
+      // 인증 토큰이 없으면 로그인 페이지로 리다이렉트
+      if (!accessToken) {
+        router.push("/login");
+        return;
+      }
+
+      // userId가 없으면 로딩 종료 (notFound에서 처리됨)
+      if (!userId) {
+        setIsLoading(false);
+        return;
+      }
 
       try {
         setIsLoading(true);
@@ -85,7 +95,7 @@ export default function UserProfilePage() {
     if (!authLoading) {
       loadUserProfile();
     }
-  }, [accessToken, userId, authLoading]);
+  }, [accessToken, userId, authLoading, router]);
 
   // 로딩 상태
   if (isLoading || authLoading) {

--- a/apps/web/src/app/user/[id]/page.tsx
+++ b/apps/web/src/app/user/[id]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useParams, useRouter } from "next/navigation";
+import Image from "next/image";
 import { useState, useEffect } from "react";
 import { MobileLayout, Header } from "@/components/common";
 import { useAuth } from "@/context/AuthContext";
@@ -121,10 +122,12 @@ export default function UserProfilePage() {
       {/* 프로필 정보 */}
       <div className="flex items-center gap-4 p-4">
         {/* 프로필 이미지 */}
-        <img
+        <Image
           src="/images/defaults/raccoon.png"
           alt="프로필 이미지"
-          className="w-14 h-14 rounded-full object-cover"
+          width={56}
+          height={56}
+          className="rounded-full object-cover"
         />
         <div className="flex-1">
           <h2 className="font-semibold text-lg">{userProfile.nickname || "닉네임 없음"}</h2>
@@ -145,7 +148,7 @@ export default function UserProfilePage() {
             <span className="text-3xl font-bold text-red-500">
               {userProfile.mannerScore != null ? `${userProfile.mannerScore.toFixed(1)}` : "-"}
             </span>
-            <img src="/icons/radish.png" alt="무" className="w-10 h-10" />
+            <Image src="/icons/radish.png" alt="무" width={40} height={40} />
           </div>
         </div>
         {/* 온도 바 */}

--- a/apps/web/src/app/user/[id]/page.tsx
+++ b/apps/web/src/app/user/[id]/page.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import { useParams, useRouter } from "next/navigation";
+import { useState, useEffect } from "react";
+import { MobileLayout, Header } from "@/components/common";
+import { useAuth } from "@/context/AuthContext";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
+
+// 유저 프로필 타입
+interface UserProfile {
+  id: string;
+  nickname: string;
+  islandName: string;
+  dreamAddress?: string;
+  hemisphere: string;
+  mannerScore: number;
+  totalTradeCount: number;
+  reviewCount: number;
+  createdAt: string;
+  isProfileComplete: boolean;
+}
+
+// 다른 유저 프로필 조회 페이지
+export default function UserProfilePage() {
+  const params = useParams();
+  const router = useRouter();
+  const { accessToken, isLoading: authLoading } = useAuth();
+  const [userProfile, setUserProfile] = useState<UserProfile | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const userId = params.id as string;
+
+  // 유저 프로필 로드
+  useEffect(() => {
+    async function loadUserProfile() {
+      if (!accessToken || !userId) return;
+
+      try {
+        setIsLoading(true);
+        setError(null);
+
+        const res = await fetch(`${API_URL}/api/users/${userId}`, {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        });
+
+        if (!res.ok) {
+          if (res.status === 404) {
+            throw new Error("유저를 찾을 수 없습니다");
+          }
+          throw new Error("유저 정보를 불러오는데 실패했습니다");
+        }
+
+        const data = await res.json();
+        setUserProfile(data);
+      } catch (err) {
+        console.error("유저 프로필 로드 실패:", err);
+        setError(err instanceof Error ? err.message : "유저 정보를 불러오는데 실패했습니다");
+      } finally {
+        setIsLoading(false);
+      }
+    }
+
+    if (!authLoading) {
+      loadUserProfile();
+    }
+  }, [accessToken, userId, authLoading]);
+
+  // 로딩 상태
+  if (isLoading || authLoading) {
+    return (
+      <MobileLayout>
+        <Header title="프로필" showBack onBack={() => router.back()} />
+        <div className="flex items-center justify-center py-20">
+          <div className="animate-spin rounded-full h-8 w-8 border-2 border-primary border-t-transparent" />
+        </div>
+      </MobileLayout>
+    );
+  }
+
+  // 에러 상태
+  if (error) {
+    return (
+      <MobileLayout>
+        <Header title="프로필" showBack onBack={() => router.back()} />
+        <div className="flex flex-col items-center justify-center py-20 text-gray-500">
+          <span className="text-6xl mb-4">😢</span>
+          <p className="text-sm">{error}</p>
+          <button
+            onClick={() => router.back()}
+            className="mt-4 px-6 py-2 bg-primary text-white rounded-lg"
+          >
+            뒤로 가기
+          </button>
+        </div>
+      </MobileLayout>
+    );
+  }
+
+  // 유저 정보가 없는 경우
+  if (!userProfile) {
+    return (
+      <MobileLayout>
+        <Header title="프로필" showBack onBack={() => router.back()} />
+        <div className="flex flex-col items-center justify-center py-20 text-gray-500">
+          <span className="text-6xl mb-4">🔍</span>
+          <p className="text-sm">유저를 찾을 수 없습니다</p>
+        </div>
+      </MobileLayout>
+    );
+  }
+
+  return (
+    <MobileLayout>
+      {/* 헤더 */}
+      <Header title="프로필" showBack onBack={() => router.back()} />
+
+      {/* 프로필 정보 */}
+      <div className="flex items-center gap-4 p-4">
+        {/* 프로필 이미지 */}
+        <img
+          src="/images/defaults/raccoon.png"
+          alt="프로필 이미지"
+          className="w-14 h-14 rounded-full object-cover"
+        />
+        <div className="flex-1">
+          <h2 className="font-semibold text-lg">{userProfile.nickname || "닉네임 없음"}</h2>
+          <p className="text-sm text-gray-500">
+            {userProfile.islandName || "섬 이름 없음"}
+          </p>
+        </div>
+      </div>
+
+      {/* 무 가격 (매너 점수) - 당근마켓 스타일 */}
+      <div className="mx-4 mt-2 p-4 bg-gray-50 rounded-xl">
+        <div className="flex items-center gap-1 mb-3">
+          <span className="font-semibold text-gray-800">무 가격</span>
+          <span className="text-xs text-gray-400 cursor-pointer">ⓘ</span>
+        </div>
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <span className="text-3xl font-bold text-red-500">
+              {userProfile.mannerScore != null ? `${userProfile.mannerScore.toFixed(1)}` : "-"}
+            </span>
+            <img src="/icons/radish.png" alt="무" className="w-10 h-10" />
+          </div>
+        </div>
+        {/* 온도 바 */}
+        {userProfile.mannerScore != null && (
+          <div className="mt-3">
+            <div className="w-full h-2 bg-[#FFFFF0] rounded-full overflow-hidden">
+              <div
+                className="h-full bg-gradient-to-r from-[#BAE8E7] via-[#7ECEC5] to-[#5BBFB3] rounded-full"
+                style={{ width: `${Math.min(Math.max(userProfile.mannerScore, 0), 100)}%` }}
+              />
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* 거래 정보 */}
+      <div className="mx-4 mt-4 p-4 bg-gray-50 rounded-xl">
+        <div className="flex justify-around text-center">
+          <div>
+            <p className="text-xl font-bold text-gray-800">{userProfile.totalTradeCount || 0}</p>
+            <p className="text-xs text-gray-500">거래 횟수</p>
+          </div>
+          <div className="w-px bg-gray-200" />
+          <div>
+            <p className="text-xl font-bold text-gray-800">{userProfile.reviewCount || 0}</p>
+            <p className="text-xs text-gray-500">받은 리뷰</p>
+          </div>
+        </div>
+      </div>
+    </MobileLayout>
+  );
+}

--- a/apps/web/src/components/common/Header.tsx
+++ b/apps/web/src/components/common/Header.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { ChevronDownIcon, SearchIcon, MenuIcon, BellIcon, ChevronLeftIcon } from "../icons";
+import { SearchIcon, MenuIcon, BellIcon, ChevronLeftIcon } from "../icons";
 import { useAuth } from "@/context/AuthContext";
 
 interface HeaderProps {
@@ -43,10 +43,9 @@ export default function Header({
             </button>
           )}
           {showLocation ? (
-            <button className="flex items-center gap-1 font-semibold text-lg">
-              <span>{isAuthenticated && user?.islandName ? user.islandName : "내 섬"}</span>
-              <ChevronDownIcon className="text-gray-600" />
-            </button>
+            <span className="font-semibold text-lg">
+              {isAuthenticated && user?.islandName ? user.islandName : "내 섬"}
+            </span>
           ) : (
             title && <h1 className="font-semibold text-lg">{title}</h1>
           )}

--- a/apps/web/src/components/common/Header.tsx
+++ b/apps/web/src/components/common/Header.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import Image from "next/image";
 import { SearchIcon, MenuIcon, BellIcon, ChevronLeftIcon } from "../icons";
 import { useAuth } from "@/context/AuthContext";
 
@@ -75,10 +76,12 @@ export default function Header({
               {isAuthenticated ? (
                 <div className="flex items-center gap-2">
                   {user?.profileImage ? (
-                    <img
+                    <Image
                       src={user.profileImage}
                       alt="프로필"
-                      className="w-8 h-8 rounded-full object-cover"
+                      width={32}
+                      height={32}
+                      className="rounded-full object-cover"
                     />
                   ) : (
                     <div className="w-8 h-8 rounded-full bg-primary/20 flex items-center justify-center">

--- a/apps/web/src/context/AuthContext.tsx
+++ b/apps/web/src/context/AuthContext.tsx
@@ -12,6 +12,7 @@ interface User {
   hemisphere?: 'NORTH' | 'SOUTH';
   dreamCode?: string;
   isProfileComplete?: boolean;
+  mannerScore?: number;
 }
 
 // AuthContext 타입


### PR DESCRIPTION
홈 화면
헤더에서 로그아웃 버튼 제거

프로필 페이지 (나의 거동숲)
나의 활동 섹션 제거 (키워드 알림, 모아보기, 거동숲 가계부)
나의 무 가격 (매너 점수) 표시 추가
당근마켓 스타일 큰 숫자
온도 바 (민트색 그라데이션)
배경 #FFFFF0
그라데이션 #BAE8E7 → #7ECEC5 → #5BBFB3

프로필 수정 페이지
배경 흰색으로 변경
반구 선택을 드롭다운에서 토글 버튼으로 변경
꿈번지 라벨을 꿈번지 (선택)으로 변경
기본 프로필 이미지를 라쿤으로 변경

거래 상세 페이지
거래 유형 칩 추가 (팔아요/구해요)
판매자 정보 클릭 시 유저 프로필 페이지로 이동

다른 유저 프로필 페이지 신규 생성 (/user/[id])
유저 이름, 섬 이름 표시
무 가격 (매너 점수) 표시
거래 횟수, 받은 리뷰 수 표시
판매내역/구매내역/관심목록 버튼 없음



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사용자 공개 프로필 페이지 추가(로딩/오류/상태 처리 포함)
  * 무 가격(신뢰도) 위젯 및 거래 통계 표시 추가
  * 상품 상세에 거래 유형(팔아요/구해요) 칩 추가
  * 판매자 정보 행 전체를 클릭해 프로필로 이동

* **스타일**
  * 프로필 편집 페이지 색상·입력·버튼·에러 UI 전면 개편
  * 여러 화면의 아바타·미디어를 최적화된 이미지 컴포넌트로 교체

* **기타**
  * 헤더에 인증 표시 제어 추가(기본 숨김)
  * 원격 이미지 호스트 설정 구성 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->