### PR TITLE
feat: 키워드 알림, 가계부, 모아보기 페이지 구현

### DIFF
--- a/apps/api/src/main/java/com/acnh/api/keywordalarm/controller/KeywordAlarmController.java
+++ b/apps/api/src/main/java/com/acnh/api/keywordalarm/controller/KeywordAlarmController.java
@@ -1,0 +1,115 @@
+package com.acnh.api.keywordalarm.controller;
+
+import com.acnh.api.keywordalarm.dto.KeywordAlarmCreateRequest;
+import com.acnh.api.keywordalarm.dto.KeywordAlarmListResponse;
+import com.acnh.api.keywordalarm.dto.KeywordAlarmResponse;
+import com.acnh.api.keywordalarm.service.KeywordAlarmService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+/**
+ * 키워드 알림 API 컨트롤러
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/keyword-alarms")
+@RequiredArgsConstructor
+public class KeywordAlarmController {
+
+    private final KeywordAlarmService keywordAlarmService;
+
+    /**
+     * 내 키워드 목록 조회
+     * GET /api/keyword-alarms
+     */
+    @GetMapping
+    public ResponseEntity<?> getMyKeywords(@AuthenticationPrincipal String visitorId) {
+        log.info("키워드 목록 조회 요청 - visitorId: {}", visitorId);
+
+        if (visitorId == null) {
+            return ResponseEntity.status(401).body(Map.of(
+                    "error", "UNAUTHORIZED",
+                    "message", "로그인이 필요합니다"
+            ));
+        }
+
+        try {
+            KeywordAlarmListResponse response = keywordAlarmService.getMyKeywords(visitorId);
+            return ResponseEntity.ok(response);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(404).body(Map.of(
+                    "error", "NOT_FOUND",
+                    "message", e.getMessage()
+            ));
+        }
+    }
+
+    /**
+     * 키워드 추가
+     * POST /api/keyword-alarms
+     */
+    @PostMapping
+    public ResponseEntity<?> createKeyword(
+            @AuthenticationPrincipal String visitorId,
+            @Valid @RequestBody KeywordAlarmCreateRequest request) {
+
+        log.info("키워드 추가 요청 - visitorId: {}, keyword: {}", visitorId, request.getKeyword());
+
+        if (visitorId == null) {
+            return ResponseEntity.status(401).body(Map.of(
+                    "error", "UNAUTHORIZED",
+                    "message", "로그인이 필요합니다"
+            ));
+        }
+
+        try {
+            KeywordAlarmResponse response = keywordAlarmService.createKeyword(visitorId, request);
+            return ResponseEntity.ok(response);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(404).body(Map.of(
+                    "error", "NOT_FOUND",
+                    "message", e.getMessage()
+            ));
+        } catch (IllegalStateException e) {
+            return ResponseEntity.badRequest().body(Map.of(
+                    "error", "INVALID_REQUEST",
+                    "message", e.getMessage()
+            ));
+        }
+    }
+
+    /**
+     * 키워드 삭제
+     * DELETE /api/keyword-alarms/{id}
+     */
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> deleteKeyword(
+            @AuthenticationPrincipal String visitorId,
+            @PathVariable Long id) {
+
+        log.info("키워드 삭제 요청 - visitorId: {}, keywordId: {}", visitorId, id);
+
+        if (visitorId == null) {
+            return ResponseEntity.status(401).body(Map.of(
+                    "error", "UNAUTHORIZED",
+                    "message", "로그인이 필요합니다"
+            ));
+        }
+
+        try {
+            keywordAlarmService.deleteKeyword(visitorId, id);
+            return ResponseEntity.ok(Map.of("message", "키워드가 삭제되었습니다"));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(404).body(Map.of(
+                    "error", "NOT_FOUND",
+                    "message", e.getMessage()
+            ));
+        }
+    }
+}

--- a/apps/api/src/main/java/com/acnh/api/keywordalarm/dto/KeywordAlarmCreateRequest.java
+++ b/apps/api/src/main/java/com/acnh/api/keywordalarm/dto/KeywordAlarmCreateRequest.java
@@ -1,0 +1,20 @@
+package com.acnh.api.keywordalarm.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 키워드 알림 생성 요청 DTO
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class KeywordAlarmCreateRequest {
+
+    @NotBlank(message = "키워드를 입력해주세요")
+    @Size(min = 1, max = 50, message = "키워드는 1~50자 이내로 입력해주세요")
+    private String keyword;
+}

--- a/apps/api/src/main/java/com/acnh/api/keywordalarm/dto/KeywordAlarmListResponse.java
+++ b/apps/api/src/main/java/com/acnh/api/keywordalarm/dto/KeywordAlarmListResponse.java
@@ -1,0 +1,26 @@
+package com.acnh.api.keywordalarm.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * 키워드 알림 목록 응답 DTO
+ */
+@Getter
+@AllArgsConstructor
+@Builder
+public class KeywordAlarmListResponse {
+
+    private List<KeywordAlarmResponse> keywords;
+    private int totalCount;
+
+    public static KeywordAlarmListResponse of(List<KeywordAlarmResponse> keywords) {
+        return KeywordAlarmListResponse.builder()
+                .keywords(keywords)
+                .totalCount(keywords.size())
+                .build();
+    }
+}

--- a/apps/api/src/main/java/com/acnh/api/keywordalarm/dto/KeywordAlarmListResponse.java
+++ b/apps/api/src/main/java/com/acnh/api/keywordalarm/dto/KeywordAlarmListResponse.java
@@ -18,9 +18,11 @@ public class KeywordAlarmListResponse {
     private int totalCount;
 
     public static KeywordAlarmListResponse of(List<KeywordAlarmResponse> keywords) {
+        // null 방어 코드 추가 (CodeRabbit 리뷰 반영)
+        List<KeywordAlarmResponse> safeKeywords = keywords != null ? keywords : List.of();
         return KeywordAlarmListResponse.builder()
-                .keywords(keywords)
-                .totalCount(keywords.size())
+                .keywords(safeKeywords)
+                .totalCount(safeKeywords.size())
                 .build();
     }
 }

--- a/apps/api/src/main/java/com/acnh/api/keywordalarm/dto/KeywordAlarmResponse.java
+++ b/apps/api/src/main/java/com/acnh/api/keywordalarm/dto/KeywordAlarmResponse.java
@@ -1,0 +1,29 @@
+package com.acnh.api.keywordalarm.dto;
+
+import com.acnh.api.keywordalarm.entity.KeywordAlarm;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * 키워드 알림 응답 DTO
+ */
+@Getter
+@AllArgsConstructor
+@Builder
+public class KeywordAlarmResponse {
+
+    private Long id;
+    private String keyword;
+    private LocalDateTime createdAt;
+
+    public static KeywordAlarmResponse from(KeywordAlarm entity) {
+        return KeywordAlarmResponse.builder()
+                .id(entity.getId())
+                .keyword(entity.getKeyword())
+                .createdAt(entity.getCreatedAt())
+                .build();
+    }
+}

--- a/apps/api/src/main/java/com/acnh/api/keywordalarm/entity/KeywordAlarm.java
+++ b/apps/api/src/main/java/com/acnh/api/keywordalarm/entity/KeywordAlarm.java
@@ -1,0 +1,34 @@
+package com.acnh.api.keywordalarm.entity;
+
+import com.acnh.api.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * 키워드 알림 엔티티
+ * - 사용자가 등록한 관심 키워드 저장
+ * - 해당 키워드가 포함된 새 거래글 등록 시 알림 발송
+ */
+@Entity
+@Table(name = "keyword_alarms",
+    uniqueConstraints = @UniqueConstraint(
+        name = "uk_keyword_alarms_user_keyword",
+        columnNames = {"user_id", "keyword"}
+    )
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class KeywordAlarm extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "keyword", nullable = false, length = 50)
+    private String keyword;
+}

--- a/apps/api/src/main/java/com/acnh/api/keywordalarm/repository/KeywordAlarmRepository.java
+++ b/apps/api/src/main/java/com/acnh/api/keywordalarm/repository/KeywordAlarmRepository.java
@@ -1,0 +1,53 @@
+package com.acnh.api.keywordalarm.repository;
+
+import com.acnh.api.keywordalarm.entity.KeywordAlarm;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 키워드 알림 리포지토리
+ */
+@Repository
+public interface KeywordAlarmRepository extends JpaRepository<KeywordAlarm, Long> {
+
+    /**
+     * 사용자의 키워드 목록 조회 (삭제되지 않은 것만)
+     */
+    List<KeywordAlarm> findByUserIdAndDeletedAtIsNullOrderByCreatedAtDesc(Long userId);
+
+    /**
+     * 특정 키워드 조회 (사용자별, 삭제되지 않은 것)
+     */
+    Optional<KeywordAlarm> findByIdAndUserIdAndDeletedAtIsNull(Long id, Long userId);
+
+    /**
+     * 중복 키워드 체크 (대소문자 구분 없이)
+     */
+    @Query("SELECT COUNT(k) > 0 FROM KeywordAlarm k WHERE k.userId = :userId " +
+           "AND LOWER(k.keyword) = LOWER(:keyword) AND k.deletedAt IS NULL")
+    boolean existsByUserIdAndKeywordIgnoreCaseAndDeletedAtIsNull(
+            @Param("userId") Long userId,
+            @Param("keyword") String keyword);
+
+    /**
+     * 새 게시글의 아이템명과 매칭되는 키워드를 가진 사용자 ID 목록 조회
+     * - 게시글 작성자 본인은 제외
+     * - LIKE 검색으로 키워드 매칭
+     */
+    @Query("SELECT DISTINCT k.userId FROM KeywordAlarm k " +
+           "WHERE k.deletedAt IS NULL AND k.userId != :authorId " +
+           "AND LOWER(:itemName) LIKE CONCAT('%', LOWER(k.keyword), '%')")
+    List<Long> findUserIdsByMatchingKeyword(
+            @Param("itemName") String itemName,
+            @Param("authorId") Long authorId);
+
+    /**
+     * 사용자의 키워드 개수 조회
+     */
+    long countByUserIdAndDeletedAtIsNull(Long userId);
+}

--- a/apps/api/src/main/java/com/acnh/api/keywordalarm/repository/KeywordAlarmRepository.java
+++ b/apps/api/src/main/java/com/acnh/api/keywordalarm/repository/KeywordAlarmRepository.java
@@ -50,4 +50,15 @@ public interface KeywordAlarmRepository extends JpaRepository<KeywordAlarm, Long
      * 사용자의 키워드 개수 조회
      */
     long countByUserIdAndDeletedAtIsNull(Long userId);
+
+    /**
+     * 삭제된 키워드 조회 (복구용)
+     * - soft delete된 키워드를 찾아서 복구할 때 사용
+     * - CodeRabbit 리뷰 반영: soft delete와 unique 제약 조건 충돌 해결
+     */
+    @Query("SELECT k FROM KeywordAlarm k WHERE k.userId = :userId " +
+           "AND LOWER(k.keyword) = LOWER(:keyword) AND k.deletedAt IS NOT NULL")
+    Optional<KeywordAlarm> findDeletedByUserIdAndKeywordIgnoreCase(
+            @Param("userId") Long userId,
+            @Param("keyword") String keyword);
 }

