### PR TITLE
fix: 프론트엔드 데이터 처리 개선 및 race condition 수정

### DIFF
--- a/apps/web/src/app/account-book/page.tsx
+++ b/apps/web/src/app/account-book/page.tsx
@@ -41,10 +41,14 @@ function getDateRange(period: PeriodFilter): { startDate?: string; endDate?: str
       startDate = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
       break;
     case "month":
-      startDate = new Date(now.getFullYear(), now.getMonth() - 1, now.getDate());
+      // CodeRabbit 리뷰 반영: 1일로 고정하여 월말 경계 오버플로우 방지
+      // Before: new Date(now.getFullYear(), now.getMonth() - 1, now.getDate())
+      // 예: 3월 31일 → 2월 31일 → 3월 3일로 오버플로우
+      startDate = new Date(now.getFullYear(), now.getMonth() - 1, 1);
       break;
     case "3months":
-      startDate = new Date(now.getFullYear(), now.getMonth() - 3, now.getDate());
+      // CodeRabbit 리뷰 반영: 1일로 고정하여 월말 경계 오버플로우 방지
+      startDate = new Date(now.getFullYear(), now.getMonth() - 3, 1);
       break;
     default:
       return {};
@@ -103,7 +107,7 @@ function TransactionItem({
           }`}>
             {isSale ? "판매" : "구매"}
           </span>
-          <span className="font-medium text-gray-900">{transaction.postItemName}</span>
+          <span className="font-medium text-gray-900">{transaction.postItemName || '삭제된 게시글'}</span>
         </div>
         <div className="flex items-center gap-2 mt-1">
           <p className="text-xs text-gray-400">

--- a/apps/web/src/app/collection/page.tsx
+++ b/apps/web/src/app/collection/page.tsx
@@ -74,7 +74,11 @@ export default function CollectionPage() {
   const [error, setError] = useState<string | null>(null);
 
   // 탭 변경 시 데이터 로드
+  // CodeRabbit 리뷰 반영: AbortController로 race condition 방지
   useEffect(() => {
+    const controller = new AbortController();
+    let isCancelled = false;
+
     async function loadPosts() {
       // 로그인 필요한 탭 체크
       if ((activeTab === "likes" || activeTab === "my") && !isAuthenticated) {
@@ -86,15 +90,17 @@ export default function CollectionPage() {
         setIsLoading(true);
         setError(null);
 
+        let loadedPosts: Post[] = [];
+
         if (activeTab === "likes") {
           // 관심목록: 서버 API 호출
           const response = await getMyLikes(0, 50);
-          setPosts(response.posts);
+          loadedPosts = response.posts;
         } else if (activeTab === "recent") {
           // 최근 본 글: localStorage에서 ID 목록 조회 후 각 게시글 정보 로드
           const recentIds = getRecentViewedPostIds();
           if (recentIds.length === 0) {
-            setPosts([]);
+            loadedPosts = [];
           } else {
             // 각 게시글 정보를 병렬로 로드 (삭제된 게시글은 제외)
             const postPromises = recentIds.map(async (id) => {
@@ -106,18 +112,31 @@ export default function CollectionPage() {
               }
             });
             const results = await Promise.all(postPromises);
-            setPosts(results.filter((p): p is Post => p !== null));
+            loadedPosts = results.filter((p): p is Post => p !== null);
           }
         } else if (activeTab === "my") {
           // 내 거래글: 서버 API 호출
           const response = await getMyPosts(0, 50);
-          setPosts(response.posts);
+          loadedPosts = response.posts;
+        }
+
+        // 요청이 취소되지 않았을 때만 상태 업데이트
+        if (!isCancelled) {
+          setPosts(loadedPosts);
         }
       } catch (err) {
-        console.error("게시글 로드 실패:", err);
-        setError(err instanceof Error ? err.message : "게시글을 불러오는데 실패했습니다");
+        // AbortError는 정상적인 취소이므로 무시
+        if (err instanceof Error && err.name === "AbortError") {
+          return;
+        }
+        if (!isCancelled) {
+          console.error("게시글 로드 실패:", err);
+          setError(err instanceof Error ? err.message : "게시글을 불러오는데 실패했습니다");
+        }
       } finally {
-        setIsLoading(false);
+        if (!isCancelled) {
+          setIsLoading(false);
+        }
       }
     }
 
@@ -125,6 +144,12 @@ export default function CollectionPage() {
     if (!authLoading) {
       loadPosts();
     }
+
+    // cleanup: 탭 전환 시 이전 요청 취소
+    return () => {
+      isCancelled = true;
+      controller.abort();
+    };
   }, [activeTab, isAuthenticated, authLoading]);
 
   // 최근 본 글 초기화

--- a/apps/web/src/lib/recentPosts.ts
+++ b/apps/web/src/lib/recentPosts.ts
@@ -10,14 +10,36 @@ export interface RecentViewedPost {
 }
 
 /**
+ * RecentViewedPost 타입 가드
+ * CodeRabbit 리뷰 반영: localStorage 데이터 스키마 검증
+ */
+function isValidRecentViewedPost(item: unknown): item is RecentViewedPost {
+  return (
+    typeof item === 'object' &&
+    item !== null &&
+    typeof (item as RecentViewedPost).postId === 'number' &&
+    typeof (item as RecentViewedPost).viewedAt === 'string'
+  );
+}
+
+/**
  * 최근 본 거래글 목록 조회
+ * CodeRabbit 리뷰 반영: 타입 가드로 데이터 스키마 검증
  */
 export function getRecentViewedPosts(): RecentViewedPost[] {
   if (typeof window === 'undefined') return [];
 
   try {
     const data = localStorage.getItem(STORAGE_KEY);
-    return data ? JSON.parse(data) : [];
+    if (!data) return [];
+
+    const parsed = JSON.parse(data);
+
+    // 배열인지 확인
+    if (!Array.isArray(parsed)) return [];
+
+    // 각 항목이 올바른 스키마인지 검증
+    return parsed.filter(isValidRecentViewedPost);
   } catch {
     return [];
   }


### PR DESCRIPTION
## Summary

CodeRabbit PR #78 리뷰에서 제안된 프론트엔드 데이터 처리 개선 사항을 반영했습니다.

## Changes

### 1. account-book 날짜 계산 월말 경계 문제 수정
- **파일**: `apps/web/src/app/account-book/page.tsx`
- **문제**: 월 이동 시 날짜 오버플로우 (3월 31일 → 2월 31일 → 3월 3일)
- **해결**: 월 이동 시 1일로 고정

```tsx
// Before
new Date(now.getFullYear(), now.getMonth() - 1, now.getDate())
// After
new Date(now.getFullYear(), now.getMonth() - 1, 1)
```

### 2. account-book postItemName null 처리
- **파일**: `apps/web/src/app/account-book/page.tsx`
- **내용**: 삭제된 게시글에 대한 기본값 처리

```tsx
{transaction.postItemName || '삭제된 게시글'}
```

### 3. collection 탭 전환 race condition 방지
- **파일**: `apps/web/src/app/collection/page.tsx`
- **문제**: 빠른 탭 전환 시 이전 응답이 현재 탭 데이터를 덮어씀
- **해결**: AbortController + isCancelled 플래그로 이전 요청 취소

```tsx
useEffect(() => {
  const controller = new AbortController();
  let isCancelled = false;
  // ... fetch logic with isCancelled check
  return () => {
    isCancelled = true;
    controller.abort();
  };
}, [activeTab]);
```

### 4. recentPosts localStorage 데이터 검증
- **파일**: `apps/web/src/lib/recentPosts.ts`
- **내용**: 타입 가드로 데이터 스키마 검증 추가
- 배열 여부 확인
- 각 항목의 `postId`(number), `viewedAt`(string) 타입 검증

## Test Plan

- [ ] account-book: 월말(31일)에 1개월/3개월 필터 적용 시 정상 동작 확인
- [ ] account-book: 삭제된 게시글의 거래 기록이 '삭제된 게시글'로 표시되는지 확인
- [ ] collection: 탭을 빠르게 전환해도 올바른 데이터가 표시되는지 확인
- [ ] recentPosts: localStorage에 잘못된 데이터가 있어도 앱이 크래시하지 않는지 확인

## Related

- CodeRabbit PR #78 리뷰

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 월간 및 분기별 거래 내역 조회 시 정확한 기간 계산 개선
* 컬렉션 탭 전환 중 데이터 로딩 충돌 방지 및 상태 관리 개선
* 삭제된 게시글에 대한 기본 텍스트 표시 추가
* 저장된 최근 조회 데이터 검증 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->