### PR TITLE
fix: 프론트엔드 UX 개선 및 코드 정리 (#78 리뷰 반영)

### DIFF
--- a/apps/web/src/app/keyword-alarm/page.tsx
+++ b/apps/web/src/app/keyword-alarm/page.tsx
@@ -101,6 +101,12 @@ export default function KeywordAlarmPage() {
     const trimmedKeyword = newKeyword.trim();
     if (!trimmedKeyword) return;
 
+    // CodeRabbit 리뷰 반영: 서버 요청 전 클라이언트에서 30개 제한 선제 검증
+    if (keywords.length >= 30) {
+      setSubmitError("키워드는 최대 30개까지 등록할 수 있습니다.");
+      return;
+    }
+
     try {
       setIsSubmitting(true);
       setSubmitError(null);

--- a/apps/web/src/app/profile/edit/page.tsx
+++ b/apps/web/src/app/profile/edit/page.tsx
@@ -193,12 +193,10 @@ export default function ProfileEditPage() {
                 </div>
               )}
             </div>
-            {formData.islandName && !isIslandNameValid && (
-              <p className="text-sm mt-1 text-red-500">
-                * 1자 이상 입력해주세요.
-              </p>
-            )}
-            {formData.islandName && isIslandNameValid && (
+            {/* CodeRabbit 리뷰 반영: dead code 제거
+               Before: formData.islandName && !isIslandNameValid 조건은
+               isIslandNameValid가 length >= 1로 설정되어 절대 true가 될 수 없었음 */}
+            {formData.islandName && (
               <p className="text-sm mt-1 text-gray-500">
                 &quot;{formData.islandName}{formData.islandSuffix}&quot;(으)로 저장됩니다.
               </p>


### PR DESCRIPTION
## Summary

CodeRabbit PR #78 리뷰에서 제안된 프론트엔드 UX 및 코드 품질 개선 사항을 반영했습니다.

## Changes

### 1. 키워드 알림 30개 제한 클라이언트 가드 추가
- **파일**: `apps/web/src/app/keyword-alarm/page.tsx`
- **변경 내용**: 서버 요청 전 클라이언트에서 30개 제한을 선제 검증
- **효과**: 불필요한 서버 요청 방지 및 즉각적인 사용자 피드백 제공

```tsx
// Before: 서버에서만 30개 제한 검증
// After: 클라이언트에서 선제 검증 후 서버 요청
if (keywords.length >= 30) {
  setSubmitError("키워드는 최대 30개까지 등록할 수 있습니다.");
  return;
}
```

### 2. profile/edit dead code 제거
- **파일**: `apps/web/src/app/profile/edit/page.tsx`
- **변경 내용**: 절대로 실행되지 않는 조건부 렌더링 코드 제거
- **이유**: `isIslandNameValid`가 `formData.islandName.length >= 1`로 설정되므로, `formData.islandName && !isIslandNameValid` 조건은 논리적으로 항상 false

```tsx
// Before (dead code):
{formData.islandName && !isIslandNameValid && (
  <p className="text-sm mt-1 text-red-500">
    * 1자 이상 입력해주세요.
  </p>
)}
{formData.islandName && isIslandNameValid && (
  <p>...</p>
)}

// After (simplified):
{formData.islandName && (
  <p>...</p>
)}
```

## Test Plan

- [ ] 키워드 알림 페이지에서 30개 키워드 등록 후 추가 시도 → 에러 메시지 표시 확인
- [ ] 프로필 수정 페이지에서 섬 이름 입력 → 정상적으로 저장 메시지 표시 확인
- [ ] 기존 기능 정상 동작 확인 (회귀 테스트)

## Related

- CodeRabbit PR #78 리뷰: https://github.com/AC-trading/ac-trading/pull/78

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 키워드 추가 시 최대 30개 제한 검증 추가
  * 섬 이름 입력 필드의 표시 방식 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->