--- a/apps/api/src/main/java/com/acnh/api/keywordalarm/service/KeywordAlarmService.java
+++ b/apps/api/src/main/java/com/acnh/api/keywordalarm/service/KeywordAlarmService.java
@@ -48,6 +48,7 @@ public class KeywordAlarmService {
 
     /**
      * 키워드 추가
+     * - 삭제된 동일 키워드가 있으면 복구 (CodeRabbit 리뷰 반영: soft delete와 unique 제약 조건 충돌 해결)
      */
     @Transactional
     public KeywordAlarmResponse createKeyword(String visitorId, KeywordAlarmCreateRequest request) {
@@ -66,14 +67,23 @@ public class KeywordAlarmService {
             throw new IllegalStateException("이미 등록된 키워드입니다");
         }
 
-        KeywordAlarm keywordAlarm = KeywordAlarm.builder()
-                .userId(member.getId())
-                .keyword(keyword)
-                .build();
-
-        keywordAlarmRepository.save(keywordAlarm);
-
-        log.info("키워드 등록 완료 - userId: {}, keyword: {}", member.getId(), keyword);
+        // 삭제된 동일 키워드가 있으면 복구 (soft delete + unique 제약 조건 충돌 해결)
+        KeywordAlarm keywordAlarm = keywordAlarmRepository
+                .findDeletedByUserIdAndKeywordIgnoreCase(member.getId(), keyword)
+                .map(existing -> {
+                    existing.restore();
+                    log.info("키워드 복구 완료 - userId: {}, keywordId: {}", member.getId(), existing.getId());
+                    return existing;
+                })
+                .orElseGet(() -> {
+                    KeywordAlarm newKeyword = KeywordAlarm.builder()
+                            .userId(member.getId())
+                            .keyword(keyword)
+                            .build();
+                    keywordAlarmRepository.save(newKeyword);
+                    log.info("키워드 등록 완료 - userId: {}, keywordId: {}", member.getId(), newKeyword.getId());
+                    return newKeyword;
+                });
 
         return KeywordAlarmResponse.from(keywordAlarm);
     }
@@ -106,12 +116,19 @@ public class KeywordAlarmService {
 
     /**
      * UUID로 회원 조회
+     * - CodeRabbit 리뷰 반영: UUID 파싱 예외 처리 추가
      */
     private Member findMemberByUuid(String visitorId) {
         if (visitorId == null || "anonymousUser".equals(visitorId)) {
             throw new IllegalArgumentException("로그인이 필요합니다");
         }
-        return memberRepository.findByUuidAndDeletedAtIsNull(UUID.fromString(visitorId))
+        UUID uuid;
+        try {
+            uuid = UUID.fromString(visitorId);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("유효하지 않은 인증 정보입니다");
+        }
+        return memberRepository.findByUuidAndDeletedAtIsNull(uuid)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다"));
     }
 }

--- a/apps/api/src/main/java/com/acnh/api/keywordalarm/service/KeywordAlarmService.java
+++ b/apps/api/src/main/java/com/acnh/api/keywordalarm/service/KeywordAlarmService.java
@@ -1,0 +1,117 @@
+package com.acnh.api.keywordalarm.service;
+
+import com.acnh.api.keywordalarm.dto.KeywordAlarmCreateRequest;
+import com.acnh.api.keywordalarm.dto.KeywordAlarmListResponse;
+import com.acnh.api.keywordalarm.dto.KeywordAlarmResponse;
+import com.acnh.api.keywordalarm.entity.KeywordAlarm;
+import com.acnh.api.keywordalarm.repository.KeywordAlarmRepository;
+import com.acnh.api.member.entity.Member;
+import com.acnh.api.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * 키워드 알림 비즈니스 로직 서비스
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class KeywordAlarmService {
+
+    private final KeywordAlarmRepository keywordAlarmRepository;
+    private final MemberRepository memberRepository;
+
+    // 최대 키워드 등록 개수 제한
+    private static final int MAX_KEYWORDS = 30;
+
+    /**
+     * 내 키워드 목록 조회
+     */
+    public KeywordAlarmListResponse getMyKeywords(String visitorId) {
+        Member member = findMemberByUuid(visitorId);
+
+        List<KeywordAlarmResponse> keywords = keywordAlarmRepository
+                .findByUserIdAndDeletedAtIsNullOrderByCreatedAtDesc(member.getId())
+                .stream()
+                .map(KeywordAlarmResponse::from)
+                .collect(Collectors.toList());
+
+        return KeywordAlarmListResponse.of(keywords);
+    }
+
+    /**
+     * 키워드 추가
+     */
+    @Transactional
+    public KeywordAlarmResponse createKeyword(String visitorId, KeywordAlarmCreateRequest request) {
+        Member member = findMemberByUuid(visitorId);
+
+        String keyword = request.getKeyword().trim();
+
+        // 키워드 개수 제한 체크
+        long currentCount = keywordAlarmRepository.countByUserIdAndDeletedAtIsNull(member.getId());
+        if (currentCount >= MAX_KEYWORDS) {
+            throw new IllegalStateException("키워드는 최대 " + MAX_KEYWORDS + "개까지 등록할 수 있습니다");
+        }
+
+        // 중복 키워드 체크 (대소문자 구분 없이)
+        if (keywordAlarmRepository.existsByUserIdAndKeywordIgnoreCaseAndDeletedAtIsNull(member.getId(), keyword)) {
+            throw new IllegalStateException("이미 등록된 키워드입니다");
+        }
+
+        KeywordAlarm keywordAlarm = KeywordAlarm.builder()
+                .userId(member.getId())
+                .keyword(keyword)
+                .build();
+
+        keywordAlarmRepository.save(keywordAlarm);
+
+        log.info("키워드 등록 완료 - userId: {}, keyword: {}", member.getId(), keyword);
+
+        return KeywordAlarmResponse.from(keywordAlarm);
+    }
+
+    /**
+     * 키워드 삭제
+     */
+    @Transactional
+    public void deleteKeyword(String visitorId, Long keywordId) {
+        Member member = findMemberByUuid(visitorId);
+
+        KeywordAlarm keywordAlarm = keywordAlarmRepository
+                .findByIdAndUserIdAndDeletedAtIsNull(keywordId, member.getId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 키워드입니다"));
+
+        keywordAlarm.delete();
+
+        log.info("키워드 삭제 완료 - userId: {}, keywordId: {}", member.getId(), keywordId);
+    }
+
+    /**
+     * 아이템명과 매칭되는 키워드를 가진 사용자 ID 목록 조회
+     * - 게시글 생성 시 알림 발송에 사용
+     */
+    public List<Long> findUserIdsByMatchingKeyword(String itemName, Long authorId) {
+        return keywordAlarmRepository.findUserIdsByMatchingKeyword(itemName, authorId);
+    }
+
+    // ========== Private Helper Methods ==========
+
+    /**
+     * UUID로 회원 조회
+     */
+    private Member findMemberByUuid(String visitorId) {
+        if (visitorId == null || "anonymousUser".equals(visitorId)) {
+            throw new IllegalArgumentException("로그인이 필요합니다");
+        }
+        return memberRepository.findByUuidAndDeletedAtIsNull(UUID.fromString(visitorId))
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다"));
+    }
+}

--- a/apps/api/src/main/java/com/acnh/api/keywordalarm/service/KeywordAlarmService.java
+++ b/apps/api/src/main/java/com/acnh/api/keywordalarm/service/KeywordAlarmService.java
@@ -9,6 +9,7 @@ import com.acnh.api.member.entity.Member;
 import com.acnh.api.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -68,24 +69,31 @@ public class KeywordAlarmService {
         }
 
         // 삭제된 동일 키워드가 있으면 복구 (soft delete + unique 제약 조건 충돌 해결)
-        KeywordAlarm keywordAlarm = keywordAlarmRepository
-                .findDeletedByUserIdAndKeywordIgnoreCase(member.getId(), keyword)
-                .map(existing -> {
-                    existing.restore();
-                    log.info("키워드 복구 완료 - userId: {}, keywordId: {}", member.getId(), existing.getId());
-                    return existing;
-                })
-                .orElseGet(() -> {
-                    KeywordAlarm newKeyword = KeywordAlarm.builder()
-                            .userId(member.getId())
-                            .keyword(keyword)
-                            .build();
-                    keywordAlarmRepository.save(newKeyword);
-                    log.info("키워드 등록 완료 - userId: {}, keywordId: {}", member.getId(), newKeyword.getId());
-                    return newKeyword;
-                });
+        // CodeRabbit 리뷰 반영: 동시 요청 시 DB 제약 예외를 사용자 오류로 변환
+        try {
+            KeywordAlarm keywordAlarm = keywordAlarmRepository
+                    .findDeletedByUserIdAndKeywordIgnoreCase(member.getId(), keyword)
+                    .map(existing -> {
+                        existing.restore();
+                        log.info("키워드 복구 완료 - userId: {}, keywordId: {}", member.getId(), existing.getId());
+                        return existing;
+                    })
+                    .orElseGet(() -> {
+                        KeywordAlarm newKeyword = KeywordAlarm.builder()
+                                .userId(member.getId())
+                                .keyword(keyword)
+                                .build();
+                        keywordAlarmRepository.save(newKeyword);
+                        log.info("키워드 등록 완료 - userId: {}, keywordId: {}", member.getId(), newKeyword.getId());
+                        return newKeyword;
+                    });
 
-        return KeywordAlarmResponse.from(keywordAlarm);
+            return KeywordAlarmResponse.from(keywordAlarm);
+        } catch (DataIntegrityViolationException e) {
+            // 동시 요청으로 인한 중복 또는 제한 초과
+            log.warn("키워드 등록 실패 (동시 요청) - userId: {}", member.getId());
+            throw new IllegalStateException("이미 등록된 키워드이거나 등록 한도를 초과했습니다");
+        }
     }
 
     /**

--- a/apps/api/src/main/java/com/acnh/api/transaction/controller/TransactionController.java
+++ b/apps/api/src/main/java/com/acnh/api/transaction/controller/TransactionController.java
@@ -1,0 +1,190 @@
+package com.acnh.api.transaction.controller;
+
+import com.acnh.api.transaction.dto.TransactionCreateRequest;
+import com.acnh.api.transaction.dto.TransactionListResponse;
+import com.acnh.api.transaction.dto.TransactionResponse;
+import com.acnh.api.transaction.dto.TransactionSummaryResponse;
+import com.acnh.api.transaction.enums.TransactionType;
+import com.acnh.api.transaction.service.TransactionService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Map;
+
+/**
+ * 거래 내역(가계부) API 컨트롤러
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/transactions")
+@RequiredArgsConstructor
+public class TransactionController {
+
+    private final TransactionService transactionService;
+
+    private static final int DEFAULT_PAGE_SIZE = 20;
+
+    /**
+     * 거래 내역 목록 조회
+     * GET /api/transactions
+     */
+    @GetMapping
+    public ResponseEntity<?> getTransactions(
+            @AuthenticationPrincipal String visitorId,
+            @RequestParam(required = false) String startDate,
+            @RequestParam(required = false) String endDate,
+            @RequestParam(required = false) String type,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+
+        log.info("거래 내역 조회 요청 - visitorId: {}, startDate: {}, endDate: {}, type: {}",
+                visitorId, startDate, endDate, type);
+
+        if (visitorId == null) {
+            return ResponseEntity.status(401).body(Map.of(
+                    "error", "UNAUTHORIZED",
+                    "message", "로그인이 필요합니다"
+            ));
+        }
+
+        try {
+            // 날짜 파싱
+            LocalDateTime start = startDate != null
+                    ? LocalDate.parse(startDate).atStartOfDay()
+                    : null;
+            LocalDateTime end = endDate != null
+                    ? LocalDate.parse(endDate).atTime(LocalTime.MAX)
+                    : null;
+
+            // 거래 유형 파싱
+            TransactionType transactionType = null;
+            if (type != null && !type.isEmpty()) {
+                try {
+                    transactionType = TransactionType.valueOf(type);
+                } catch (IllegalArgumentException e) {
+                    return ResponseEntity.badRequest().body(Map.of(
+                            "error", "INVALID_TYPE",
+                            "message", "유효하지 않은 거래 유형입니다"
+                    ));
+                }
+            }
+
+            Pageable pageable = PageRequest.of(page, Math.min(size, DEFAULT_PAGE_SIZE));
+            TransactionListResponse response = transactionService.getTransactions(
+                    visitorId, start, end, transactionType, pageable);
+            return ResponseEntity.ok(response);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(404).body(Map.of(
+                    "error", "NOT_FOUND",
+                    "message", e.getMessage()
+            ));
+        }
+    }
+
+    /**
+     * 거래 통계 조회
+     * GET /api/transactions/summary
+     */
+    @GetMapping("/summary")
+    public ResponseEntity<?> getSummary(
+            @AuthenticationPrincipal String visitorId,
+            @RequestParam(required = false) String startDate,
+            @RequestParam(required = false) String endDate) {
+
+        log.info("거래 통계 조회 요청 - visitorId: {}, startDate: {}, endDate: {}",
+                visitorId, startDate, endDate);
+
+        if (visitorId == null) {
+            return ResponseEntity.status(401).body(Map.of(
+                    "error", "UNAUTHORIZED",
+                    "message", "로그인이 필요합니다"
+            ));
+        }
+
+        try {
+            // 날짜 파싱
+            LocalDateTime start = startDate != null
+                    ? LocalDate.parse(startDate).atStartOfDay()
+                    : null;
+            LocalDateTime end = endDate != null
+                    ? LocalDate.parse(endDate).atTime(LocalTime.MAX)
+                    : null;
+
+            TransactionSummaryResponse response = transactionService.getSummary(visitorId, start, end);
+            return ResponseEntity.ok(response);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(404).body(Map.of(
+                    "error", "NOT_FOUND",
+                    "message", e.getMessage()
+            ));
+        }
+    }
+
+    /**
+     * 거래 내역 생성
+     * POST /api/transactions
+     */
+    @PostMapping
+    public ResponseEntity<?> createTransaction(
+            @AuthenticationPrincipal String visitorId,
+            @Valid @RequestBody TransactionCreateRequest request) {
+
+        log.info("거래 내역 생성 요청 - visitorId: {}, type: {}, amount: {}",
+                visitorId, request.getType(), request.getAmount());
+
+        if (visitorId == null) {
+            return ResponseEntity.status(401).body(Map.of(
+                    "error", "UNAUTHORIZED",
+                    "message", "로그인이 필요합니다"
+            ));
+        }
+
+        try {
+            TransactionResponse response = transactionService.createTransaction(visitorId, request);
+            return ResponseEntity.ok(response);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(Map.of(
+                    "error", "INVALID_REQUEST",
+                    "message", e.getMessage()
+            ));
+        }
+    }
+
+    /**
+     * 거래 내역 삭제
+     * DELETE /api/transactions/{id}
+     */
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> deleteTransaction(
+            @AuthenticationPrincipal String visitorId,
+            @PathVariable Long id) {
+
+        log.info("거래 내역 삭제 요청 - visitorId: {}, transactionId: {}", visitorId, id);
+
+        if (visitorId == null) {
+            return ResponseEntity.status(401).body(Map.of(
+                    "error", "UNAUTHORIZED",
+                    "message", "로그인이 필요합니다"
+            ));
+        }
+
+        try {
+            transactionService.deleteTransaction(visitorId, id);
+            return ResponseEntity.ok(Map.of("message", "거래 내역이 삭제되었습니다"));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(404).body(Map.of(
+                    "error", "NOT_FOUND",
+                    "message", e.getMessage()
+            ));
+        }
+    }
+}

--- a/apps/api/src/main/java/com/acnh/api/transaction/controller/TransactionController.java
+++ b/apps/api/src/main/java/com/acnh/api/transaction/controller/TransactionController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.format.DateTimeParseException;
 import java.util.Map;
 
 /**
@@ -49,21 +50,35 @@ public class TransactionController {
         log.info("거래 내역 조회 요청 - visitorId: {}, startDate: {}, endDate: {}, type: {}",
                 visitorId, startDate, endDate, type);
 
-        if (visitorId == null) {
+        // CodeRabbit 리뷰 반영: anonymousUser 처리 추가
+        if (visitorId == null || "anonymousUser".equals(visitorId)) {
             return ResponseEntity.status(401).body(Map.of(
                     "error", "UNAUTHORIZED",
                     "message", "로그인이 필요합니다"
             ));
         }
 
+        // CodeRabbit 리뷰 반영: 페이징 파라미터 검증
+        if (page < 0 || size <= 0) {
+            return ResponseEntity.badRequest().body(Map.of(
+                    "error", "INVALID_PAGING",
+                    "message", "page는 0 이상, size는 1 이상이어야 합니다"
+            ));
+        }
+
         try {
-            // 날짜 파싱
-            LocalDateTime start = startDate != null
-                    ? LocalDate.parse(startDate).atStartOfDay()
-                    : null;
-            LocalDateTime end = endDate != null
-                    ? LocalDate.parse(endDate).atTime(LocalTime.MAX)
-                    : null;
+            // CodeRabbit 리뷰 반영: 날짜 파싱 예외 처리
+            LocalDateTime start = null;
+            LocalDateTime end = null;
+            try {
+                if (startDate != null) start = LocalDate.parse(startDate).atStartOfDay();
+                if (endDate != null) end = LocalDate.parse(endDate).atTime(LocalTime.MAX);
+            } catch (DateTimeParseException e) {
+                return ResponseEntity.badRequest().body(Map.of(
+                        "error", "INVALID_DATE",
+                        "message", "날짜 형식은 YYYY-MM-DD 이어야 합니다"
+                ));
+            }
 
             // 거래 유형 파싱
             TransactionType transactionType = null;
@@ -103,7 +118,8 @@ public class TransactionController {
         log.info("거래 통계 조회 요청 - visitorId: {}, startDate: {}, endDate: {}",
                 visitorId, startDate, endDate);
 
-        if (visitorId == null) {
+        // CodeRabbit 리뷰 반영: anonymousUser 처리 추가
+        if (visitorId == null || "anonymousUser".equals(visitorId)) {
             return ResponseEntity.status(401).body(Map.of(
                     "error", "UNAUTHORIZED",
                     "message", "로그인이 필요합니다"
@@ -111,13 +127,18 @@ public class TransactionController {
         }
 
         try {
-            // 날짜 파싱
-            LocalDateTime start = startDate != null
-                    ? LocalDate.parse(startDate).atStartOfDay()
-                    : null;
-            LocalDateTime end = endDate != null
-                    ? LocalDate.parse(endDate).atTime(LocalTime.MAX)
-                    : null;
+            // CodeRabbit 리뷰 반영: 날짜 파싱 예외 처리
+            LocalDateTime start = null;
+            LocalDateTime end = null;
+            try {
+                if (startDate != null) start = LocalDate.parse(startDate).atStartOfDay();
+                if (endDate != null) end = LocalDate.parse(endDate).atTime(LocalTime.MAX);
+            } catch (DateTimeParseException e) {
+                return ResponseEntity.badRequest().body(Map.of(
+                        "error", "INVALID_DATE",
+                        "message", "날짜 형식은 YYYY-MM-DD 이어야 합니다"
+                ));
+            }
 
             TransactionSummaryResponse response = transactionService.getSummary(visitorId, start, end);
             return ResponseEntity.ok(response);
@@ -141,7 +162,8 @@ public class TransactionController {
         log.info("거래 내역 생성 요청 - visitorId: {}, type: {}, amount: {}",
                 visitorId, request.getType(), request.getAmount());
 
-        if (visitorId == null) {
+        // CodeRabbit 리뷰 반영: anonymousUser 처리 추가
+        if (visitorId == null || "anonymousUser".equals(visitorId)) {
             return ResponseEntity.status(401).body(Map.of(
                     "error", "UNAUTHORIZED",
                     "message", "로그인이 필요합니다"
@@ -170,7 +192,8 @@ public class TransactionController {
 
         log.info("거래 내역 삭제 요청 - visitorId: {}, transactionId: {}", visitorId, id);
 
-        if (visitorId == null) {
+        // CodeRabbit 리뷰 반영: anonymousUser 처리 추가
+        if (visitorId == null || "anonymousUser".equals(visitorId)) {
             return ResponseEntity.status(401).body(Map.of(
                     "error", "UNAUTHORIZED",
                     "message", "로그인이 필요합니다"

--- a/apps/api/src/main/java/com/acnh/api/transaction/dto/TransactionCreateRequest.java
+++ b/apps/api/src/main/java/com/acnh/api/transaction/dto/TransactionCreateRequest.java
@@ -1,0 +1,41 @@
+package com.acnh.api.transaction.dto;
+
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 거래 내역 생성 요청 DTO
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TransactionCreateRequest {
+
+    private Long postId;  // 연관 게시글 (선택)
+
+    @NotBlank(message = "아이템명을 입력해주세요")
+    @Size(max = 100, message = "아이템명은 100자 이내로 입력해주세요")
+    private String itemName;
+
+    @NotNull(message = "거래 유형을 선택해주세요")
+    private String type;  // SALE, PURCHASE
+
+    @NotNull(message = "화폐 종류를 선택해주세요")
+    private String currencyType;  // BELL, MILE_TICKET
+
+    @NotNull(message = "금액을 입력해주세요")
+    @Min(value = 0, message = "금액은 0 이상이어야 합니다")
+    private Integer amount;
+
+    @Size(max = 50, message = "상대방 닉네임은 50자 이내로 입력해주세요")
+    private String partnerNickname;
+
+    @Size(max = 500, message = "메모는 500자 이내로 입력해주세요")
+    private String memo;
+
+    private LocalDateTime tradedAt;  // 거래 일시 (미입력 시 현재 시간)
+}

--- a/apps/api/src/main/java/com/acnh/api/transaction/dto/TransactionListResponse.java
+++ b/apps/api/src/main/java/com/acnh/api/transaction/dto/TransactionListResponse.java
@@ -1,0 +1,33 @@
+package com.acnh.api.transaction.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+/**
+ * 거래 내역 목록 응답 DTO
+ */
+@Getter
+@AllArgsConstructor
+@Builder
+public class TransactionListResponse {
+
+    private List<TransactionResponse> transactions;
+    private int currentPage;
+    private int totalPages;
+    private long totalElements;
+    private boolean hasNext;
+
+    public static TransactionListResponse from(Page<TransactionResponse> page) {
+        return TransactionListResponse.builder()
+                .transactions(page.getContent())
+                .currentPage(page.getNumber())
+                .totalPages(page.getTotalPages())
+                .totalElements(page.getTotalElements())
+                .hasNext(page.hasNext())
+                .build();
+    }
+}

--- a/apps/api/src/main/java/com/acnh/api/transaction/dto/TransactionResponse.java
+++ b/apps/api/src/main/java/com/acnh/api/transaction/dto/TransactionResponse.java
@@ -1,0 +1,45 @@
+package com.acnh.api.transaction.dto;
+
+import com.acnh.api.transaction.entity.Transaction;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * 거래 내역 응답 DTO
+ */
+@Getter
+@AllArgsConstructor
+@Builder
+public class TransactionResponse {
+
+    private Long id;
+    private Long postId;
+    private String postItemName;
+    private String type;  // SALE, PURCHASE
+    private String currencyType;  // BELL, MILE_TICKET
+    private Integer amount;
+    private Long partnerId;
+    private String partnerNickname;
+    private String memo;
+    private LocalDateTime tradedAt;
+    private LocalDateTime createdAt;
+
+    public static TransactionResponse from(Transaction entity) {
+        return TransactionResponse.builder()
+                .id(entity.getId())
+                .postId(entity.getPostId())
+                .postItemName(entity.getItemName())
+                .type(entity.getType().name())
+                .currencyType(entity.getCurrencyType().name())
+                .amount(entity.getAmount())
+                .partnerId(entity.getPartnerId())
+                .partnerNickname(entity.getPartnerNickname())
+                .memo(entity.getMemo())
+                .tradedAt(entity.getTradedAt())
+                .createdAt(entity.getCreatedAt())
+                .build();
+    }
+}

--- a/apps/api/src/main/java/com/acnh/api/transaction/dto/TransactionSummaryResponse.java
+++ b/apps/api/src/main/java/com/acnh/api/transaction/dto/TransactionSummaryResponse.java
@@ -1,0 +1,34 @@
+package com.acnh.api.transaction.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 거래 통계 응답 DTO
+ */
+@Getter
+@AllArgsConstructor
+@Builder
+public class TransactionSummaryResponse {
+
+    private long totalSales;      // 총 판매액
+    private long totalPurchases;  // 총 구매액
+    private long netProfit;       // 순이익 (판매 - 구매)
+    private long salesCount;      // 판매 건수
+    private long purchaseCount;   // 구매 건수
+
+    public static TransactionSummaryResponse of(
+            long totalSales,
+            long totalPurchases,
+            long salesCount,
+            long purchaseCount) {
+        return TransactionSummaryResponse.builder()
+                .totalSales(totalSales)
+                .totalPurchases(totalPurchases)
+                .netProfit(totalSales - totalPurchases)
+                .salesCount(salesCount)
+                .purchaseCount(purchaseCount)
+                .build();
+    }
+}

--- a/apps/api/src/main/java/com/acnh/api/transaction/entity/Transaction.java
+++ b/apps/api/src/main/java/com/acnh/api/transaction/entity/Transaction.java
@@ -1,0 +1,58 @@
+package com.acnh.api.transaction.entity;
+
+import com.acnh.api.common.entity.BaseEntity;
+import com.acnh.api.post.enums.CurrencyType;
+import com.acnh.api.transaction.enums.TransactionType;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+/**
+ * 거래 내역 엔티티
+ * - 사용자의 구매/판매 거래 기록 저장
+ */
+@Entity
+@Table(name = "transactions")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Transaction extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "post_id")
+    private Long postId;  // 연관 게시글 (선택)
+
+    @Column(name = "item_name", nullable = false, length = 100)
+    private String itemName;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false, length = 10)
+    private TransactionType type;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "currency_type", nullable = false, length = 20)
+    private CurrencyType currencyType;
+
+    @Column(name = "amount", nullable = false)
+    private Integer amount;
+
+    @Column(name = "partner_id")
+    private Long partnerId;  // 거래 상대방 ID (선택)
+
+    @Column(name = "partner_nickname", length = 50)
+    private String partnerNickname;
+
+    @Column(name = "memo", length = 500)
+    private String memo;
+
+    @Column(name = "traded_at", nullable = false)
+    private LocalDateTime tradedAt;
+}

--- a/apps/api/src/main/java/com/acnh/api/transaction/enums/TransactionType.java
+++ b/apps/api/src/main/java/com/acnh/api/transaction/enums/TransactionType.java
@@ -1,0 +1,9 @@
+package com.acnh.api.transaction.enums;
+
+/**
+ * 거래 유형
+ */
+public enum TransactionType {
+    SALE,      // 판매
+    PURCHASE   // 구매
+}

--- a/apps/api/src/main/java/com/acnh/api/transaction/repository/TransactionRepository.java
+++ b/apps/api/src/main/java/com/acnh/api/transaction/repository/TransactionRepository.java
@@ -1,0 +1,84 @@
+package com.acnh.api.transaction.repository;
+
+import com.acnh.api.transaction.entity.Transaction;
+import com.acnh.api.transaction.enums.TransactionType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+/**
+ * 거래 내역 리포지토리
+ */
+@Repository
+public interface TransactionRepository extends JpaRepository<Transaction, Long> {
+
+    /**
+     * 사용자의 거래 내역 전체 조회 (최신순)
+     */
+    Page<Transaction> findByUserIdAndDeletedAtIsNullOrderByTradedAtDesc(Long userId, Pageable pageable);
+
+    /**
+     * 사용자의 거래 내역 기간별 조회 (최신순)
+     */
+    Page<Transaction> findByUserIdAndTradedAtBetweenAndDeletedAtIsNullOrderByTradedAtDesc(
+            Long userId, LocalDateTime start, LocalDateTime end, Pageable pageable);
+
+    /**
+     * 사용자의 특정 유형 거래 내역 조회 (최신순)
+     */
+    Page<Transaction> findByUserIdAndTypeAndDeletedAtIsNullOrderByTradedAtDesc(
+            Long userId, TransactionType type, Pageable pageable);
+
+    /**
+     * 사용자의 특정 유형 거래 내역 기간별 조회 (최신순)
+     */
+    Page<Transaction> findByUserIdAndTypeAndTradedAtBetweenAndDeletedAtIsNullOrderByTradedAtDesc(
+            Long userId, TransactionType type, LocalDateTime start, LocalDateTime end, Pageable pageable);
+
+    /**
+     * 특정 거래 내역 조회 (사용자 검증용)
+     */
+    Optional<Transaction> findByIdAndUserIdAndDeletedAtIsNull(Long id, Long userId);
+
+    /**
+     * 사용자의 특정 유형 총액 조회
+     */
+    @Query("SELECT COALESCE(SUM(t.amount), 0) FROM Transaction t " +
+           "WHERE t.userId = :userId AND t.type = :type AND t.deletedAt IS NULL")
+    Long sumAmountByUserIdAndType(@Param("userId") Long userId, @Param("type") TransactionType type);
+
+    /**
+     * 사용자의 특정 유형 총액 조회 (기간별)
+     */
+    @Query("SELECT COALESCE(SUM(t.amount), 0) FROM Transaction t " +
+           "WHERE t.userId = :userId AND t.type = :type " +
+           "AND t.tradedAt BETWEEN :start AND :end AND t.deletedAt IS NULL")
+    Long sumAmountByUserIdAndTypeAndPeriod(
+            @Param("userId") Long userId,
+            @Param("type") TransactionType type,
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end);
+
+    /**
+     * 사용자의 특정 유형 거래 건수 조회
+     */
+    long countByUserIdAndTypeAndDeletedAtIsNull(Long userId, TransactionType type);
+
+    /**
+     * 사용자의 특정 유형 거래 건수 조회 (기간별)
+     */
+    @Query("SELECT COUNT(t) FROM Transaction t " +
+           "WHERE t.userId = :userId AND t.type = :type " +
+           "AND t.tradedAt BETWEEN :start AND :end AND t.deletedAt IS NULL")
+    long countByUserIdAndTypeAndPeriod(
+            @Param("userId") Long userId,
+            @Param("type") TransactionType type,
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end);
+}

--- a/apps/api/src/main/java/com/acnh/api/transaction/service/TransactionService.java
+++ b/apps/api/src/main/java/com/acnh/api/transaction/service/TransactionService.java
@@ -180,12 +180,19 @@ public class TransactionService {
 
     /**
      * UUID로 회원 조회
+     * - CodeRabbit 리뷰 반영: UUID 파싱 예외 처리 추가
      */
     private Member findMemberByUuid(String visitorId) {
         if (visitorId == null || "anonymousUser".equals(visitorId)) {
             throw new IllegalArgumentException("로그인이 필요합니다");
         }
-        return memberRepository.findByUuidAndDeletedAtIsNull(UUID.fromString(visitorId))
+        UUID uuid;
+        try {
+            uuid = UUID.fromString(visitorId);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("유효하지 않은 인증 정보입니다");
+        }
+        return memberRepository.findByUuidAndDeletedAtIsNull(uuid)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다"));
     }
 }

--- a/apps/api/src/main/java/com/acnh/api/transaction/service/TransactionService.java
+++ b/apps/api/src/main/java/com/acnh/api/transaction/service/TransactionService.java
@@ -1,0 +1,191 @@
+package com.acnh.api.transaction.service;
+
+import com.acnh.api.member.entity.Member;
+import com.acnh.api.member.repository.MemberRepository;
+import com.acnh.api.post.enums.CurrencyType;
+import com.acnh.api.transaction.dto.*;
+import com.acnh.api.transaction.entity.Transaction;
+import com.acnh.api.transaction.enums.TransactionType;
+import com.acnh.api.transaction.repository.TransactionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * 거래 내역 비즈니스 로직 서비스
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TransactionService {
+
+    private final TransactionRepository transactionRepository;
+    private final MemberRepository memberRepository;
+
+    /**
+     * 거래 내역 목록 조회
+     */
+    public TransactionListResponse getTransactions(
+            String visitorId,
+            LocalDateTime startDate,
+            LocalDateTime endDate,
+            TransactionType type,
+            Pageable pageable) {
+
+        Member member = findMemberByUuid(visitorId);
+
+        Page<Transaction> transactionPage;
+
+        if (type != null && startDate != null && endDate != null) {
+            // 유형 + 기간 필터
+            transactionPage = transactionRepository
+                    .findByUserIdAndTypeAndTradedAtBetweenAndDeletedAtIsNullOrderByTradedAtDesc(
+                            member.getId(), type, startDate, endDate, pageable);
+        } else if (type != null) {
+            // 유형 필터만
+            transactionPage = transactionRepository
+                    .findByUserIdAndTypeAndDeletedAtIsNullOrderByTradedAtDesc(
+                            member.getId(), type, pageable);
+        } else if (startDate != null && endDate != null) {
+            // 기간 필터만
+            transactionPage = transactionRepository
+                    .findByUserIdAndTradedAtBetweenAndDeletedAtIsNullOrderByTradedAtDesc(
+                            member.getId(), startDate, endDate, pageable);
+        } else {
+            // 필터 없음
+            transactionPage = transactionRepository
+                    .findByUserIdAndDeletedAtIsNullOrderByTradedAtDesc(member.getId(), pageable);
+        }
+
+        List<TransactionResponse> responses = transactionPage.getContent().stream()
+                .map(TransactionResponse::from)
+                .collect(Collectors.toList());
+
+        Page<TransactionResponse> responsePage = new PageImpl<>(
+                responses, pageable, transactionPage.getTotalElements());
+
+        return TransactionListResponse.from(responsePage);
+    }
+
+    /**
+     * 거래 통계 조회
+     */
+    public TransactionSummaryResponse getSummary(
+            String visitorId,
+            LocalDateTime startDate,
+            LocalDateTime endDate) {
+
+        Member member = findMemberByUuid(visitorId);
+
+        long totalSales;
+        long totalPurchases;
+        long salesCount;
+        long purchaseCount;
+
+        if (startDate != null && endDate != null) {
+            // 기간별 통계
+            totalSales = transactionRepository.sumAmountByUserIdAndTypeAndPeriod(
+                    member.getId(), TransactionType.SALE, startDate, endDate);
+            totalPurchases = transactionRepository.sumAmountByUserIdAndTypeAndPeriod(
+                    member.getId(), TransactionType.PURCHASE, startDate, endDate);
+            salesCount = transactionRepository.countByUserIdAndTypeAndPeriod(
+                    member.getId(), TransactionType.SALE, startDate, endDate);
+            purchaseCount = transactionRepository.countByUserIdAndTypeAndPeriod(
+                    member.getId(), TransactionType.PURCHASE, startDate, endDate);
+        } else {
+            // 전체 통계
+            totalSales = transactionRepository.sumAmountByUserIdAndType(
+                    member.getId(), TransactionType.SALE);
+            totalPurchases = transactionRepository.sumAmountByUserIdAndType(
+                    member.getId(), TransactionType.PURCHASE);
+            salesCount = transactionRepository.countByUserIdAndTypeAndDeletedAtIsNull(
+                    member.getId(), TransactionType.SALE);
+            purchaseCount = transactionRepository.countByUserIdAndTypeAndDeletedAtIsNull(
+                    member.getId(), TransactionType.PURCHASE);
+        }
+
+        return TransactionSummaryResponse.of(totalSales, totalPurchases, salesCount, purchaseCount);
+    }
+
+    /**
+     * 거래 내역 생성
+     */
+    @Transactional
+    public TransactionResponse createTransaction(String visitorId, TransactionCreateRequest request) {
+        Member member = findMemberByUuid(visitorId);
+
+        // 거래 유형 파싱
+        TransactionType type;
+        try {
+            type = TransactionType.valueOf(request.getType());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("유효하지 않은 거래 유형입니다: " + request.getType());
+        }
+
+        // 화폐 종류 파싱
+        CurrencyType currencyType;
+        try {
+            currencyType = CurrencyType.valueOf(request.getCurrencyType());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("유효하지 않은 화폐 종류입니다: " + request.getCurrencyType());
+        }
+
+        Transaction transaction = Transaction.builder()
+                .userId(member.getId())
+                .postId(request.getPostId())
+                .itemName(request.getItemName())
+                .type(type)
+                .currencyType(currencyType)
+                .amount(request.getAmount())
+                .partnerNickname(request.getPartnerNickname())
+                .memo(request.getMemo())
+                .tradedAt(request.getTradedAt() != null ? request.getTradedAt() : LocalDateTime.now())
+                .build();
+
+        transactionRepository.save(transaction);
+
+        log.info("거래 내역 생성 완료 - userId: {}, type: {}, amount: {}",
+                member.getId(), type, request.getAmount());
+
+        return TransactionResponse.from(transaction);
+    }
+
+    /**
+     * 거래 내역 삭제
+     */
+    @Transactional
+    public void deleteTransaction(String visitorId, Long transactionId) {
+        Member member = findMemberByUuid(visitorId);
+
+        Transaction transaction = transactionRepository
+                .findByIdAndUserIdAndDeletedAtIsNull(transactionId, member.getId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 거래 내역입니다"));
+
+        transaction.delete();
+
+        log.info("거래 내역 삭제 완료 - userId: {}, transactionId: {}", member.getId(), transactionId);
+    }
+
+    // ========== Private Helper Methods ==========
+
+    /**
+     * UUID로 회원 조회
+     */
+    private Member findMemberByUuid(String visitorId) {
+        if (visitorId == null || "anonymousUser".equals(visitorId)) {
+            throw new IllegalArgumentException("로그인이 필요합니다");
+        }
+        return memberRepository.findByUuidAndDeletedAtIsNull(UUID.fromString(visitorId))
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다"));
+    }
+}

--- a/apps/web/src/app/account-book/page.tsx
+++ b/apps/web/src/app/account-book/page.tsx
@@ -156,6 +156,19 @@ function AddTransactionModal({
   const [memo, setMemo] = useState("");
   const [error, setError] = useState<string | null>(null);
 
+  // CodeRabbit 리뷰 반영: 모달이 열릴 때 폼 상태 초기화
+  useEffect(() => {
+    if (isOpen) {
+      setType("SALE");
+      setCurrencyType("BELL");
+      setItemName("");
+      setAmount("");
+      setPartnerNickname("");
+      setMemo("");
+      setError(null);
+    }
+  }, [isOpen]);
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);

--- a/apps/web/src/app/account-book/page.tsx
+++ b/apps/web/src/app/account-book/page.tsx
@@ -1,0 +1,543 @@
+"use client";
+
+import Link from "next/link";
+import { useState, useEffect } from "react";
+import { MobileLayout, Header } from "@/components/common";
+import { PlusIcon } from "@/components/icons";
+import { useAuth } from "@/context/AuthContext";
+import {
+  getTransactions,
+  getTransactionSummary,
+  createTransaction,
+  deleteTransaction,
+  Transaction,
+  TransactionSummary,
+  TransactionCreateRequest,
+  formatPrice,
+  formatRelativeTime,
+} from "@/lib/postApi";
+
+// 기간 필터 타입
+type PeriodFilter = "all" | "week" | "month" | "3months";
+
+// 기간 필터 옵션
+const periodFilters: { id: PeriodFilter; label: string }[] = [
+  { id: "all", label: "전체" },
+  { id: "week", label: "1주일" },
+  { id: "month", label: "1개월" },
+  { id: "3months", label: "3개월" },
+];
+
+// 기간 필터에 따른 날짜 계산
+function getDateRange(period: PeriodFilter): { startDate?: string; endDate?: string } {
+  if (period === "all") return {};
+
+  const now = new Date();
+  const endDate = now.toISOString().split("T")[0];
+
+  let startDate: Date;
+  switch (period) {
+    case "week":
+      startDate = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+      break;
+    case "month":
+      startDate = new Date(now.getFullYear(), now.getMonth() - 1, now.getDate());
+      break;
+    case "3months":
+      startDate = new Date(now.getFullYear(), now.getMonth() - 3, now.getDate());
+      break;
+    default:
+      return {};
+  }
+
+  return {
+    startDate: startDate.toISOString().split("T")[0],
+    endDate,
+  };
+}
+
+// 통계 카드 컴포넌트
+function SummaryCard({ summary }: { summary: TransactionSummary }) {
+  return (
+    <div className="p-4 bg-gradient-to-r from-primary-light/30 to-primary/20 rounded-xl mx-4 mt-4">
+      <div className="grid grid-cols-3 gap-4 text-center">
+        <div>
+          <p className="text-xs text-gray-500 mb-1">총 판매</p>
+          <p className="font-bold text-primary">{summary.totalSales.toLocaleString()}</p>
+          <p className="text-xs text-gray-400">{summary.salesCount}건</p>
+        </div>
+        <div>
+          <p className="text-xs text-gray-500 mb-1">총 구매</p>
+          <p className="font-bold text-red-500">{summary.totalPurchases.toLocaleString()}</p>
+          <p className="text-xs text-gray-400">{summary.purchaseCount}건</p>
+        </div>
+        <div>
+          <p className="text-xs text-gray-500 mb-1">순이익</p>
+          <p className={`font-bold ${summary.netProfit >= 0 ? "text-primary" : "text-red-500"}`}>
+            {summary.netProfit >= 0 ? "+" : ""}{summary.netProfit.toLocaleString()}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// 거래 내역 아이템 컴포넌트
+function TransactionItem({
+  transaction,
+  onDelete,
+}: {
+  transaction: Transaction;
+  onDelete: (id: number) => void;
+}) {
+  const isSale = transaction.type === "SALE";
+
+  return (
+    <div className="flex items-center justify-between p-4 border-b border-gray-100">
+      <div className="flex-1">
+        <div className="flex items-center gap-2">
+          <span className={`text-xs px-2 py-0.5 rounded-full ${
+            isSale
+              ? "bg-primary/10 text-primary"
+              : "bg-red-50 text-red-500"
+          }`}>
+            {isSale ? "판매" : "구매"}
+          </span>
+          <span className="font-medium text-gray-900">{transaction.postItemName}</span>
+        </div>
+        <div className="flex items-center gap-2 mt-1">
+          <p className="text-xs text-gray-400">
+            {formatRelativeTime(transaction.tradedAt)}
+          </p>
+          {transaction.partnerNickname && (
+            <p className="text-xs text-gray-400">
+              · {transaction.partnerNickname}
+            </p>
+          )}
+        </div>
+        {transaction.memo && (
+          <p className="text-xs text-gray-500 mt-1 truncate">{transaction.memo}</p>
+        )}
+      </div>
+      <div className="flex items-center gap-3">
+        <span className={`font-bold ${isSale ? "text-primary" : "text-red-500"}`}>
+          {isSale ? "+" : "-"}{formatPrice(transaction.amount, transaction.currencyType)}
+        </span>
+        <button
+          onClick={() => onDelete(transaction.id)}
+          className="p-1 text-gray-400 hover:text-gray-600 transition-colors"
+        >
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// 거래 추가 모달 컴포넌트
+function AddTransactionModal({
+  isOpen,
+  onClose,
+  onSubmit,
+  isSubmitting,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (data: TransactionCreateRequest) => void;
+  isSubmitting: boolean;
+}) {
+  const [type, setType] = useState<"SALE" | "PURCHASE">("SALE");
+  const [currencyType, setCurrencyType] = useState<"BELL" | "MILE_TICKET">("BELL");
+  const [itemName, setItemName] = useState("");
+  const [amount, setAmount] = useState("");
+  const [partnerNickname, setPartnerNickname] = useState("");
+  const [memo, setMemo] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    if (!itemName.trim()) {
+      setError("아이템명을 입력해주세요");
+      return;
+    }
+
+    const amountNum = parseInt(amount, 10);
+    if (isNaN(amountNum) || amountNum < 0) {
+      setError("올바른 금액을 입력해주세요");
+      return;
+    }
+
+    onSubmit({
+      type,
+      currencyType,
+      itemName: itemName.trim(),
+      amount: amountNum,
+      partnerNickname: partnerNickname.trim() || undefined,
+      memo: memo.trim() || undefined,
+    });
+  };
+
+  const resetForm = () => {
+    setType("SALE");
+    setCurrencyType("BELL");
+    setItemName("");
+    setAmount("");
+    setPartnerNickname("");
+    setMemo("");
+    setError(null);
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black/50 z-50 flex items-end justify-center">
+      <div className="w-full bg-white rounded-t-2xl p-4 space-y-4 animate-slide-up max-h-[80vh] overflow-y-auto">
+        <div className="flex items-center justify-between">
+          <h3 className="text-lg font-semibold">거래 기록 추가</h3>
+          <button
+            onClick={() => {
+              resetForm();
+              onClose();
+            }}
+            className="p-1 hover:bg-gray-100 rounded-full"
+          >
+            <span className="text-xl">✕</span>
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {/* 거래 유형 */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">거래 유형</label>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={() => setType("SALE")}
+                className={`flex-1 py-2 rounded-lg text-sm border transition-colors ${
+                  type === "SALE"
+                    ? "border-primary bg-primary/10 text-primary"
+                    : "border-gray-300 text-gray-700"
+                }`}
+              >
+                판매
+              </button>
+              <button
+                type="button"
+                onClick={() => setType("PURCHASE")}
+                className={`flex-1 py-2 rounded-lg text-sm border transition-colors ${
+                  type === "PURCHASE"
+                    ? "border-red-500 bg-red-50 text-red-500"
+                    : "border-gray-300 text-gray-700"
+                }`}
+              >
+                구매
+              </button>
+            </div>
+          </div>
+
+          {/* 아이템명 */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">아이템명</label>
+            <input
+              type="text"
+              value={itemName}
+              onChange={(e) => setItemName(e.target.value)}
+              placeholder="거래한 아이템 이름"
+              className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:border-primary"
+            />
+          </div>
+
+          {/* 화폐 종류 */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">화폐</label>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={() => setCurrencyType("BELL")}
+                className={`px-4 py-2 rounded-lg text-sm border transition-colors ${
+                  currencyType === "BELL"
+                    ? "border-primary bg-primary/10 text-primary"
+                    : "border-gray-300 text-gray-700"
+                }`}
+              >
+                벨
+              </button>
+              <button
+                type="button"
+                onClick={() => setCurrencyType("MILE_TICKET")}
+                className={`px-4 py-2 rounded-lg text-sm border transition-colors ${
+                  currencyType === "MILE_TICKET"
+                    ? "border-primary bg-primary/10 text-primary"
+                    : "border-gray-300 text-gray-700"
+                }`}
+              >
+                마일
+              </button>
+            </div>
+          </div>
+
+          {/* 금액 */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">금액</label>
+            <div className="flex items-center border border-gray-300 rounded-lg overflow-hidden">
+              <input
+                type="number"
+                value={amount}
+                onChange={(e) => setAmount(e.target.value)}
+                placeholder="0"
+                min="0"
+                className="flex-1 px-4 py-3 focus:outline-none text-gray-900"
+              />
+              <span className="px-4 text-primary font-medium">
+                {currencyType === "BELL" ? "벨" : "마일"}
+              </span>
+            </div>
+          </div>
+
+          {/* 거래 상대방 (선택) */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">
+              거래 상대방 <span className="text-gray-400">(선택)</span>
+            </label>
+            <input
+              type="text"
+              value={partnerNickname}
+              onChange={(e) => setPartnerNickname(e.target.value)}
+              placeholder="상대방 닉네임"
+              className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:border-primary"
+            />
+          </div>
+
+          {/* 메모 (선택) */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">
+              메모 <span className="text-gray-400">(선택)</span>
+            </label>
+            <textarea
+              value={memo}
+              onChange={(e) => setMemo(e.target.value)}
+              placeholder="간단한 메모"
+              rows={2}
+              className="w-full px-4 py-3 border border-gray-300 rounded-lg resize-none focus:outline-none focus:border-primary"
+            />
+          </div>
+
+          {error && <p className="text-sm text-red-500">{error}</p>}
+
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="w-full py-4 bg-primary text-white font-semibold rounded-xl hover:bg-primary-dark transition-colors disabled:bg-gray-300"
+          >
+            {isSubmitting ? "저장 중..." : "저장하기"}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+// 가계부 페이지
+export default function AccountBookPage() {
+  const { isAuthenticated, isLoading: authLoading } = useAuth();
+  const [transactions, setTransactions] = useState<Transaction[]>([]);
+  const [summary, setSummary] = useState<TransactionSummary | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // 필터 상태
+  const [periodFilter, setPeriodFilter] = useState<PeriodFilter>("all");
+
+  // 모달 상태
+  const [showAddModal, setShowAddModal] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // 데이터 로드
+  useEffect(() => {
+    async function loadData() {
+      if (!isAuthenticated) {
+        setIsLoading(false);
+        return;
+      }
+
+      try {
+        setIsLoading(true);
+        setError(null);
+
+        const dateRange = getDateRange(periodFilter);
+
+        // 거래 내역과 통계를 병렬로 로드
+        const [transactionsRes, summaryRes] = await Promise.all([
+          getTransactions({ ...dateRange, page: 0, size: 50 }),
+          getTransactionSummary(dateRange),
+        ]);
+
+        setTransactions(transactionsRes.transactions);
+        setSummary(summaryRes);
+      } catch (err) {
+        console.error("데이터 로드 실패:", err);
+        setError(err instanceof Error ? err.message : "데이터를 불러오는데 실패했습니다");
+      } finally {
+        setIsLoading(false);
+      }
+    }
+
+    if (!authLoading) {
+      loadData();
+    }
+  }, [isAuthenticated, authLoading, periodFilter]);
+
+  // 거래 추가
+  const handleAddTransaction = async (data: TransactionCreateRequest) => {
+    try {
+      setIsSubmitting(true);
+      const created = await createTransaction(data);
+      setTransactions((prev) => [created, ...prev]);
+
+      // 통계 갱신
+      const dateRange = getDateRange(periodFilter);
+      const summaryRes = await getTransactionSummary(dateRange);
+      setSummary(summaryRes);
+
+      setShowAddModal(false);
+    } catch (err) {
+      console.error("거래 추가 실패:", err);
+      alert(err instanceof Error ? err.message : "거래 추가에 실패했습니다");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  // 거래 삭제
+  const handleDeleteTransaction = async (id: number) => {
+    if (!confirm("이 거래 기록을 삭제하시겠습니까?")) return;
+
+    try {
+      await deleteTransaction(id);
+      setTransactions((prev) => prev.filter((t) => t.id !== id));
+
+      // 통계 갱신
+      const dateRange = getDateRange(periodFilter);
+      const summaryRes = await getTransactionSummary(dateRange);
+      setSummary(summaryRes);
+    } catch (err) {
+      console.error("거래 삭제 실패:", err);
+      alert(err instanceof Error ? err.message : "거래 삭제에 실패했습니다");
+    }
+  };
+
+  // 로그인 필요 여부
+  const needsLogin = !authLoading && !isAuthenticated;
+
+  return (
+    <MobileLayout>
+      {/* 헤더 */}
+      <Header
+        title="가계부"
+        showBack
+        onBack={() => window.history.back()}
+      />
+
+      {/* 로그인 필요 안내 */}
+      {needsLogin && (
+        <div className="flex flex-col items-center justify-center py-20 text-gray-400">
+          <span className="text-6xl mb-4">🔒</span>
+          <p>로그인이 필요해요</p>
+          <Link
+            href="/login"
+            className="mt-4 px-6 py-2 bg-primary text-white rounded-lg hover:bg-primary-dark transition-colors"
+          >
+            로그인
+          </Link>
+        </div>
+      )}
+
+      {/* 로그인 상태일 때 */}
+      {!needsLogin && (
+        <>
+          {/* 통계 카드 */}
+          {summary && <SummaryCard summary={summary} />}
+
+          {/* 기간 필터 */}
+          <div className="flex gap-2 px-4 py-3 overflow-x-auto">
+            {periodFilters.map((filter) => (
+              <button
+                key={filter.id}
+                onClick={() => setPeriodFilter(filter.id)}
+                className={`px-4 py-2 rounded-full text-sm font-medium whitespace-nowrap transition-colors ${
+                  periodFilter === filter.id
+                    ? "bg-primary text-white"
+                    : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+                }`}
+              >
+                {filter.label}
+              </button>
+            ))}
+          </div>
+
+          {/* 로딩 상태 */}
+          {isLoading && (
+            <div className="flex items-center justify-center py-20">
+              <div className="animate-spin rounded-full h-8 w-8 border-2 border-primary border-t-transparent" />
+            </div>
+          )}
+
+          {/* 에러 상태 */}
+          {error && !isLoading && (
+            <div className="flex flex-col items-center justify-center py-20 text-gray-500">
+              <p className="text-sm">{error}</p>
+              <button
+                onClick={() => window.location.reload()}
+                className="mt-4 px-4 py-2 text-sm text-primary hover:underline"
+              >
+                다시 시도
+              </button>
+            </div>
+          )}
+
+          {/* 빈 상태 */}
+          {!isLoading && !error && transactions.length === 0 && (
+            <div className="flex flex-col items-center justify-center py-20 text-gray-400">
+              <span className="text-6xl mb-4">📒</span>
+              <p>거래 기록이 없어요</p>
+              <p className="text-sm mt-1">아래 버튼을 눌러 거래를 기록해보세요</p>
+            </div>
+          )}
+
+          {/* 거래 내역 목록 */}
+          {!isLoading && !error && transactions.length > 0 && (
+            <div>
+              {transactions.map((transaction) => (
+                <TransactionItem
+                  key={transaction.id}
+                  transaction={transaction}
+                  onDelete={handleDeleteTransaction}
+                />
+              ))}
+            </div>
+          )}
+
+          {/* 거래 추가 FAB 버튼 */}
+          <button
+            onClick={() => setShowAddModal(true)}
+            className="fixed bottom-24 right-4 w-14 h-14 bg-primary rounded-full flex items-center justify-center shadow-lg hover:bg-primary-dark transition-colors z-40"
+          >
+            <PlusIcon className="text-white" />
+          </button>
+
+          {/* 거래 추가 모달 */}
+          <AddTransactionModal
+            isOpen={showAddModal}
+            onClose={() => setShowAddModal(false)}
+            onSubmit={handleAddTransaction}
+            isSubmitting={isSubmitting}
+          />
+        </>
+      )}
+    </MobileLayout>
+  );
+}

--- a/apps/web/src/app/collection/page.tsx
+++ b/apps/web/src/app/collection/page.tsx
@@ -1,0 +1,262 @@
+"use client";
+
+import Link from "next/link";
+import { useState, useEffect } from "react";
+import { MobileLayout, Header } from "@/components/common";
+import { HeartIcon } from "@/components/icons";
+import { useAuth } from "@/context/AuthContext";
+import {
+  getMyLikes,
+  getMyPosts,
+  getPost,
+  formatPrice,
+  formatRelativeTime,
+  Post,
+} from "@/lib/postApi";
+import { getRecentViewedPostIds, clearRecentViewedPosts } from "@/lib/recentPosts";
+
+// 탭 타입
+type TabType = "likes" | "recent" | "my";
+
+// 탭 정보
+const tabs: { id: TabType; label: string }[] = [
+  { id: "likes", label: "관심목록" },
+  { id: "recent", label: "최근 본 글" },
+  { id: "my", label: "내 거래글" },
+];
+
+// 거래글 아이템 컴포넌트 (홈 페이지와 동일한 디자인)
+function PostItem({ post }: { post: Post }) {
+  return (
+    <Link
+      href={`/post/${post.id}`}
+      className="flex gap-4 p-4 border-b border-gray-100 hover:bg-gray-50 transition-colors"
+    >
+      {/* 상품 카테고리 아이콘 */}
+      <div className="w-28 h-28 bg-gray-100 rounded-xl overflow-hidden flex-shrink-0">
+        <img
+          src="/icons/DIY.png"
+          alt="상품 카테고리"
+          className="w-full h-full object-cover"
+        />
+      </div>
+
+      {/* 상품 정보 */}
+      <div className="flex-1 flex flex-col justify-between py-1">
+        <div>
+          <h3 className="font-medium text-gray-900 line-clamp-2">{post.itemName}</h3>
+          <p className="text-xs text-gray-500 mt-1">
+            {post.userIslandName || "섬 이름 없음"} · {formatRelativeTime(post.bumpedAt || post.createdAt)}
+          </p>
+        </div>
+        <div className="flex items-center justify-between">
+          <p className="font-bold text-primary">{formatPrice(post.price, post.currencyType)}</p>
+          <div className="flex items-center gap-3 text-gray-400">
+            {post.likeCount > 0 && (
+              <span className="flex items-center gap-1">
+                <HeartIcon className="w-4 h-4" />
+                <span className="text-xs">{post.likeCount}</span>
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+    </Link>
+  );
+}
+
+// 모아보기 페이지
+export default function CollectionPage() {
+  const { isAuthenticated, isLoading: authLoading } = useAuth();
+  const [activeTab, setActiveTab] = useState<TabType>("likes");
+  const [posts, setPosts] = useState<Post[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // 탭 변경 시 데이터 로드
+  useEffect(() => {
+    async function loadPosts() {
+      // 로그인 필요한 탭 체크
+      if ((activeTab === "likes" || activeTab === "my") && !isAuthenticated) {
+        setPosts([]);
+        return;
+      }
+
+      try {
+        setIsLoading(true);
+        setError(null);
+
+        if (activeTab === "likes") {
+          // 관심목록: 서버 API 호출
+          const response = await getMyLikes(0, 50);
+          setPosts(response.posts);
+        } else if (activeTab === "recent") {
+          // 최근 본 글: localStorage에서 ID 목록 조회 후 각 게시글 정보 로드
+          const recentIds = getRecentViewedPostIds();
+          if (recentIds.length === 0) {
+            setPosts([]);
+          } else {
+            // 각 게시글 정보를 병렬로 로드 (삭제된 게시글은 제외)
+            const postPromises = recentIds.map(async (id) => {
+              try {
+                return await getPost(id);
+              } catch {
+                // 삭제된 게시글은 null 반환
+                return null;
+              }
+            });
+            const results = await Promise.all(postPromises);
+            setPosts(results.filter((p): p is Post => p !== null));
+          }
+        } else if (activeTab === "my") {
+          // 내 거래글: 서버 API 호출
+          const response = await getMyPosts(0, 50);
+          setPosts(response.posts);
+        }
+      } catch (err) {
+        console.error("게시글 로드 실패:", err);
+        setError(err instanceof Error ? err.message : "게시글을 불러오는데 실패했습니다");
+      } finally {
+        setIsLoading(false);
+      }
+    }
+
+    // 인증 로딩 중이면 대기
+    if (!authLoading) {
+      loadPosts();
+    }
+  }, [activeTab, isAuthenticated, authLoading]);
+
+  // 최근 본 글 초기화
+  const handleClearRecent = () => {
+    clearRecentViewedPosts();
+    if (activeTab === "recent") {
+      setPosts([]);
+    }
+  };
+
+  // 빈 상태 메시지
+  const getEmptyMessage = () => {
+    switch (activeTab) {
+      case "likes":
+        return {
+          emoji: "💚",
+          title: "관심 등록한 거래글이 없어요",
+          subtitle: "마음에 드는 거래글에 하트를 눌러보세요",
+        };
+      case "recent":
+        return {
+          emoji: "👀",
+          title: "최근 본 거래글이 없어요",
+          subtitle: "거래글을 둘러보고 다시 와보세요",
+        };
+      case "my":
+        return {
+          emoji: "📝",
+          title: "작성한 거래글이 없어요",
+          subtitle: "첫 번째 거래글을 등록해보세요",
+        };
+    }
+  };
+
+  // 로그인 필요 메시지
+  const needsLogin = (activeTab === "likes" || activeTab === "my") && !authLoading && !isAuthenticated;
+
+  return (
+    <MobileLayout>
+      {/* 헤더 */}
+      <Header
+        title="모아보기"
+        showBack
+        onBack={() => window.history.back()}
+        rightElement={
+          activeTab === "recent" && posts.length > 0 ? (
+            <button
+              onClick={handleClearRecent}
+              className="text-sm text-gray-500 hover:text-gray-700"
+            >
+              전체 삭제
+            </button>
+          ) : undefined
+        }
+      />
+
+      {/* 탭 바 */}
+      <div className="flex border-b border-gray-200 bg-white sticky top-14 z-10">
+        {tabs.map((tab) => (
+          <button
+            key={tab.id}
+            onClick={() => setActiveTab(tab.id)}
+            className={`flex-1 py-3 text-sm font-medium transition-colors ${
+              activeTab === tab.id
+                ? "text-primary border-b-2 border-primary"
+                : "text-gray-500 hover:text-gray-700"
+            }`}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {/* 로그인 필요 안내 */}
+      {needsLogin && (
+        <div className="flex flex-col items-center justify-center py-20 text-gray-400">
+          <span className="text-6xl mb-4">🔒</span>
+          <p>로그인이 필요해요</p>
+          <Link
+            href="/login"
+            className="mt-4 px-6 py-2 bg-primary text-white rounded-lg hover:bg-primary-dark transition-colors"
+          >
+            로그인
+          </Link>
+        </div>
+      )}
+
+      {/* 로딩 상태 */}
+      {!needsLogin && isLoading && (
+        <div className="flex items-center justify-center py-20">
+          <div className="animate-spin rounded-full h-8 w-8 border-2 border-primary border-t-transparent" />
+        </div>
+      )}
+
+      {/* 에러 상태 */}
+      {!needsLogin && error && !isLoading && (
+        <div className="flex flex-col items-center justify-center py-20 text-gray-500">
+          <p className="text-sm">{error}</p>
+          <button
+            onClick={() => window.location.reload()}
+            className="mt-4 px-4 py-2 text-sm text-primary hover:underline"
+          >
+            다시 시도
+          </button>
+        </div>
+      )}
+
+      {/* 빈 상태 */}
+      {!needsLogin && !isLoading && !error && posts.length === 0 && (
+        <div className="flex flex-col items-center justify-center py-20 text-gray-400">
+          <span className="text-6xl mb-4">{getEmptyMessage().emoji}</span>
+          <p>{getEmptyMessage().title}</p>
+          <p className="text-sm mt-1">{getEmptyMessage().subtitle}</p>
+          {activeTab === "my" && (
+            <Link
+              href="/post/new"
+              className="mt-4 px-6 py-2 bg-primary text-white rounded-lg hover:bg-primary-dark transition-colors"
+            >
+              거래글 작성
+            </Link>
+          )}
+        </div>
+      )}
+
+      {/* 거래글 목록 */}
+      {!needsLogin && !isLoading && !error && posts.length > 0 && (
+        <div className="divide-y divide-gray-100">
+          {posts.map((post) => (
+            <PostItem key={post.id} post={post} />
+          ))}
+        </div>
+      )}
+    </MobileLayout>
+  );
+}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -24,13 +24,15 @@
 }
 
 html, body {
-  max-width: 100vw;
+  width: 100%;
+  max-width: 100%;
   overflow-x: hidden;
 }
 
 body {
+  width: 100%;
   color: var(--foreground);
-  background: var(--background);
+  background: #ffffff;
   font-family: "Pretendard", Arial, Helvetica, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -32,7 +32,7 @@ html, body {
 body {
   width: 100%;
   color: var(--foreground);
-  background: #ffffff;
+  background: var(--background);
   font-family: "Pretendard", Arial, Helvetica, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;

--- a/apps/web/src/app/keyword-alarm/page.tsx
+++ b/apps/web/src/app/keyword-alarm/page.tsx
@@ -1,0 +1,245 @@
+"use client";
+
+import Link from "next/link";
+import { useState, useEffect } from "react";
+import { MobileLayout, Header } from "@/components/common";
+import { useAuth } from "@/context/AuthContext";
+import {
+  getKeywordAlarms,
+  createKeywordAlarm,
+  deleteKeywordAlarm,
+  KeywordAlarm,
+  formatRelativeTime,
+} from "@/lib/postApi";
+
+// 키워드 아이템 컴포넌트
+function KeywordItem({
+  keyword,
+  onDelete,
+  isDeleting,
+}: {
+  keyword: KeywordAlarm;
+  onDelete: (id: number) => void;
+  isDeleting: boolean;
+}) {
+  return (
+    <div className="flex items-center justify-between p-4 border-b border-gray-100">
+      <div className="flex-1">
+        <span className="font-medium text-gray-900">{keyword.keyword}</span>
+        <p className="text-xs text-gray-400 mt-0.5">
+          {formatRelativeTime(keyword.createdAt)} 등록
+        </p>
+      </div>
+      <button
+        onClick={() => onDelete(keyword.id)}
+        disabled={isDeleting}
+        className="p-2 text-gray-400 hover:text-gray-600 transition-colors disabled:opacity-50"
+      >
+        <svg
+          className="w-5 h-5"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M6 18L18 6M6 6l12 12"
+          />
+        </svg>
+      </button>
+    </div>
+  );
+}
+
+// 키워드 알림 페이지
+export default function KeywordAlarmPage() {
+  const { isAuthenticated, isLoading: authLoading } = useAuth();
+  const [keywords, setKeywords] = useState<KeywordAlarm[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // 입력 상태
+  const [newKeyword, setNewKeyword] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  // 삭제 중인 키워드 ID
+  const [deletingId, setDeletingId] = useState<number | null>(null);
+
+  // 키워드 목록 로드
+  useEffect(() => {
+    async function loadKeywords() {
+      if (!isAuthenticated) {
+        setIsLoading(false);
+        return;
+      }
+
+      try {
+        setIsLoading(true);
+        setError(null);
+        const response = await getKeywordAlarms();
+        setKeywords(response.keywords);
+      } catch (err) {
+        console.error("키워드 로드 실패:", err);
+        setError(err instanceof Error ? err.message : "키워드를 불러오는데 실패했습니다");
+      } finally {
+        setIsLoading(false);
+      }
+    }
+
+    if (!authLoading) {
+      loadKeywords();
+    }
+  }, [isAuthenticated, authLoading]);
+
+  // 키워드 추가
+  const handleAddKeyword = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    const trimmedKeyword = newKeyword.trim();
+    if (!trimmedKeyword) return;
+
+    try {
+      setIsSubmitting(true);
+      setSubmitError(null);
+
+      const created = await createKeywordAlarm(trimmedKeyword);
+      setKeywords((prev) => [created, ...prev]);
+      setNewKeyword("");
+    } catch (err) {
+      console.error("키워드 추가 실패:", err);
+      setSubmitError(err instanceof Error ? err.message : "키워드 추가에 실패했습니다");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  // 키워드 삭제
+  const handleDeleteKeyword = async (id: number) => {
+    try {
+      setDeletingId(id);
+      await deleteKeywordAlarm(id);
+      setKeywords((prev) => prev.filter((k) => k.id !== id));
+    } catch (err) {
+      console.error("키워드 삭제 실패:", err);
+      alert(err instanceof Error ? err.message : "키워드 삭제에 실패했습니다");
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  // 로그인 필요 여부
+  const needsLogin = !authLoading && !isAuthenticated;
+
+  return (
+    <MobileLayout>
+      {/* 헤더 */}
+      <Header
+        title="키워드 알림"
+        showBack
+        onBack={() => window.history.back()}
+      />
+
+      {/* 로그인 필요 안내 */}
+      {needsLogin && (
+        <div className="flex flex-col items-center justify-center py-20 text-gray-400">
+          <span className="text-6xl mb-4">🔒</span>
+          <p>로그인이 필요해요</p>
+          <Link
+            href="/login"
+            className="mt-4 px-6 py-2 bg-primary text-white rounded-lg hover:bg-primary-dark transition-colors"
+          >
+            로그인
+          </Link>
+        </div>
+      )}
+
+      {/* 로그인 상태일 때 */}
+      {!needsLogin && (
+        <>
+          {/* 키워드 입력 폼 */}
+          <form onSubmit={handleAddKeyword} className="p-4 bg-gray-50 border-b border-gray-100">
+            <div className="flex gap-2">
+              <input
+                type="text"
+                value={newKeyword}
+                onChange={(e) => {
+                  setNewKeyword(e.target.value);
+                  setSubmitError(null);
+                }}
+                placeholder="관심 키워드를 입력하세요"
+                maxLength={50}
+                className="flex-1 px-4 py-3 rounded-lg border border-gray-200 focus:outline-none focus:border-primary text-gray-900"
+              />
+              <button
+                type="submit"
+                disabled={!newKeyword.trim() || isSubmitting}
+                className="px-6 py-3 bg-primary text-white font-medium rounded-lg hover:bg-primary-dark transition-colors disabled:bg-gray-300 disabled:cursor-not-allowed"
+              >
+                {isSubmitting ? "..." : "추가"}
+              </button>
+            </div>
+            {submitError && (
+              <p className="mt-2 text-sm text-red-500">{submitError}</p>
+            )}
+            <p className="mt-2 text-xs text-gray-500">
+              키워드가 포함된 새 거래글이 등록되면 알림을 받아요 (최대 30개)
+            </p>
+          </form>
+
+          {/* 키워드 개수 표시 */}
+          {keywords.length > 0 && (
+            <div className="px-4 py-2 bg-primary-light/30 text-primary text-sm font-medium">
+              등록된 키워드 {keywords.length}개
+            </div>
+          )}
+
+          {/* 로딩 상태 */}
+          {isLoading && (
+            <div className="flex items-center justify-center py-20">
+              <div className="animate-spin rounded-full h-8 w-8 border-2 border-primary border-t-transparent" />
+            </div>
+          )}
+
+          {/* 에러 상태 */}
+          {error && !isLoading && (
+            <div className="flex flex-col items-center justify-center py-20 text-gray-500">
+              <p className="text-sm">{error}</p>
+              <button
+                onClick={() => window.location.reload()}
+                className="mt-4 px-4 py-2 text-sm text-primary hover:underline"
+              >
+                다시 시도
+              </button>
+            </div>
+          )}
+
+          {/* 빈 상태 */}
+          {!isLoading && !error && keywords.length === 0 && (
+            <div className="flex flex-col items-center justify-center py-20 text-gray-400">
+              <span className="text-6xl mb-4">🔔</span>
+              <p>등록된 키워드가 없어요</p>
+              <p className="text-sm mt-1">관심 있는 키워드를 등록해보세요!</p>
+            </div>
+          )}
+
+          {/* 키워드 목록 */}
+          {!isLoading && !error && keywords.length > 0 && (
+            <div>
+              {keywords.map((keyword) => (
+                <KeywordItem
+                  key={keyword.id}
+                  keyword={keyword}
+                  onDelete={handleDeleteKeyword}
+                  isDeleting={deletingId === keyword.id}
+                />
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </MobileLayout>
+  );
+}

--- a/apps/web/src/app/post/[id]/page.tsx
+++ b/apps/web/src/app/post/[id]/page.tsx
@@ -18,6 +18,7 @@ import {
   createReport,
   ReportReasonCode,
 } from "@/lib/postApi";
+import { addRecentViewedPost } from "@/lib/recentPosts";
 
 // 신고 사유 옵션
 const REPORT_REASONS: { code: ReportReasonCode; label: string }[] = [
@@ -88,6 +89,8 @@ export default function PostDetailPage() {
         if (data.currencyType) {
           setOfferCurrencyType(data.currencyType);
         }
+        // 최근 본 글에 기록
+        addRecentViewedPost(postNum);
       } catch (err) {
         console.error("게시글 로드 실패:", err);
         setError(err instanceof Error ? err.message : "게시글을 불러오는데 실패했습니다");

--- a/apps/web/src/app/profile/edit/page.tsx
+++ b/apps/web/src/app/profile/edit/page.tsx
@@ -15,6 +15,7 @@ export default function ProfileEditPage() {
   const { user, accessToken, isLoading } = useAuth();
   const [formData, setFormData] = useState({
     islandName: "",
+    islandSuffix: "섬" as "섬" | "도",
     name: "",
     hemisphere: "NORTH",
     dreamAddress: "",
@@ -26,13 +27,25 @@ export default function ProfileEditPage() {
   // 기존 프로필 정보 불러오기
   useEffect(() => {
     if (user) {
+      // 섬 이름에서 접미사(섬/도) 분리
+      let baseName = user.islandName || "";
+      let suffix: "섬" | "도" = "섬";
+      if (baseName.endsWith("도")) {
+        suffix = "도";
+        baseName = baseName.slice(0, -1);
+      } else if (baseName.endsWith("섬")) {
+        suffix = "섬";
+        baseName = baseName.slice(0, -1);
+      }
+
       setFormData({
-        islandName: user.islandName || "",
+        islandName: baseName,
+        islandSuffix: suffix,
         name: user.nickname || "",
         hemisphere: user.hemisphere || "NORTH",
         dreamAddress: user.dreamCode || "",
       });
-      setIsIslandNameValid((user.islandName?.length || 0) >= 2);
+      setIsIslandNameValid(baseName.length >= 1);
     }
   }, [user]);
 
@@ -47,9 +60,9 @@ export default function ProfileEditPage() {
     const { name, value } = e.target;
     setFormData((prev) => ({ ...prev, [name]: value }));
 
-    // 섬 이름 유효성 검사
+    // 섬 이름 유효성 검사 (접미사 제외 1자 이상)
     if (name === "islandName") {
-      setIsIslandNameValid(value.length >= 2);
+      setIsIslandNameValid(value.length >= 1);
     }
   };
 
@@ -63,6 +76,9 @@ export default function ProfileEditPage() {
       const isNewUser = !user?.isProfileComplete;
       const endpoint = isNewUser ? "/api/users/me/profile-setup" : "/api/users/me/update";
 
+      // 섬 이름 + 접미사(섬/도) 결합
+      const fullIslandName = formData.islandName + formData.islandSuffix;
+
       const res = await fetch(`${API_URL}${endpoint}`, {
         method: "POST",
         headers: {
@@ -71,7 +87,7 @@ export default function ProfileEditPage() {
         },
         body: JSON.stringify({
           nickname: formData.name,
-          islandName: formData.islandName,
+          islandName: fullIslandName,
           dreamAddress: formData.dreamAddress || null,
           ...(isNewUser && { hemisphere: formData.hemisphere }),
         }),
@@ -127,17 +143,49 @@ export default function ProfileEditPage() {
           {/* 섬 이름 */}
           <div>
             <label className="block text-gray-800 font-medium mb-1">섬 이름</label>
-            <input
-              type="text"
-              name="islandName"
-              value={formData.islandName}
-              onChange={handleChange}
-              placeholder="섬 이름을 입력하세요"
-              className="w-full px-4 py-3 rounded-lg border border-gray-300 bg-white text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
-            />
+            <div className="flex gap-2">
+              <input
+                type="text"
+                name="islandName"
+                value={formData.islandName}
+                onChange={handleChange}
+                placeholder="섬 이름"
+                className="flex-1 px-4 py-3 rounded-lg border border-gray-300 bg-white text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
+              />
+              {/* 섬/도 선택 */}
+              <div className="flex">
+                <button
+                  type="button"
+                  onClick={() => setFormData((prev) => ({ ...prev, islandSuffix: "섬" }))}
+                  className={`px-4 py-3 rounded-l-lg text-sm font-medium border transition-colors ${
+                    formData.islandSuffix === "섬"
+                      ? "border-primary bg-primary/10 text-primary border-r-0"
+                      : "border-gray-300 text-gray-700 hover:border-gray-400 border-r-0"
+                  }`}
+                >
+                  섬
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setFormData((prev) => ({ ...prev, islandSuffix: "도" }))}
+                  className={`px-4 py-3 rounded-r-lg text-sm font-medium border transition-colors ${
+                    formData.islandSuffix === "도"
+                      ? "border-primary bg-primary/10 text-primary"
+                      : "border-gray-300 text-gray-700 hover:border-gray-400"
+                  }`}
+                >
+                  도
+                </button>
+              </div>
+            </div>
             {formData.islandName && !isIslandNameValid && (
               <p className="text-sm mt-1 text-red-500">
-                * 2자 이상 입력해주세요.
+                * 1자 이상 입력해주세요.
+              </p>
+            )}
+            {formData.islandName && isIslandNameValid && (
+              <p className="text-sm mt-1 text-gray-500">
+                &quot;{formData.islandName}{formData.islandSuffix}&quot;(으)로 저장됩니다.
               </p>
             )}
           </div>

--- a/apps/web/src/app/profile/edit/page.tsx
+++ b/apps/web/src/app/profile/edit/page.tsx
@@ -15,32 +15,43 @@ export default function ProfileEditPage() {
   const { user, accessToken, isLoading } = useAuth();
   const [formData, setFormData] = useState({
     islandName: "",
-    islandSuffix: "섬" as "섬" | "도",
+    islandSuffix: "섬" as "섬" | "도" | "", // 빈 문자열은 접미사 없음을 의미
     name: "",
     hemisphere: "NORTH",
     dreamAddress: "",
   });
   const [isIslandNameValid, setIsIslandNameValid] = useState(false);
+  // CodeRabbit 리뷰 반영: 기존 섬 이름에 접미사가 있었는지 추적
+  const [hadOriginalSuffix, setHadOriginalSuffix] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   // 기존 프로필 정보 불러오기
   useEffect(() => {
     if (user) {
-      // 섬 이름에서 접미사(섬/도) 분리
+      // CodeRabbit 리뷰 반영: 섬 이름에서 접미사(섬/도) 분리 + 접미사 없는 경우 처리
       let baseName = user.islandName || "";
-      let suffix: "섬" | "도" = "섬";
+      let suffix: "섬" | "도" | "" = "섬";
+      let hasSuffix = false;
+
       if (baseName.endsWith("도")) {
         suffix = "도";
         baseName = baseName.slice(0, -1);
+        hasSuffix = true;
       } else if (baseName.endsWith("섬")) {
         suffix = "섬";
         baseName = baseName.slice(0, -1);
+        hasSuffix = true;
+      } else if (baseName) {
+        // 접미사가 없는 기존 이름 (영문, 특수문자 등)
+        suffix = "";
+        hasSuffix = false;
       }
 
+      setHadOriginalSuffix(hasSuffix || !user.islandName); // 신규 유저는 접미사 사용
       setFormData({
         islandName: baseName,
-        islandSuffix: suffix,
+        islandSuffix: hasSuffix || !user.islandName ? (suffix || "섬") : "",
         name: user.nickname || "",
         hemisphere: user.hemisphere || "NORTH",
         dreamAddress: user.dreamCode || "",
@@ -76,8 +87,10 @@ export default function ProfileEditPage() {
       const isNewUser = !user?.isProfileComplete;
       const endpoint = isNewUser ? "/api/users/me/profile-setup" : "/api/users/me/update";
 
-      // 섬 이름 + 접미사(섬/도) 결합
-      const fullIslandName = formData.islandName + formData.islandSuffix;
+      // 섬 이름 + 접미사(섬/도) 결합 (접미사가 있는 경우에만)
+      const fullIslandName = formData.islandSuffix
+        ? formData.islandName + formData.islandSuffix
+        : formData.islandName;
 
       const res = await fetch(`${API_URL}${endpoint}`, {
         method: "POST",
@@ -152,31 +165,33 @@ export default function ProfileEditPage() {
                 placeholder="섬 이름"
                 className="flex-1 px-4 py-3 rounded-lg border border-gray-300 bg-white text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
               />
-              {/* 섬/도 선택 */}
-              <div className="flex">
-                <button
-                  type="button"
-                  onClick={() => setFormData((prev) => ({ ...prev, islandSuffix: "섬" }))}
-                  className={`px-4 py-3 rounded-l-lg text-sm font-medium border transition-colors ${
-                    formData.islandSuffix === "섬"
-                      ? "border-primary bg-primary/10 text-primary border-r-0"
-                      : "border-gray-300 text-gray-700 hover:border-gray-400 border-r-0"
-                  }`}
-                >
-                  섬
-                </button>
-                <button
-                  type="button"
-                  onClick={() => setFormData((prev) => ({ ...prev, islandSuffix: "도" }))}
-                  className={`px-4 py-3 rounded-r-lg text-sm font-medium border transition-colors ${
-                    formData.islandSuffix === "도"
-                      ? "border-primary bg-primary/10 text-primary"
-                      : "border-gray-300 text-gray-700 hover:border-gray-400"
-                  }`}
-                >
-                  도
-                </button>
-              </div>
+              {/* 섬/도 선택 - 기존에 접미사가 있거나 신규 유저인 경우에만 표시 */}
+              {hadOriginalSuffix && (
+                <div className="flex">
+                  <button
+                    type="button"
+                    onClick={() => setFormData((prev) => ({ ...prev, islandSuffix: "섬" }))}
+                    className={`px-4 py-3 rounded-l-lg text-sm font-medium border transition-colors ${
+                      formData.islandSuffix === "섬"
+                        ? "border-primary bg-primary/10 text-primary border-r-0"
+                        : "border-gray-300 text-gray-700 hover:border-gray-400 border-r-0"
+                    }`}
+                  >
+                    섬
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setFormData((prev) => ({ ...prev, islandSuffix: "도" }))}
+                    className={`px-4 py-3 rounded-r-lg text-sm font-medium border transition-colors ${
+                      formData.islandSuffix === "도"
+                        ? "border-primary bg-primary/10 text-primary"
+                        : "border-gray-300 text-gray-700 hover:border-gray-400"
+                    }`}
+                  >
+                    도
+                  </button>
+                </div>
+              )}
             </div>
             {formData.islandName && !isIslandNameValid && (
               <p className="text-sm mt-1 text-red-500">

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -19,7 +19,7 @@ export default function ProfilePage() {
   if (!isLoading && !isAuthenticated) {
     return (
       <MobileLayout>
-        <Header title="나의 거동숲" />
+        <Header showLocation />
         <div className="flex flex-col items-center justify-center py-20 text-gray-500">
           <span className="text-6xl mb-4">🔒</span>
           <p className="text-sm">로그인이 필요합니다</p>
@@ -35,7 +35,7 @@ export default function ProfilePage() {
   if (isLoading) {
     return (
       <MobileLayout>
-        <Header title="나의 거동숲" />
+        <Header showLocation />
         <div className="flex items-center justify-center py-20">
           <div className="animate-spin rounded-full h-8 w-8 border-2 border-primary border-t-transparent" />
         </div>
@@ -47,7 +47,7 @@ export default function ProfilePage() {
     <MobileLayout>
       {/* 헤더 */}
       <Header
-        title="나의 거동숲"
+        showLocation
         rightElement={
           <button className="p-1 hover:bg-gray-100 rounded-full transition-colors">
             <SettingsIcon className="text-gray-800" />
@@ -69,8 +69,8 @@ export default function ProfilePage() {
           className="rounded-full object-cover"
         />
         <div className="flex-1">
-          <h2 className="font-semibold text-lg">{user?.nickname || "닉네임 없음"}</h2>
-          <p className="text-sm text-gray-500">
+          <h2 className="font-semibold text-lg text-gray-900">{user?.nickname || "닉네임 없음"}</h2>
+          <p className="text-sm text-gray-900">
             {user?.islandName || "섬 이름 없음"}
           </p>
         </div>

--- a/apps/web/src/components/common/BottomNav.tsx
+++ b/apps/web/src/components/common/BottomNav.tsx
@@ -45,8 +45,8 @@ export default function BottomNav() {
           );
         })}
       </div>
-      {/* 아이폰 하단 홈인디케이터 영역 */}
-      <div className="h-1 w-32 bg-black rounded-full mx-auto mb-2" />
+      {/* 아이폰 하단 safe area 여백 - 모바일에서만 표시 */}
+      <div className="h-2 md:h-0" />
     </nav>
   );
 }

--- a/apps/web/src/components/common/Header.tsx
+++ b/apps/web/src/components/common/Header.tsx
@@ -44,11 +44,11 @@ export default function Header({
             </button>
           )}
           {showLocation ? (
-            <span className="font-semibold text-lg">
+            <span className="font-semibold text-lg text-gray-900">
               {isAuthenticated && user?.islandName ? user.islandName : "내 섬"}
             </span>
           ) : (
-            title && <h1 className="font-semibold text-lg">{title}</h1>
+            title && <h1 className="font-semibold text-lg text-gray-900">{title}</h1>
           )}
         </div>
 

--- a/apps/web/src/components/common/MobileLayout.tsx
+++ b/apps/web/src/components/common/MobileLayout.tsx
@@ -7,16 +7,13 @@ interface MobileLayoutProps {
   hideNav?: boolean;
 }
 
-// 모바일 앱 레이아웃
-// Before: 390px 고정 너비 (최신 폰에서 회색 여백 발생)
-// After: 전체 너비 사용 (반응형)
+// 반응형 웹 레이아웃
+// - 전체 너비 사용 (웹 페이지처럼 보이도록)
 export default function MobileLayout({ children, hideNav = false }: MobileLayoutProps) {
   return (
-    <div className="min-h-screen bg-white">
-      <div className="w-full min-h-screen bg-white relative">
-        <main className={`${hideNav ? "" : "pb-20"}`}>{children}</main>
-        {!hideNav && <BottomNav />}
-      </div>
+    <div className="w-full min-h-screen bg-white">
+      <main className={`w-full ${hideNav ? "" : "pb-20"}`}>{children}</main>
+      {!hideNav && <BottomNav />}
     </div>
   );
 }

--- a/apps/web/src/lib/postApi.ts
+++ b/apps/web/src/lib/postApi.ts
@@ -785,3 +785,163 @@ export async function unblockUser(blockedUserId: string): Promise<{ message: str
     method: 'DELETE',
   });
 }
+
+// ========== 키워드 알림 타입 정의 ==========
+
+// 키워드 알림 응답 타입
+export interface KeywordAlarm {
+  id: number;
+  keyword: string;
+  createdAt: string;
+}
+
+// 키워드 알림 목록 응답 타입
+export interface KeywordAlarmListResponse {
+  keywords: KeywordAlarm[];
+  totalCount: number;
+}
+
+// ========== 키워드 알림 API 함수 ==========
+
+/**
+ * 내 키워드 목록 조회
+ * GET /api/keyword-alarms
+ */
+export async function getKeywordAlarms(): Promise<KeywordAlarmListResponse> {
+  return fetchWithAuth<KeywordAlarmListResponse>(`${API_URL}/api/keyword-alarms`);
+}
+
+/**
+ * 키워드 추가
+ * POST /api/keyword-alarms
+ */
+export async function createKeywordAlarm(keyword: string): Promise<KeywordAlarm> {
+  return fetchWithAuth<KeywordAlarm>(`${API_URL}/api/keyword-alarms`, {
+    method: 'POST',
+    body: JSON.stringify({ keyword }),
+  });
+}
+
+/**
+ * 키워드 삭제
+ * DELETE /api/keyword-alarms/{id}
+ */
+export async function deleteKeywordAlarm(id: number): Promise<{ message: string }> {
+  return fetchWithAuth<{ message: string }>(`${API_URL}/api/keyword-alarms/${id}`, {
+    method: 'DELETE',
+  });
+}
+
+// ========== 가계부(거래 내역) 타입 정의 ==========
+
+// 거래 내역 응답 타입
+export interface Transaction {
+  id: number;
+  postId: number | null;
+  postItemName: string | null;
+  type: 'SALE' | 'PURCHASE';
+  currencyType: 'BELL' | 'MILE_TICKET';
+  amount: number;
+  partnerId: number | null;
+  partnerNickname: string | null;
+  memo: string | null;
+  tradedAt: string;
+  createdAt: string;
+}
+
+// 거래 내역 목록 응답 타입
+export interface TransactionListResponse {
+  transactions: Transaction[];
+  currentPage: number;
+  totalPages: number;
+  totalElements: number;
+  hasNext: boolean;
+}
+
+// 거래 통계 응답 타입
+export interface TransactionSummary {
+  totalSales: number;
+  totalPurchases: number;
+  netProfit: number;
+  salesCount: number;
+  purchaseCount: number;
+}
+
+// 거래 내역 생성 요청 타입
+export interface TransactionCreateRequest {
+  postId?: number;
+  type: 'SALE' | 'PURCHASE';
+  currencyType: 'BELL' | 'MILE_TICKET';
+  amount: number;
+  itemName: string;
+  partnerNickname?: string;
+  memo?: string;
+  tradedAt?: string;
+}
+
+// ========== 가계부 API 함수 ==========
+
+/**
+ * 거래 내역 목록 조회
+ * GET /api/transactions
+ */
+export async function getTransactions(params?: {
+  startDate?: string;
+  endDate?: string;
+  type?: 'SALE' | 'PURCHASE';
+  page?: number;
+  size?: number;
+}): Promise<TransactionListResponse> {
+  const searchParams = new URLSearchParams();
+
+  if (params?.startDate) searchParams.set('startDate', params.startDate);
+  if (params?.endDate) searchParams.set('endDate', params.endDate);
+  if (params?.type) searchParams.set('type', params.type);
+  if (params?.page !== undefined) searchParams.set('page', String(params.page));
+  if (params?.size !== undefined) searchParams.set('size', String(params.size));
+
+  const queryString = searchParams.toString();
+  const url = `${API_URL}/api/transactions${queryString ? `?${queryString}` : ''}`;
+
+  return fetchWithAuth<TransactionListResponse>(url);
+}
+
+/**
+ * 거래 통계 조회
+ * GET /api/transactions/summary
+ */
+export async function getTransactionSummary(params?: {
+  startDate?: string;
+  endDate?: string;
+}): Promise<TransactionSummary> {
+  const searchParams = new URLSearchParams();
+
+  if (params?.startDate) searchParams.set('startDate', params.startDate);
+  if (params?.endDate) searchParams.set('endDate', params.endDate);
+
+  const queryString = searchParams.toString();
+  const url = `${API_URL}/api/transactions/summary${queryString ? `?${queryString}` : ''}`;
+
+  return fetchWithAuth<TransactionSummary>(url);
+}
+
+/**
+ * 거래 내역 생성
+ * POST /api/transactions
+ */
+export async function createTransaction(request: TransactionCreateRequest): Promise<Transaction> {
+  return fetchWithAuth<Transaction>(`${API_URL}/api/transactions`, {
+    method: 'POST',
+    body: JSON.stringify(request),
+  });
+}
+
+/**
+ * 거래 내역 삭제
+ * DELETE /api/transactions/{id}
+ */
+export async function deleteTransaction(id: number): Promise<{ message: string }> {
+  return fetchWithAuth<{ message: string }>(`${API_URL}/api/transactions/${id}`, {
+    method: 'DELETE',
+  });
+}

--- a/apps/web/src/lib/recentPosts.ts
+++ b/apps/web/src/lib/recentPosts.ts
@@ -1,0 +1,82 @@
+// 최근 본 거래글 관리 유틸리티
+// localStorage를 사용하여 클라이언트에서 관리
+
+const STORAGE_KEY = 'recent_viewed_posts';
+const MAX_ITEMS = 20;
+
+export interface RecentViewedPost {
+  postId: number;
+  viewedAt: string;
+}
+
+/**
+ * 최근 본 거래글 목록 조회
+ */
+export function getRecentViewedPosts(): RecentViewedPost[] {
+  if (typeof window === 'undefined') return [];
+
+  try {
+    const data = localStorage.getItem(STORAGE_KEY);
+    return data ? JSON.parse(data) : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * 최근 본 거래글 ID 목록만 조회
+ */
+export function getRecentViewedPostIds(): number[] {
+  return getRecentViewedPosts().map(p => p.postId);
+}
+
+/**
+ * 최근 본 거래글 추가
+ * - 중복 제거 후 맨 앞에 추가
+ * - 최대 20개 유지
+ */
+export function addRecentViewedPost(postId: number): void {
+  if (typeof window === 'undefined') return;
+
+  try {
+    const posts = getRecentViewedPosts()
+      .filter(p => p.postId !== postId); // 중복 제거
+
+    posts.unshift({
+      postId,
+      viewedAt: new Date().toISOString(),
+    });
+
+    // 최대 개수 유지
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(posts.slice(0, MAX_ITEMS)));
+  } catch {
+    // localStorage 에러 무시
+  }
+}
+
+/**
+ * 최근 본 거래글 목록 초기화
+ */
+export function clearRecentViewedPosts(): void {
+  if (typeof window === 'undefined') return;
+
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // localStorage 에러 무시
+  }
+}
+
+/**
+ * 특정 거래글 제거 (삭제된 게시글 처리용)
+ */
+export function removeRecentViewedPost(postId: number): void {
+  if (typeof window === 'undefined') return;
+
+  try {
+    const posts = getRecentViewedPosts().filter(p => p.postId !== postId);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(posts));
+  } catch {
+    // localStorage 에러 무시
+  }
+}


### PR DESCRIPTION
## Summary
- 키워드 알림, 가계부, 모아보기 3개 신규 페이지 구현
- 백엔드 API 엔드포인트 추가 (keywordalarm, transaction 패키지)
- 데스크톱에서 전체 너비 사용하도록 레이아웃 수정

## 구현 내용

### 1. 모아보기 페이지 (`/collection`)
- **관심목록**: 찜한 거래글 목록 (기존 API 활용)
- **최근 본 글**: localStorage 기반 조회 기록
- **내 거래글**: 내가 작성한 거래글 목록

### 2. 키워드 알림 페이지 (`/keyword-alarm`)
- 관심 키워드 등록/삭제 (최대 30개)
- 키워드가 포함된 새 거래글 등록 시 알림 (향후 구현)

**API 엔드포인트:**
- `GET /api/keyword-alarms` - 내 키워드 목록
- `POST /api/keyword-alarms` - 키워드 추가
- `DELETE /api/keyword-alarms/{id}` - 키워드 삭제

### 3. 가계부 페이지 (`/account-book`)
- 거래 내역 기록 (판매/구매)
- 통계 카드 (총 판매액, 총 구매액, 순이익)
- 기간별 필터링 (전체, 1주, 1개월, 3개월)

**API 엔드포인트:**
- `GET /api/transactions` - 거래 내역 목록
- `GET /api/transactions/summary` - 거래 통계
- `POST /api/transactions` - 거래 기록 추가
- `DELETE /api/transactions/{id}` - 거래 기록 삭제

### 4. 레이아웃 수정
- MobileLayout: 데스크톱에서 전체 너비 사용
- globals.css: body width 100% 명시
- BottomNav: 아이폰 홈인디케이터 정리

## 파일 변경 내역

### 프론트엔드 (신규)
- `apps/web/src/app/collection/page.tsx`
- `apps/web/src/app/keyword-alarm/page.tsx`
- `apps/web/src/app/account-book/page.tsx`
- `apps/web/src/lib/recentPosts.ts`

### 프론트엔드 (수정)
- `apps/web/src/lib/postApi.ts` - API 타입/함수 추가
- `apps/web/src/app/post/[id]/page.tsx` - 최근 본 글 기록
- `apps/web/src/components/common/MobileLayout.tsx`
- `apps/web/src/components/common/BottomNav.tsx`
- `apps/web/src/app/globals.css`

### 백엔드 (신규)
- `apps/api/src/main/java/com/acnh/api/keywordalarm/` (전체 패키지)
- `apps/api/src/main/java/com/acnh/api/transaction/` (전체 패키지)

## Test plan
- [ ] `/collection` 페이지 접속 및 탭 전환 확인
- [ ] `/keyword-alarm` 페이지에서 키워드 추가/삭제 테스트
- [ ] `/account-book` 페이지에서 거래 기록 추가/삭제 테스트
- [ ] 데스크톱 브라우저에서 전체 너비 레이아웃 확인
- [ ] 백엔드 API 스웨거에서 엔드포인트 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 키워드 알람: 관심 키워드 추가·삭제 및 목록 관리 UI 추가
  * 거래내역 관리(계정장): 거래 등록·조회·삭제, 기간 필터 및 매매 요약 카드 추가
  * 컬렉션 페이지: 좋아요·최근·내 게시물 탭 추가
  * 최근 본 게시물 자동 기록 및 관리 기능 추가

* **개선 사항**
  * 모바일 레이아웃: 전체 폭 지원 및 하단 안전 영역 개선
  * 프로필 편집: 섬명 접미사 선택 UI 및 유효성 완화, 프로필 헤더 가독성 향상

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->