### PR TITLE
fix: 백엔드 API 검증 및 예외 처리 개선

### DIFF
--- a/apps/api/src/main/java/com/acnh/api/auth/dto/SocialLoginRequest.java
+++ b/apps/api/src/main/java/com/acnh/api/auth/dto/SocialLoginRequest.java
@@ -1,5 +1,6 @@
 package com.acnh.api.auth.dto;
 
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -25,5 +26,26 @@ public class SocialLoginRequest {
         this.provider = provider;
         this.accessToken = accessToken;
         this.idToken = idToken;
+    }
+
+    /**
+     * CodeRabbit 리뷰 반영: provider별 토큰 필드 검증
+     * - Google: idToken 필수
+     * - Kakao: accessToken 필수
+     */
+    @AssertTrue(message = "Google 로그인은 idToken이 필수입니다.")
+    private boolean isGoogleTokenValid() {
+        if (!"google".equalsIgnoreCase(provider)) {
+            return true;
+        }
+        return idToken != null && !idToken.isBlank();
+    }
+
+    @AssertTrue(message = "Kakao 로그인은 accessToken이 필수입니다.")
+    private boolean isKakaoTokenValid() {
+        if (!"kakao".equalsIgnoreCase(provider)) {
+            return true;
+        }
+        return accessToken != null && !accessToken.isBlank();
     }
 }

--- a/apps/api/src/main/java/com/acnh/api/block/controller/BlockController.java
+++ b/apps/api/src/main/java/com/acnh/api/block/controller/BlockController.java
@@ -36,7 +36,9 @@ public class BlockController {
 
         log.info("차단 요청 - blockedUserId: {}, visitorId: {}", request.getBlockedUserId(), visitorId);
 
-        if (visitorId == null) {
+        // Before: visitorId == null만 체크
+        // After: "anonymousUser"도 비인증 상태로 처리 (Spring Security 기본값)
+        if (visitorId == null || "anonymousUser".equals(visitorId)) {
             return ResponseEntity.status(401).body(Map.of(
                     "error", "UNAUTHORIZED",
                     "message", "로그인이 필요합니다"
@@ -59,7 +61,9 @@ public class BlockController {
 
         log.info("차단 해제 요청 - blockedUserId: {}, visitorId: {}", blockedUserId, visitorId);
 
-        if (visitorId == null) {
+        // Before: visitorId == null만 체크
+        // After: "anonymousUser"도 비인증 상태로 처리 (Spring Security 기본값)
+        if (visitorId == null || "anonymousUser".equals(visitorId)) {
             return ResponseEntity.status(401).body(Map.of(
                     "error", "UNAUTHORIZED",
                     "message", "로그인이 필요합니다"
@@ -83,7 +87,9 @@ public class BlockController {
 
         log.info("차단 목록 조회 요청 - visitorId: {}", visitorId);
 
-        if (visitorId == null) {
+        // Before: visitorId == null만 체크
+        // After: "anonymousUser"도 비인증 상태로 처리 (Spring Security 기본값)
+        if (visitorId == null || "anonymousUser".equals(visitorId)) {
             return ResponseEntity.status(401).body(Map.of(
                     "error", "UNAUTHORIZED",
                     "message", "로그인이 필요합니다"

--- a/apps/api/src/main/java/com/acnh/api/block/controller/BlockController.java
+++ b/apps/api/src/main/java/com/acnh/api/block/controller/BlockController.java
@@ -43,21 +43,9 @@ public class BlockController {
             ));
         }
 
-        try {
-            BlockResponse response = blockService.blockUser(request, visitorId);
-            return ResponseEntity.status(201).body(response);
-        } catch (IllegalArgumentException e) {
-            if (e.getMessage().contains("존재하지 않는")) {
-                return ResponseEntity.status(404).body(Map.of(
-                        "error", "NOT_FOUND",
-                        "message", e.getMessage()
-                ));
-            }
-            return ResponseEntity.badRequest().body(Map.of(
-                    "error", "INVALID_REQUEST",
-                    "message", e.getMessage()
-            ));
-        }
+        // GlobalExceptionHandler가 NotFoundException/InvalidRequestException 처리
+        BlockResponse response = blockService.blockUser(request, visitorId);
+        return ResponseEntity.status(201).body(response);
     }
 
     /**
@@ -78,23 +66,11 @@ public class BlockController {
             ));
         }
 
-        try {
-            blockService.unblockUser(blockedUserId, visitorId);
-            return ResponseEntity.ok(Map.of(
-                    "message", "차단이 해제되었습니다"
-            ));
-        } catch (IllegalArgumentException e) {
-            if (e.getMessage().contains("존재하지 않는") || e.getMessage().contains("차단 내역")) {
-                return ResponseEntity.status(404).body(Map.of(
-                        "error", "NOT_FOUND",
-                        "message", e.getMessage()
-                ));
-            }
-            return ResponseEntity.badRequest().body(Map.of(
-                    "error", "INVALID_REQUEST",
-                    "message", e.getMessage()
-            ));
-        }
+        // GlobalExceptionHandler가 NotFoundException/InvalidRequestException 처리
+        blockService.unblockUser(blockedUserId, visitorId);
+        return ResponseEntity.ok(Map.of(
+                "message", "차단이 해제되었습니다"
+        ));
     }
 
     /**
@@ -114,14 +90,8 @@ public class BlockController {
             ));
         }
 
-        try {
-            BlockListResponse response = blockService.getBlockedUsers(visitorId);
-            return ResponseEntity.ok(response);
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.status(404).body(Map.of(
-                    "error", "NOT_FOUND",
-                    "message", e.getMessage()
-            ));
-        }
+        // GlobalExceptionHandler가 NotFoundException/InvalidRequestException 처리
+        BlockListResponse response = blockService.getBlockedUsers(visitorId);
+        return ResponseEntity.ok(response);
     }
 }

--- a/apps/api/src/main/java/com/acnh/api/block/service/BlockService.java
+++ b/apps/api/src/main/java/com/acnh/api/block/service/BlockService.java
@@ -5,6 +5,8 @@ import com.acnh.api.block.dto.BlockRequest;
 import com.acnh.api.block.dto.BlockResponse;
 import com.acnh.api.block.entity.Block;
 import com.acnh.api.block.repository.BlockRepository;
+import com.acnh.api.common.exception.InvalidRequestException;
+import com.acnh.api.common.exception.NotFoundException;
 import com.acnh.api.member.entity.Member;
 import com.acnh.api.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -41,12 +43,12 @@ public class BlockService {
 
         // 자기 자신 차단 불가
         if (blocker.getId().equals(blocked.getId())) {
-            throw new IllegalArgumentException("자기 자신을 차단할 수 없습니다");
+            throw new InvalidRequestException("자기 자신을 차단할 수 없습니다");
         }
 
         // 이미 차단된 사용자인지 확인
         if (blockRepository.existsByBlockerIdAndBlockedIdAndDeletedAtIsNull(blocker.getId(), blocked.getId())) {
-            throw new IllegalArgumentException("이미 차단한 사용자입니다");
+            throw new InvalidRequestException("이미 차단한 사용자입니다");
         }
 
         Block block = Block.builder()
@@ -71,7 +73,7 @@ public class BlockService {
 
         // 자기 자신 차단 불가
         if (blocker.getId().equals(blocked.getId())) {
-            throw new IllegalArgumentException("자기 자신을 차단할 수 없습니다");
+            throw new InvalidRequestException("자기 자신을 차단할 수 없습니다");
         }
 
         // 이미 차단된 사용자인지 확인 - 이미 차단된 경우 그냥 반환
@@ -100,7 +102,7 @@ public class BlockService {
         Member blocker = findMemberByUuid(visitorId);
 
         Block block = blockRepository.findByBlockerIdAndBlockedIdAndDeletedAtIsNull(blocker.getId(), blockedUserId)
-                .orElseThrow(() -> new IllegalArgumentException("차단 내역이 존재하지 않습니다"));
+                .orElseThrow(() -> new NotFoundException("차단 내역", blockedUserId));
 
         block.delete();
         log.info("차단 해제 - blockerId: {}, blockedId: {}", blocker.getId(), blockedUserId);
@@ -160,14 +162,23 @@ public class BlockService {
      */
     private Member findMemberByUuid(String visitorId) {
         if (visitorId == null || "anonymousUser".equals(visitorId)) {
-            throw new IllegalArgumentException("로그인이 필요합니다");
+            throw new InvalidRequestException("로그인이 필요합니다");
         }
-        return memberRepository.findByUuidAndDeletedAtIsNull(UUID.fromString(visitorId))
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다"));
+
+        // UUID 파싱 실패 시 원본 예외 메시지 노출 방지
+        UUID uuid;
+        try {
+            uuid = UUID.fromString(visitorId);
+        } catch (IllegalArgumentException e) {
+            throw new InvalidRequestException("로그인이 필요합니다");
+        }
+
+        return memberRepository.findByUuidAndDeletedAtIsNull(uuid)
+                .orElseThrow(() -> new NotFoundException("사용자", visitorId));
     }
 
     private Member findMemberById(Long memberId) {
         return memberRepository.findByIdAndDeletedAtIsNull(memberId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다"));
+                .orElseThrow(() -> new NotFoundException("사용자", memberId));
     }
 }

--- a/apps/api/src/main/java/com/acnh/api/chat/controller/ChatController.java
+++ b/apps/api/src/main/java/com/acnh/api/chat/controller/ChatController.java
@@ -48,21 +48,9 @@ public class ChatController {
             ));
         }
 
-        try {
-            ChatRoomResponse response = chatService.createOrGetChatRoom(request, visitorId);
-            return ResponseEntity.ok(response);
-        } catch (IllegalArgumentException e) {
-            if (e.getMessage().contains("존재하지 않는")) {
-                return ResponseEntity.status(404).body(Map.of(
-                        "error", "NOT_FOUND",
-                        "message", e.getMessage()
-                ));
-            }
-            return ResponseEntity.badRequest().body(Map.of(
-                    "error", "INVALID_REQUEST",
-                    "message", e.getMessage()
-            ));
-        }
+        // GlobalExceptionHandler가 NotFoundException/InvalidRequestException 처리
+        ChatRoomResponse response = chatService.createOrGetChatRoom(request, visitorId);
+        return ResponseEntity.ok(response);
     }
 
     /**
@@ -84,16 +72,10 @@ public class ChatController {
             ));
         }
 
-        try {
-            Pageable pageable = PageRequest.of(page, Math.min(size, DEFAULT_PAGE_SIZE));
-            ChatRoomListResponse response = chatService.getMyChatRooms(visitorId, pageable);
-            return ResponseEntity.ok(response);
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.status(404).body(Map.of(
-                    "error", "NOT_FOUND",
-                    "message", e.getMessage()
-            ));
-        }
+        // GlobalExceptionHandler가 NotFoundException/InvalidRequestException 처리
+        Pageable pageable = PageRequest.of(page, Math.min(size, DEFAULT_PAGE_SIZE));
+        ChatRoomListResponse response = chatService.getMyChatRooms(visitorId, pageable);
+        return ResponseEntity.ok(response);
     }
 
     /**
@@ -114,21 +96,9 @@ public class ChatController {
             ));
         }
 
-        try {
-            ChatRoomResponse response = chatService.getChatRoom(roomId, visitorId);
-            return ResponseEntity.ok(response);
-        } catch (IllegalArgumentException e) {
-            if (e.getMessage().contains("존재하지 않는") || e.getMessage().contains("접근 권한")) {
-                return ResponseEntity.status(404).body(Map.of(
-                        "error", "NOT_FOUND",
-                        "message", e.getMessage()
-                ));
-            }
-            return ResponseEntity.badRequest().body(Map.of(
-                    "error", "INVALID_REQUEST",
-                    "message", e.getMessage()
-            ));
-        }
+        // GlobalExceptionHandler가 NotFoundException/InvalidRequestException 처리
+        ChatRoomResponse response = chatService.getChatRoom(roomId, visitorId);
+        return ResponseEntity.ok(response);
     }
 
     /**
@@ -149,21 +119,9 @@ public class ChatController {
             ));
         }
 
-        try {
-            List<ChatMessageResponse> response = chatService.getMessages(roomId, visitorId);
-            return ResponseEntity.ok(response);
-        } catch (IllegalArgumentException e) {
-            if (e.getMessage().contains("존재하지 않는") || e.getMessage().contains("접근 권한")) {
-                return ResponseEntity.status(404).body(Map.of(
-                        "error", "NOT_FOUND",
-                        "message", e.getMessage()
-                ));
-            }
-            return ResponseEntity.badRequest().body(Map.of(
-                    "error", "INVALID_REQUEST",
-                    "message", e.getMessage()
-            ));
-        }
+        // GlobalExceptionHandler가 NotFoundException/InvalidRequestException 처리
+        List<ChatMessageResponse> response = chatService.getMessages(roomId, visitorId);
+        return ResponseEntity.ok(response);
     }
 
     /**
@@ -185,22 +143,10 @@ public class ChatController {
             ));
         }
 
-        try {
-            var scheduledAt = request != null ? request.getScheduledTradeAt() : null;
-            ChatRoomResponse response = chatService.reserveChatRoom(roomId, visitorId, scheduledAt);
-            return ResponseEntity.ok(response);
-        } catch (IllegalArgumentException e) {
-            if (e.getMessage().contains("존재하지 않는")) {
-                return ResponseEntity.status(404).body(Map.of(
-                        "error", "NOT_FOUND",
-                        "message", e.getMessage()
-                ));
-            }
-            return ResponseEntity.badRequest().body(Map.of(
-                    "error", "INVALID_REQUEST",
-                    "message", e.getMessage()
-            ));
-        }
+        // GlobalExceptionHandler가 NotFoundException/InvalidRequestException 처리
+        var scheduledAt = request != null ? request.getScheduledTradeAt() : null;
+        ChatRoomResponse response = chatService.reserveChatRoom(roomId, visitorId, scheduledAt);
+        return ResponseEntity.ok(response);
     }
 
     /**
@@ -221,21 +167,9 @@ public class ChatController {
             ));
         }
 
-        try {
-            ChatRoomResponse response = chatService.unreserveChatRoom(roomId, visitorId);
-            return ResponseEntity.ok(response);
-        } catch (IllegalArgumentException e) {
-            if (e.getMessage().contains("존재하지 않는")) {
-                return ResponseEntity.status(404).body(Map.of(
-                        "error", "NOT_FOUND",
-                        "message", e.getMessage()
-                ));
-            }
-            return ResponseEntity.badRequest().body(Map.of(
-                    "error", "INVALID_REQUEST",
-                    "message", e.getMessage()
-            ));
-        }
+        // GlobalExceptionHandler가 NotFoundException/InvalidRequestException 처리
+        ChatRoomResponse response = chatService.unreserveChatRoom(roomId, visitorId);
+        return ResponseEntity.ok(response);
     }
 
     /**
@@ -256,21 +190,9 @@ public class ChatController {
             ));
         }
 
-        try {
-            ChatRoomResponse response = chatService.completeTrade(roomId, visitorId);
-            return ResponseEntity.ok(response);
-        } catch (IllegalArgumentException e) {
-            if (e.getMessage().contains("존재하지 않는")) {
-                return ResponseEntity.status(404).body(Map.of(
-                        "error", "NOT_FOUND",
-                        "message", e.getMessage()
-                ));
-            }
-            return ResponseEntity.badRequest().body(Map.of(
-                    "error", "INVALID_REQUEST",
-                    "message", e.getMessage()
-            ));
-        }
+        // GlobalExceptionHandler가 NotFoundException/InvalidRequestException 처리
+        ChatRoomResponse response = chatService.completeTrade(roomId, visitorId);
+        return ResponseEntity.ok(response);
     }
 
     /**
@@ -291,22 +213,10 @@ public class ChatController {
             ));
         }
 
-        try {
-            chatService.leaveChatRoom(roomId, visitorId);
-            return ResponseEntity.ok(Map.of(
-                    "message", "채팅방을 나갔습니다"
-            ));
-        } catch (IllegalArgumentException e) {
-            if (e.getMessage().contains("존재하지 않는") || e.getMessage().contains("접근 권한")) {
-                return ResponseEntity.status(404).body(Map.of(
-                        "error", "NOT_FOUND",
-                        "message", e.getMessage()
-                ));
-            }
-            return ResponseEntity.badRequest().body(Map.of(
-                    "error", "INVALID_REQUEST",
-                    "message", e.getMessage()
-            ));
-        }
+        // GlobalExceptionHandler가 NotFoundException/InvalidRequestException 처리
+        chatService.leaveChatRoom(roomId, visitorId);
+        return ResponseEntity.ok(Map.of(
+                "message", "채팅방을 나갔습니다"
+        ));
     }
 }

--- a/apps/api/src/main/java/com/acnh/api/chat/controller/ChatController.java
+++ b/apps/api/src/main/java/com/acnh/api/chat/controller/ChatController.java
@@ -41,7 +41,9 @@ public class ChatController {
 
         log.info("채팅방 생성 요청 - postId: {}, visitorId: {}", request.getPostId(), visitorId);
 
-        if (visitorId == null) {
+        // Before: visitorId == null만 체크
+        // After: "anonymousUser"도 비인증 상태로 처리 (Spring Security 기본값)
+        if (visitorId == null || "anonymousUser".equals(visitorId)) {
             return ResponseEntity.status(401).body(Map.of(
                     "error", "UNAUTHORIZED",
                     "message", "로그인이 필요합니다"
@@ -65,7 +67,9 @@ public class ChatController {
 
         log.info("채팅방 목록 조회 요청 - visitorId: {}, page: {}, size: {}", visitorId, page, size);
 
-        if (visitorId == null) {
+        // Before: visitorId == null만 체크
+        // After: "anonymousUser"도 비인증 상태로 처리 (Spring Security 기본값)
+        if (visitorId == null || "anonymousUser".equals(visitorId)) {
             return ResponseEntity.status(401).body(Map.of(
                     "error", "UNAUTHORIZED",
                     "message", "로그인이 필요합니다"
@@ -89,7 +93,9 @@ public class ChatController {
 
         log.info("채팅방 상세 조회 요청 - roomId: {}, visitorId: {}", roomId, visitorId);
 
-        if (visitorId == null) {
+        // Before: visitorId == null만 체크
+        // After: "anonymousUser"도 비인증 상태로 처리 (Spring Security 기본값)
+        if (visitorId == null || "anonymousUser".equals(visitorId)) {
             return ResponseEntity.status(401).body(Map.of(
                     "error", "UNAUTHORIZED",
                     "message", "로그인이 필요합니다"
@@ -112,7 +118,9 @@ public class ChatController {
 
         log.info("메시지 목록 조회 요청 - roomId: {}, visitorId: {}", roomId, visitorId);
 
-        if (visitorId == null) {
+        // Before: visitorId == null만 체크
+        // After: "anonymousUser"도 비인증 상태로 처리 (Spring Security 기본값)
+        if (visitorId == null || "anonymousUser".equals(visitorId)) {
             return ResponseEntity.status(401).body(Map.of(
                     "error", "UNAUTHORIZED",
                     "message", "로그인이 필요합니다"
@@ -136,7 +144,9 @@ public class ChatController {
 
         log.info("예약자 지정 요청 - roomId: {}, visitorId: {}", roomId, visitorId);
 
-        if (visitorId == null) {
+        // Before: visitorId == null만 체크
+        // After: "anonymousUser"도 비인증 상태로 처리 (Spring Security 기본값)
+        if (visitorId == null || "anonymousUser".equals(visitorId)) {
             return ResponseEntity.status(401).body(Map.of(
                     "error", "UNAUTHORIZED",
                     "message", "로그인이 필요합니다"
@@ -160,7 +170,9 @@ public class ChatController {
 
         log.info("예약 해제 요청 - roomId: {}, visitorId: {}", roomId, visitorId);
 
-        if (visitorId == null) {
+        // Before: visitorId == null만 체크
+        // After: "anonymousUser"도 비인증 상태로 처리 (Spring Security 기본값)
+        if (visitorId == null || "anonymousUser".equals(visitorId)) {
             return ResponseEntity.status(401).body(Map.of(
                     "error", "UNAUTHORIZED",
                     "message", "로그인이 필요합니다"
@@ -183,7 +195,9 @@ public class ChatController {
 
         log.info("거래 완료 요청 - roomId: {}, visitorId: {}", roomId, visitorId);
 
-        if (visitorId == null) {
+        // Before: visitorId == null만 체크
+        // After: "anonymousUser"도 비인증 상태로 처리 (Spring Security 기본값)
+        if (visitorId == null || "anonymousUser".equals(visitorId)) {
             return ResponseEntity.status(401).body(Map.of(
                     "error", "UNAUTHORIZED",
                     "message", "로그인이 필요합니다"
@@ -206,7 +220,9 @@ public class ChatController {
 
         log.info("채팅방 나가기 요청 - roomId: {}, visitorId: {}", roomId, visitorId);
 
-        if (visitorId == null) {
+        // Before: visitorId == null만 체크
+        // After: "anonymousUser"도 비인증 상태로 처리 (Spring Security 기본값)
+        if (visitorId == null || "anonymousUser".equals(visitorId)) {
             return ResponseEntity.status(401).body(Map.of(
                     "error", "UNAUTHORIZED",
                     "message", "로그인이 필요합니다"

--- a/apps/api/src/main/java/com/acnh/api/chat/service/ChatService.java
+++ b/apps/api/src/main/java/com/acnh/api/chat/service/ChatService.java
@@ -5,6 +5,8 @@ import com.acnh.api.chat.entity.ChatMessage;
 import com.acnh.api.chat.entity.ChatRoom;
 import com.acnh.api.chat.repository.ChatMessageRepository;
 import com.acnh.api.chat.repository.ChatRoomRepository;
+import com.acnh.api.common.exception.InvalidRequestException;
+import com.acnh.api.common.exception.NotFoundException;
 import com.acnh.api.filter.ProfanityFilter;
 import com.acnh.api.member.entity.Member;
 import com.acnh.api.member.repository.MemberRepository;
@@ -49,7 +51,7 @@ public class ChatService {
 
         // 자기 게시글에는 채팅방 생성 불가
         if (post.getUserId().equals(member.getId())) {
-            throw new IllegalArgumentException("본인 게시글에는 채팅을 시작할 수 없습니다");
+            throw new InvalidRequestException("본인 게시글에는 채팅을 시작할 수 없습니다");
         }
 
         // 기존 채팅방이 있으면 반환
@@ -283,7 +285,7 @@ public class ChatService {
      */
     public Member findMemberById(Long memberId) {
         return memberRepository.findByIdAndDeletedAtIsNull(memberId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다"));
+                .orElseThrow(() -> new NotFoundException("사용자", memberId));
     }
 
     /**
@@ -305,12 +307,12 @@ public class ChatService {
 
         // 게시글 작성자만 예약 가능
         if (!chatRoom.getPostOwnerId().equals(member.getId())) {
-            throw new IllegalArgumentException("게시글 작성자만 예약자를 지정할 수 있습니다");
+            throw new InvalidRequestException("게시글 작성자만 예약자를 지정할 수 있습니다");
         }
 
         // 이미 예약된 경우
         if (chatRoom.getReservedUserId() != null) {
-            throw new IllegalArgumentException("이미 예약된 채팅방입니다");
+            throw new InvalidRequestException("이미 예약된 채팅방입니다");
         }
 
         // 채팅방의 신청자를 예약자로 지정
@@ -333,12 +335,12 @@ public class ChatService {
 
         // 게시글 작성자만 예약 해제 가능
         if (!chatRoom.getPostOwnerId().equals(member.getId())) {
-            throw new IllegalArgumentException("게시글 작성자만 예약을 해제할 수 있습니다");
+            throw new InvalidRequestException("게시글 작성자만 예약을 해제할 수 있습니다");
         }
 
         // 예약되지 않은 경우
         if (chatRoom.getReservedUserId() == null) {
-            throw new IllegalArgumentException("예약되지 않은 채팅방입니다");
+            throw new InvalidRequestException("예약되지 않은 채팅방입니다");
         }
 
         chatRoom.cancelReservation();
@@ -361,12 +363,12 @@ public class ChatService {
 
         // 게시글 작성자만 거래 완료 가능
         if (!chatRoom.getPostOwnerId().equals(member.getId())) {
-            throw new IllegalArgumentException("게시글 작성자만 거래 완료 처리할 수 있습니다");
+            throw new InvalidRequestException("게시글 작성자만 거래 완료 처리할 수 있습니다");
         }
 
         // 예약된 채팅방만 거래 완료 가능
         if (chatRoom.getReservedUserId() == null) {
-            throw new IllegalArgumentException("예약된 채팅방만 거래 완료 처리할 수 있습니다");
+            throw new InvalidRequestException("예약된 채팅방만 거래 완료 처리할 수 있습니다");
         }
 
         chatRoom.updateStatus("COMPLETED");
@@ -408,7 +410,7 @@ public class ChatService {
 
         // 게시글 작성자만 조회 가능
         if (!post.getUserId().equals(member.getId())) {
-            throw new IllegalArgumentException("게시글 작성자만 조회할 수 있습니다");
+            throw new InvalidRequestException("게시글 작성자만 조회할 수 있습니다");
         }
 
         List<ChatRoom> chatRooms = chatRoomRepository.findByPostIdAndDeletedAtIsNull(postId);
@@ -427,10 +429,19 @@ public class ChatService {
      */
     private Member findMemberByUuid(String visitorId) {
         if (visitorId == null || "anonymousUser".equals(visitorId)) {
-            throw new IllegalArgumentException("로그인이 필요합니다");
+            throw new InvalidRequestException("로그인이 필요합니다");
         }
-        return memberRepository.findByUuidAndDeletedAtIsNull(UUID.fromString(visitorId))
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다"));
+
+        // UUID 파싱 실패 시 원본 예외 메시지 노출 방지
+        UUID uuid;
+        try {
+            uuid = UUID.fromString(visitorId);
+        } catch (IllegalArgumentException e) {
+            throw new InvalidRequestException("로그인이 필요합니다");
+        }
+
+        return memberRepository.findByUuidAndDeletedAtIsNull(uuid)
+                .orElseThrow(() -> new NotFoundException("사용자", visitorId));
     }
 
     /**
@@ -438,7 +449,7 @@ public class ChatService {
      */
     private Post findPostById(Long postId) {
         return postRepository.findByIdAndDeletedAtIsNull(postId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글입니다"));
+                .orElseThrow(() -> new NotFoundException("게시글", postId));
     }
 
     /**
@@ -446,7 +457,7 @@ public class ChatService {
      */
     private ChatRoom findChatRoomById(Long roomId) {
         return chatRoomRepository.findByIdAndDeletedAtIsNull(roomId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 채팅방입니다"));
+                .orElseThrow(() -> new NotFoundException("채팅방", roomId));
     }
 
     /**
@@ -454,7 +465,7 @@ public class ChatService {
      */
     private void validateParticipant(ChatRoom chatRoom, Long userId) {
         if (!chatRoom.getPostOwnerId().equals(userId) && !chatRoom.getApplicantId().equals(userId)) {
-            throw new IllegalArgumentException("채팅방에 접근 권한이 없습니다");
+            throw new InvalidRequestException("채팅방에 접근 권한이 없습니다");
         }
     }
 

--- a/apps/api/src/main/java/com/acnh/api/common/exception/GlobalExceptionHandler.java
+++ b/apps/api/src/main/java/com/acnh/api/common/exception/GlobalExceptionHandler.java
@@ -12,10 +12,37 @@ import java.util.Map;
 
 /**
  * 전역 예외 처리
+ * CodeRabbit 리뷰 반영: 커스텀 예외를 사용한 중앙화된 예외 처리
  */
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    /**
+     * 리소스를 찾을 수 없음 예외 처리 (404)
+     */
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity<Map<String, String>> handleNotFoundException(NotFoundException e) {
+        log.warn("리소스 없음: {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(Map.of(
+                        "error", "NOT_FOUND",
+                        "message", e.getMessage() != null ? e.getMessage() : "리소스를 찾을 수 없습니다"
+                ));
+    }
+
+    /**
+     * 잘못된 요청 예외 처리 (400)
+     */
+    @ExceptionHandler(InvalidRequestException.class)
+    public ResponseEntity<Map<String, String>> handleInvalidRequestException(InvalidRequestException e) {
+        log.warn("잘못된 요청: {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(Map.of(
+                        "error", "INVALID_REQUEST",
+                        "message", e.getMessage() != null ? e.getMessage() : "잘못된 요청입니다"
+                ));
+    }
 
     /**
      * 파일 크기 초과 예외 처리
@@ -28,13 +55,13 @@ public class GlobalExceptionHandler {
     }
 
     /**
-     * 잘못된 인자 예외 처리
+     * 잘못된 인자 예외 처리 (하위 호환성 유지)
      */
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<Map<String, String>> handleIllegalArgumentException(IllegalArgumentException e) {
         log.warn("잘못된 요청: {}", e.getMessage());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(Map.of("error", e.getMessage()));
+                .body(Map.of("error", e.getMessage() != null ? e.getMessage() : "잘못된 요청입니다"));
     }
 
     /**

--- a/apps/api/src/main/java/com/acnh/api/common/exception/InvalidRequestException.java
+++ b/apps/api/src/main/java/com/acnh/api/common/exception/InvalidRequestException.java
@@ -1,0 +1,12 @@
+package com.acnh.api.common.exception;
+
+/**
+ * 잘못된 요청일 때 발생하는 예외
+ * HTTP 400 Bad Request로 매핑됨
+ */
+public class InvalidRequestException extends RuntimeException {
+
+    public InvalidRequestException(String message) {
+        super(message);
+    }
+}

--- a/apps/api/src/main/java/com/acnh/api/common/exception/NotFoundException.java
+++ b/apps/api/src/main/java/com/acnh/api/common/exception/NotFoundException.java
@@ -1,0 +1,16 @@
+package com.acnh.api.common.exception;
+
+/**
+ * 리소스를 찾을 수 없을 때 발생하는 예외
+ * HTTP 404 Not Found로 매핑됨
+ */
+public class NotFoundException extends RuntimeException {
+
+    public NotFoundException(String message) {
+        super(message);
+    }
+
+    public NotFoundException(String resourceName, Object id) {
+        super(String.format("%s을(를) 찾을 수 없습니다: %s", resourceName, id));
+    }
+}

--- a/apps/api/src/main/java/com/acnh/api/keywordalarm/controller/KeywordAlarmController.java
+++ b/apps/api/src/main/java/com/acnh/api/keywordalarm/controller/KeywordAlarmController.java
@@ -32,7 +32,9 @@ public class KeywordAlarmController {
     public ResponseEntity<?> getMyKeywords(@AuthenticationPrincipal String visitorId) {
         log.info("키워드 목록 조회 요청 - visitorId: {}", visitorId);
 
-        if (visitorId == null) {
+        // Before: visitorId == null만 체크
+        // After: "anonymousUser"도 비인증 상태로 처리 (Spring Security 기본값)
+        if (visitorId == null || "anonymousUser".equals(visitorId)) {
             return ResponseEntity.status(401).body(Map.of(
                     "error", "UNAUTHORIZED",
                     "message", "로그인이 필요합니다"
@@ -61,7 +63,9 @@ public class KeywordAlarmController {
 
         log.info("키워드 추가 요청 - visitorId: {}, keyword: {}", visitorId, request.getKeyword());
 
-        if (visitorId == null) {
+        // Before: visitorId == null만 체크
+        // After: "anonymousUser"도 비인증 상태로 처리 (Spring Security 기본값)
+        if (visitorId == null || "anonymousUser".equals(visitorId)) {
             return ResponseEntity.status(401).body(Map.of(
                     "error", "UNAUTHORIZED",
                     "message", "로그인이 필요합니다"
@@ -95,7 +99,9 @@ public class KeywordAlarmController {
 
         log.info("키워드 삭제 요청 - visitorId: {}, keywordId: {}", visitorId, id);
 
-        if (visitorId == null) {
+        // Before: visitorId == null만 체크
+        // After: "anonymousUser"도 비인증 상태로 처리 (Spring Security 기본값)
+        if (visitorId == null || "anonymousUser".equals(visitorId)) {
             return ResponseEntity.status(401).body(Map.of(
                     "error", "UNAUTHORIZED",
                     "message", "로그인이 필요합니다"

--- a/apps/api/src/main/java/com/acnh/api/member/controller/MemberController.java
+++ b/apps/api/src/main/java/com/acnh/api/member/controller/MemberController.java
@@ -57,22 +57,9 @@ public class MemberController {
             return ResponseEntity.status(401).build();
         }
 
-        try {
-            MemberProfileResponse response = memberService.updateProfile(visitorId, request);
-            return ResponseEntity.ok(response);
-        } catch (IllegalArgumentException e) {
-            // 회원을 찾을 수 없는 경우
-            return ResponseEntity.status(404).body(Map.of(
-                    "error", "MEMBER_NOT_FOUND",
-                    "message", e.getMessage()
-            ));
-        } catch (IllegalStateException e) {
-            // 24시간 제한 에러
-            return ResponseEntity.badRequest().body(Map.of(
-                    "error", "PROFILE_UPDATE_LIMIT",
-                    "message", e.getMessage()
-            ));
-        }
+        // GlobalExceptionHandler가 NotFoundException/InvalidRequestException 처리
+        MemberProfileResponse response = memberService.updateProfile(visitorId, request);
+        return ResponseEntity.ok(response);
     }
 
     /**
@@ -91,22 +78,9 @@ public class MemberController {
             return ResponseEntity.status(401).build();
         }
 
-        try {
-            MemberProfileResponse response = memberService.setupProfile(visitorId, request);
-            return ResponseEntity.ok(response);
-        } catch (IllegalArgumentException e) {
-            // 회원을 찾을 수 없는 경우
-            return ResponseEntity.status(404).body(Map.of(
-                    "error", "MEMBER_NOT_FOUND",
-                    "message", e.getMessage()
-            ));
-        } catch (IllegalStateException e) {
-            // 이미 프로필이 설정된 경우
-            return ResponseEntity.badRequest().body(Map.of(
-                    "error", "PROFILE_ALREADY_SET",
-                    "message", e.getMessage()
-            ));
-        }
+        // GlobalExceptionHandler가 NotFoundException/InvalidRequestException 처리
+        MemberProfileResponse response = memberService.setupProfile(visitorId, request);
+        return ResponseEntity.ok(response);
     }
 
     /**

--- a/apps/api/src/main/java/com/acnh/api/member/controller/MemberController.java
+++ b/apps/api/src/main/java/com/acnh/api/member/controller/MemberController.java
@@ -34,7 +34,9 @@ public class MemberController {
     public ResponseEntity<MemberProfileResponse> getMyProfile(@AuthenticationPrincipal String visitorId) {
         log.info("내 프로필 조회 요청 - visitorId: {}", visitorId);
 
-        if (visitorId == null) {
+        // Before: visitorId == null만 체크
+        // After: "anonymousUser"도 비인증 상태로 처리 (Spring Security 기본값)
+        if (visitorId == null || "anonymousUser".equals(visitorId)) {
             return ResponseEntity.status(401).build();
         }
 
@@ -53,7 +55,9 @@ public class MemberController {
             @Valid @RequestBody ProfileUpdateRequest request) {
         log.info("프로필 수정 요청 - visitorId: {}", visitorId);
 
-        if (visitorId == null) {
+        // Before: visitorId == null만 체크
+        // After: "anonymousUser"도 비인증 상태로 처리 (Spring Security 기본값)
+        if (visitorId == null || "anonymousUser".equals(visitorId)) {
             return ResponseEntity.status(401).build();
         }
 
@@ -74,7 +78,9 @@ public class MemberController {
             @Valid @RequestBody ProfileSetupRequest request) {
         log.info("프로필 초기 설정 요청 - visitorId: {}", visitorId);
 
-        if (visitorId == null) {
+        // Before: visitorId == null만 체크
+        // After: "anonymousUser"도 비인증 상태로 처리 (Spring Security 기본값)
+        if (visitorId == null || "anonymousUser".equals(visitorId)) {
             return ResponseEntity.status(401).build();
         }
 
@@ -91,7 +97,9 @@ public class MemberController {
     public ResponseEntity<Map<String, String>> deleteAccount(@AuthenticationPrincipal String visitorId) {
         log.info("회원 탈퇴 요청 - visitorId: {}", visitorId);
 
-        if (visitorId == null) {
+        // Before: visitorId == null만 체크
+        // After: "anonymousUser"도 비인증 상태로 처리 (Spring Security 기본값)
+        if (visitorId == null || "anonymousUser".equals(visitorId)) {
             return ResponseEntity.status(401).build();
         }
 
@@ -109,7 +117,9 @@ public class MemberController {
             @PathVariable UUID targetMemberId) {
         log.info("유저 프로필 조회 요청 - visitorId: {}, targetMemberId: {}", visitorId, targetMemberId);
 
-        if (visitorId == null) {
+        // Before: visitorId == null만 체크
+        // After: "anonymousUser"도 비인증 상태로 처리 (Spring Security 기본값)
+        if (visitorId == null || "anonymousUser".equals(visitorId)) {
             return ResponseEntity.status(401).build();
         }
 

--- a/apps/api/src/main/java/com/acnh/api/member/service/MemberService.java
+++ b/apps/api/src/main/java/com/acnh/api/member/service/MemberService.java
@@ -129,7 +129,9 @@ public class MemberService {
             throw new InvalidRequestException("로그인이 필요합니다");
         }
 
+        // Before: NotFoundException에 visitorId(String) 사용
+        // After: 파싱된 uuid(UUID) 변수 사용으로 일관성 유지
         return memberRepository.findByUuidAndDeletedAtIsNull(uuid)
-                .orElseThrow(() -> new NotFoundException("사용자", visitorId));
+                .orElseThrow(() -> new NotFoundException("사용자", uuid));
     }
 }

--- a/apps/api/src/main/java/com/acnh/api/member/service/MemberService.java
+++ b/apps/api/src/main/java/com/acnh/api/member/service/MemberService.java
@@ -1,5 +1,7 @@
 package com.acnh.api.member.service;
 
+import com.acnh.api.common.exception.InvalidRequestException;
+import com.acnh.api.common.exception.NotFoundException;
 import com.acnh.api.member.dto.ProfileSetupRequest;
 import com.acnh.api.member.dto.ProfileUpdateRequest;
 import com.acnh.api.member.dto.MemberProfileResponse;
@@ -40,7 +42,7 @@ public class MemberService {
      */
     public MemberProfileResponse getMemberProfile(UUID targetMemberId) {
         Member member = memberRepository.findByUuidAndDeletedAtIsNull(targetMemberId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다"));
+                .orElseThrow(() -> new NotFoundException("사용자", targetMemberId));
         Long reviewCount = reviewRepository.countByRevieweeIdAndDeletedAtIsNull(member.getId());
         return MemberProfileResponse.from(member, reviewCount);
     }
@@ -56,7 +58,7 @@ public class MemberService {
         // 24시간 제한 체크
         if (!member.canUpdateProfile()) {
             LocalDateTime nextAvailable = member.getNextProfileUpdateAvailableAt();
-            throw new IllegalStateException(
+            throw new InvalidRequestException(
                     String.format("프로필은 24시간에 한 번만 수정할 수 있습니다. 다음 수정 가능 시간: %s", nextAvailable)
             );
         }
@@ -84,7 +86,7 @@ public class MemberService {
 
         // 이미 프로필이 설정된 경우 (기본 닉네임이 아닌 경우) 거부
         if (!member.getNickname().startsWith("섬주민")) {
-            throw new IllegalStateException("이미 프로필이 설정되어 있습니다. 프로필 수정 API를 사용해주세요.");
+            throw new InvalidRequestException("이미 프로필이 설정되어 있습니다. 프로필 수정 API를 사용해주세요.");
         }
 
         member.setupProfile(
@@ -116,9 +118,18 @@ public class MemberService {
      */
     private Member findMemberByUuid(String visitorId) {
         if (visitorId == null || "anonymousUser".equals(visitorId)) {
-            throw new IllegalArgumentException("로그인이 필요합니다");
+            throw new InvalidRequestException("로그인이 필요합니다");
         }
-        return memberRepository.findByUuidAndDeletedAtIsNull(UUID.fromString(visitorId))
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다"));
+
+        // UUID 파싱 실패 시 원본 예외 메시지 노출 방지
+        UUID uuid;
+        try {
+            uuid = UUID.fromString(visitorId);
+        } catch (IllegalArgumentException e) {
+            throw new InvalidRequestException("로그인이 필요합니다");
+        }
+
+        return memberRepository.findByUuidAndDeletedAtIsNull(uuid)
+                .orElseThrow(() -> new NotFoundException("사용자", visitorId));
     }
 }

--- a/apps/api/src/main/java/com/acnh/api/post/controller/LikeController.java
+++ b/apps/api/src/main/java/com/acnh/api/post/controller/LikeController.java
@@ -44,16 +44,10 @@ public class LikeController {
             ));
         }
 
-        try {
-            Pageable pageable = PageRequest.of(page, Math.min(size, DEFAULT_PAGE_SIZE));
-            PostListResponse response = likeService.getMyLikes(visitorId, pageable);
-            return ResponseEntity.ok(response);
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.status(404).body(Map.of(
-                    "error", "NOT_FOUND",
-                    "message", e.getMessage()
-            ));
-        }
+        // GlobalExceptionHandler가 NotFoundException/InvalidRequestException 처리
+        Pageable pageable = PageRequest.of(page, Math.min(size, DEFAULT_PAGE_SIZE));
+        PostListResponse response = likeService.getMyLikes(visitorId, pageable);
+        return ResponseEntity.ok(response);
     }
 
     /**
@@ -74,27 +68,10 @@ public class LikeController {
             ));
         }
 
-        try {
-            LikeResponse response = likeService.likePost(postId, visitorId);
-            return ResponseEntity.ok(response);
-        } catch (IllegalArgumentException e) {
-            if (e.getMessage().contains("존재하지 않는")) {
-                return ResponseEntity.status(404).body(Map.of(
-                        "error", "NOT_FOUND",
-                        "message", e.getMessage()
-                ));
-            }
-            return ResponseEntity.badRequest().body(Map.of(
-                    "error", "INVALID_REQUEST",
-                    "message", e.getMessage()
-            ));
-        } catch (IllegalStateException e) {
-            // 이미 찜한 경우
-            return ResponseEntity.badRequest().body(Map.of(
-                    "error", "ALREADY_LIKED",
-                    "message", e.getMessage()
-            ));
-        }
+        // GlobalExceptionHandler가 NotFoundException/InvalidRequestException 처리
+        // IllegalStateException(이미 찜한 경우)은 RuntimeException 핸들러에서 처리
+        LikeResponse response = likeService.likePost(postId, visitorId);
+        return ResponseEntity.ok(response);
     }
 
     /**
@@ -115,26 +92,9 @@ public class LikeController {
             ));
         }
 
-        try {
-            LikeResponse response = likeService.unlikePost(postId, visitorId);
-            return ResponseEntity.ok(response);
-        } catch (IllegalArgumentException e) {
-            if (e.getMessage().contains("존재하지 않는")) {
-                return ResponseEntity.status(404).body(Map.of(
-                        "error", "NOT_FOUND",
-                        "message", e.getMessage()
-                ));
-            }
-            return ResponseEntity.badRequest().body(Map.of(
-                    "error", "INVALID_REQUEST",
-                    "message", e.getMessage()
-            ));
-        } catch (IllegalStateException e) {
-            // 찜하지 않은 경우
-            return ResponseEntity.badRequest().body(Map.of(
-                    "error", "NOT_LIKED",
-                    "message", e.getMessage()
-            ));
-        }
+        // GlobalExceptionHandler가 NotFoundException/InvalidRequestException 처리
+        // IllegalStateException(찜하지 않은 경우)은 RuntimeException 핸들러에서 처리
+        LikeResponse response = likeService.unlikePost(postId, visitorId);
+        return ResponseEntity.ok(response);
     }
 }

--- a/apps/api/src/main/java/com/acnh/api/post/controller/LikeController.java
+++ b/apps/api/src/main/java/com/acnh/api/post/controller/LikeController.java
@@ -37,7 +37,9 @@ public class LikeController {
 
         log.info("내 찜 목록 조회 요청 - visitorId: {}, page: {}, size: {}", visitorId, page, size);
 
-        if (visitorId == null) {
+        // Before: visitorId == null만 체크
+        // After: "anonymousUser"도 비인증 상태로 처리 (Spring Security 기본값)
+        if (visitorId == null || "anonymousUser".equals(visitorId)) {
             return ResponseEntity.status(401).body(Map.of(
                     "error", "UNAUTHORIZED",
                     "message", "로그인이 필요합니다"
@@ -61,7 +63,9 @@ public class LikeController {
 
         log.info("게시글 찜하기 요청 - postId: {}, visitorId: {}", postId, visitorId);
 
-        if (visitorId == null) {
+        // Before: visitorId == null만 체크
+        // After: "anonymousUser"도 비인증 상태로 처리 (Spring Security 기본값)
+        if (visitorId == null || "anonymousUser".equals(visitorId)) {
             return ResponseEntity.status(401).body(Map.of(
                     "error", "UNAUTHORIZED",
                     "message", "로그인이 필요합니다"
@@ -69,7 +73,7 @@ public class LikeController {
         }
 
         // GlobalExceptionHandler가 NotFoundException/InvalidRequestException 처리
-        // IllegalStateException(이미 찜한 경우)은 RuntimeException 핸들러에서 처리
+        // 이미 찜한 경우 InvalidRequestException(400) 반환
         LikeResponse response = likeService.likePost(postId, visitorId);
         return ResponseEntity.ok(response);
     }
@@ -85,7 +89,9 @@ public class LikeController {
 
         log.info("게시글 찜 취소 요청 - postId: {}, visitorId: {}", postId, visitorId);
 
-        if (visitorId == null) {
+        // Before: visitorId == null만 체크
+        // After: "anonymousUser"도 비인증 상태로 처리 (Spring Security 기본값)
+        if (visitorId == null || "anonymousUser".equals(visitorId)) {
             return ResponseEntity.status(401).body(Map.of(
                     "error", "UNAUTHORIZED",
                     "message", "로그인이 필요합니다"
@@ -93,7 +99,7 @@ public class LikeController {
         }
 
         // GlobalExceptionHandler가 NotFoundException/InvalidRequestException 처리
-        // IllegalStateException(찜하지 않은 경우)은 RuntimeException 핸들러에서 처리
+        // 찜하지 않은 경우 InvalidRequestException(400) 반환
         LikeResponse response = likeService.unlikePost(postId, visitorId);
         return ResponseEntity.ok(response);
     }

--- a/apps/api/src/main/java/com/acnh/api/post/controller/PostController.java
+++ b/apps/api/src/main/java/com/acnh/api/post/controller/PostController.java
@@ -52,16 +52,10 @@ public class PostController {
         log.info("피드 조회 요청 - categoryId: {}, postType: {}, status: {}, currencyType: {}, minPrice: {}, maxPrice: {}, page: {}, size: {}",
                 categoryId, postType, status, currencyType, minPrice, maxPrice, page, size);
 
-        try {
-            Pageable pageable = PageRequest.of(page, Math.min(size, DEFAULT_PAGE_SIZE));
-            PostListResponse response = postService.getFeed(categoryId, postType, status, currencyType, minPrice, maxPrice, visitorId, pageable);
-            return ResponseEntity.ok(response);
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(Map.of(
-                    "error", "INVALID_REQUEST",
-                    "message", e.getMessage()
-            ));
-        }
+        // GlobalExceptionHandler가 NotFoundException/InvalidRequestException 처리
+        Pageable pageable = PageRequest.of(page, Math.min(size, DEFAULT_PAGE_SIZE));
+        PostListResponse response = postService.getFeed(categoryId, postType, status, currencyType, minPrice, maxPrice, visitorId, pageable);
+        return ResponseEntity.ok(response);
     }
 
     /**
@@ -88,16 +82,10 @@ public class PostController {
         log.info("검색 요청 - keyword: {}, categoryId: {}, postType: {}, status: {}, currencyType: {}, minPrice: {}, maxPrice: {}, page: {}, size: {}",
                 keyword, categoryId, postType, status, currencyType, minPrice, maxPrice, page, size);
 
-        try {
-            Pageable pageable = PageRequest.of(page, Math.min(size, DEFAULT_PAGE_SIZE));
-            PostListResponse response = postService.searchPosts(keyword, categoryId, postType, status, currencyType, minPrice, maxPrice, visitorId, pageable);
-            return ResponseEntity.ok(response);
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(Map.of(
-                    "error", "INVALID_REQUEST",
-                    "message", e.getMessage()
-            ));
-        }
+        // GlobalExceptionHandler가 NotFoundException/InvalidRequestException 처리
+        Pageable pageable = PageRequest.of(page, Math.min(size, DEFAULT_PAGE_SIZE));
+        PostListResponse response = postService.searchPosts(keyword, categoryId, postType, status, currencyType, minPrice, maxPrice, visitorId, pageable);
+        return ResponseEntity.ok(response);
     }
 
     /**
@@ -119,16 +107,10 @@ public class PostController {
             ));
         }
 
-        try {
-            Pageable pageable = PageRequest.of(page, Math.min(size, DEFAULT_PAGE_SIZE));
-            PostListResponse response = postService.getMyPosts(visitorId, pageable);
-            return ResponseEntity.ok(response);
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.status(404).body(Map.of(
-                    "error", "NOT_FOUND",
-                    "message", e.getMessage()
-            ));
-        }
+        // GlobalExceptionHandler가 NotFoundException/InvalidRequestException 처리
+        Pageable pageable = PageRequest.of(page, Math.min(size, DEFAULT_PAGE_SIZE));
+        PostListResponse response = postService.getMyPosts(visitorId, pageable);
+        return ResponseEntity.ok(response);
     }
 
     /**
@@ -142,15 +124,9 @@ public class PostController {
 
         log.info("게시글 상세 조회 요청 - postId: {}", postId);
 
-        try {
-            PostResponse response = postService.getPost(postId, visitorId);
-            return ResponseEntity.ok(response);
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.status(404).body(Map.of(
-                    "error", "POST_NOT_FOUND",
-                    "message", e.getMessage()
-            ));
-        }
+        // GlobalExceptionHandler가 NotFoundException 처리
+        PostResponse response = postService.getPost(postId, visitorId);
+        return ResponseEntity.ok(response);
     }
 
     /**
@@ -171,15 +147,9 @@ public class PostController {
             ));
         }
 
-        try {
-            PostResponse response = postService.createPost(request, visitorId);
-            return ResponseEntity.status(201).body(response);
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(Map.of(
-                    "error", "INVALID_REQUEST",
-                    "message", e.getMessage()
-            ));
-        }
+        // GlobalExceptionHandler가 NotFoundException/InvalidRequestException 처리
+        PostResponse response = postService.createPost(request, visitorId);
+        return ResponseEntity.status(201).body(response);
     }
 
     /**
@@ -201,21 +171,9 @@ public class PostController {
             ));
         }
 
-        try {
-            PostResponse response = postService.updatePost(postId, request, visitorId);
-            return ResponseEntity.ok(response);
-        } catch (IllegalArgumentException e) {
-            if (e.getMessage().contains("존재하지 않는")) {
-                return ResponseEntity.status(404).body(Map.of(
-                        "error", "NOT_FOUND",
-                        "message", e.getMessage()
-                ));
-            }
-            return ResponseEntity.badRequest().body(Map.of(
-                    "error", "INVALID_REQUEST",
-                    "message", e.getMessage()
-            ));
-        }
+        // GlobalExceptionHandler가 NotFoundException/InvalidRequestException 처리
+        PostResponse response = postService.updatePost(postId, request, visitorId);
+        return ResponseEntity.ok(response);
     }
 
     /**
@@ -236,21 +194,9 @@ public class PostController {
             ));
         }
 
-        try {
-            postService.deletePost(postId, visitorId);
-            return ResponseEntity.ok(Map.of("message", "게시글이 삭제되었습니다"));
-        } catch (IllegalArgumentException e) {
-            if (e.getMessage().contains("존재하지 않는")) {
-                return ResponseEntity.status(404).body(Map.of(
-                        "error", "POST_NOT_FOUND",
-                        "message", e.getMessage()
-                ));
-            }
-            return ResponseEntity.badRequest().body(Map.of(
-                    "error", "INVALID_REQUEST",
-                    "message", e.getMessage()
-            ));
-        }
+        // GlobalExceptionHandler가 NotFoundException/InvalidRequestException 처리
+        postService.deletePost(postId, visitorId);
+        return ResponseEntity.ok(Map.of("message", "게시글이 삭제되었습니다"));
     }
 
     /**
@@ -272,21 +218,9 @@ public class PostController {
             ));
         }
 
-        try {
-            PostResponse response = postService.updatePostStatus(postId, request, visitorId);
-            return ResponseEntity.ok(response);
-        } catch (IllegalArgumentException e) {
-            if (e.getMessage().contains("존재하지 않는")) {
-                return ResponseEntity.status(404).body(Map.of(
-                        "error", "NOT_FOUND",
-                        "message", e.getMessage()
-                ));
-            }
-            return ResponseEntity.badRequest().body(Map.of(
-                    "error", "INVALID_REQUEST",
-                    "message", e.getMessage()
-            ));
-        }
+        // GlobalExceptionHandler가 NotFoundException/InvalidRequestException 처리
+        PostResponse response = postService.updatePostStatus(postId, request, visitorId);
+        return ResponseEntity.ok(response);
     }
 
     /**
@@ -308,27 +242,10 @@ public class PostController {
             ));
         }
 
-        try {
-            PostResponse response = postService.bumpPost(postId, visitorId);
-            return ResponseEntity.ok(response);
-        } catch (IllegalArgumentException e) {
-            if (e.getMessage().contains("존재하지 않는")) {
-                return ResponseEntity.status(404).body(Map.of(
-                        "error", "NOT_FOUND",
-                        "message", e.getMessage()
-                ));
-            }
-            return ResponseEntity.badRequest().body(Map.of(
-                    "error", "INVALID_REQUEST",
-                    "message", e.getMessage()
-            ));
-        } catch (IllegalStateException e) {
-            // 끌어올리기 제한 에러
-            return ResponseEntity.badRequest().body(Map.of(
-                    "error", "BUMP_LIMIT_EXCEEDED",
-                    "message", e.getMessage()
-            ));
-        }
+        // GlobalExceptionHandler가 NotFoundException/InvalidRequestException 처리
+        // IllegalStateException(끌어올리기 제한)은 RuntimeException 핸들러에서 처리
+        PostResponse response = postService.bumpPost(postId, visitorId);
+        return ResponseEntity.ok(response);
     }
 
     /**
@@ -350,20 +267,8 @@ public class PostController {
             ));
         }
 
-        try {
-            List<ChatRoomResponse> response = chatService.getChatRoomsByPostId(postId, visitorId);
-            return ResponseEntity.ok(response);
-        } catch (IllegalArgumentException e) {
-            if (e.getMessage().contains("존재하지 않는")) {
-                return ResponseEntity.status(404).body(Map.of(
-                        "error", "NOT_FOUND",
-                        "message", e.getMessage()
-                ));
-            }
-            return ResponseEntity.badRequest().body(Map.of(
-                    "error", "INVALID_REQUEST",
-                    "message", e.getMessage()
-            ));
-        }
+        // GlobalExceptionHandler가 NotFoundException/InvalidRequestException 처리
+        List<ChatRoomResponse> response = chatService.getChatRoomsByPostId(postId, visitorId);
+        return ResponseEntity.ok(response);
     }
 }

--- a/apps/api/src/main/java/com/acnh/api/post/controller/PostController.java
+++ b/apps/api/src/main/java/com/acnh/api/post/controller/PostController.java
@@ -100,7 +100,9 @@ public class PostController {
 
         log.info("내 게시글 조회 요청 - visitorId: {}", visitorId);
 
-        if (visitorId == null) {
+        // Before: visitorId == null만 체크
+        // After: "anonymousUser"도 비인증 상태로 처리 (Spring Security 기본값)
+        if (visitorId == null || "anonymousUser".equals(visitorId)) {
             return ResponseEntity.status(401).body(Map.of(
                     "error", "UNAUTHORIZED",
                     "message", "로그인이 필요합니다"
@@ -140,7 +142,9 @@ public class PostController {
 
         log.info("게시글 작성 요청 - visitorId: {}", visitorId);
 
-        if (visitorId == null) {
+        // Before: visitorId == null만 체크
+        // After: "anonymousUser"도 비인증 상태로 처리 (Spring Security 기본값)
+        if (visitorId == null || "anonymousUser".equals(visitorId)) {
             return ResponseEntity.status(401).body(Map.of(
                     "error", "UNAUTHORIZED",
                     "message", "로그인이 필요합니다"
@@ -164,7 +168,9 @@ public class PostController {
 
         log.info("게시글 수정 요청 - postId: {}, visitorId: {}", postId, visitorId);
 
-        if (visitorId == null) {
+        // Before: visitorId == null만 체크
+        // After: "anonymousUser"도 비인증 상태로 처리 (Spring Security 기본값)
+        if (visitorId == null || "anonymousUser".equals(visitorId)) {
             return ResponseEntity.status(401).body(Map.of(
                     "error", "UNAUTHORIZED",
                     "message", "로그인이 필요합니다"
@@ -187,7 +193,9 @@ public class PostController {
 
         log.info("게시글 삭제 요청 - postId: {}, visitorId: {}", postId, visitorId);
 
-        if (visitorId == null) {
+        // Before: visitorId == null만 체크
+        // After: "anonymousUser"도 비인증 상태로 처리 (Spring Security 기본값)
+        if (visitorId == null || "anonymousUser".equals(visitorId)) {
             return ResponseEntity.status(401).body(Map.of(
                     "error", "UNAUTHORIZED",
                     "message", "로그인이 필요합니다"
@@ -211,7 +219,9 @@ public class PostController {
 
         log.info("게시글 상태 변경 요청 - postId: {}, status: {}, visitorId: {}", postId, request.getStatus(), visitorId);
 
-        if (visitorId == null) {
+        // Before: visitorId == null만 체크
+        // After: "anonymousUser"도 비인증 상태로 처리 (Spring Security 기본값)
+        if (visitorId == null || "anonymousUser".equals(visitorId)) {
             return ResponseEntity.status(401).body(Map.of(
                     "error", "UNAUTHORIZED",
                     "message", "로그인이 필요합니다"
@@ -235,7 +245,9 @@ public class PostController {
 
         log.info("게시글 끌어올리기 요청 - postId: {}, visitorId: {}", postId, visitorId);
 
-        if (visitorId == null) {
+        // Before: visitorId == null만 체크
+        // After: "anonymousUser"도 비인증 상태로 처리 (Spring Security 기본값)
+        if (visitorId == null || "anonymousUser".equals(visitorId)) {
             return ResponseEntity.status(401).body(Map.of(
                     "error", "UNAUTHORIZED",
                     "message", "로그인이 필요합니다"
@@ -260,7 +272,9 @@ public class PostController {
 
         log.info("게시글별 채팅방 목록 조회 요청 - postId: {}, visitorId: {}", postId, visitorId);
 
-        if (visitorId == null) {
+        // Before: visitorId == null만 체크
+        // After: "anonymousUser"도 비인증 상태로 처리 (Spring Security 기본값)
+        if (visitorId == null || "anonymousUser".equals(visitorId)) {
             return ResponseEntity.status(401).body(Map.of(
                     "error", "UNAUTHORIZED",
                     "message", "로그인이 필요합니다"

--- a/apps/api/src/main/java/com/acnh/api/post/controller/PostController.java
+++ b/apps/api/src/main/java/com/acnh/api/post/controller/PostController.java
@@ -255,7 +255,7 @@ public class PostController {
         }
 
         // GlobalExceptionHandler가 NotFoundException/InvalidRequestException 처리
-        // IllegalStateException(끌어올리기 제한)은 RuntimeException 핸들러에서 처리
+        // 끌어올리기 제한 시 InvalidRequestException(400) 반환
         PostResponse response = postService.bumpPost(postId, visitorId);
         return ResponseEntity.ok(response);
     }

--- a/apps/api/src/main/java/com/acnh/api/post/service/LikeService.java
+++ b/apps/api/src/main/java/com/acnh/api/post/service/LikeService.java
@@ -2,6 +2,8 @@ package com.acnh.api.post.service;
 
 import com.acnh.api.category.entity.Category;
 import com.acnh.api.category.repository.CategoryRepository;
+import com.acnh.api.common.exception.InvalidRequestException;
+import com.acnh.api.common.exception.NotFoundException;
 import com.acnh.api.member.entity.Member;
 import com.acnh.api.member.repository.MemberRepository;
 import com.acnh.api.post.dto.LikeResponse;
@@ -130,10 +132,10 @@ public class LikeService {
      */
     private Member findMemberByUuid(String visitorId) {
         if (visitorId == null || "anonymousUser".equals(visitorId)) {
-            throw new IllegalArgumentException("로그인이 필요합니다");
+            throw new InvalidRequestException("로그인이 필요합니다");
         }
         return memberRepository.findByUuidAndDeletedAtIsNull(UUID.fromString(visitorId))
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다"));
+                .orElseThrow(() -> new NotFoundException("사용자", visitorId));
     }
 
     /**
@@ -141,7 +143,7 @@ public class LikeService {
      */
     private Post findPostById(Long postId) {
         return postRepository.findByIdAndDeletedAtIsNull(postId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글입니다"));
+                .orElseThrow(() -> new NotFoundException("게시글", postId));
     }
 
     /**

--- a/apps/api/src/main/java/com/acnh/api/post/service/LikeService.java
+++ b/apps/api/src/main/java/com/acnh/api/post/service/LikeService.java
@@ -75,8 +75,10 @@ public class LikeService {
         Post post = findPostById(postId);
 
         // 이미 찜한 경우 체크
+        // Before: IllegalStateException → GlobalExceptionHandler에서 500으로 처리됨
+        // After: InvalidRequestException → GlobalExceptionHandler에서 400으로 처리됨
         if (postLikeRepository.existsByPostIdAndUserIdAndDeletedAtIsNull(postId, member.getId())) {
-            throw new IllegalStateException("이미 찜한 게시글입니다");
+            throw new InvalidRequestException("이미 찜한 게시글입니다");
         }
 
         // 찜 생성
@@ -106,8 +108,10 @@ public class LikeService {
         Post post = findPostById(postId);
 
         // 찜 기록 조회
+        // Before: IllegalStateException → GlobalExceptionHandler에서 500으로 처리됨
+        // After: InvalidRequestException → GlobalExceptionHandler에서 400으로 처리됨
         PostLike like = postLikeRepository.findByPostIdAndUserIdAndDeletedAtIsNull(postId, member.getId())
-                .orElseThrow(() -> new IllegalStateException("찜하지 않은 게시글입니다"));
+                .orElseThrow(() -> new InvalidRequestException("찜하지 않은 게시글입니다"));
 
         // 찜 삭제 (soft delete)
         like.delete();

--- a/apps/api/src/main/java/com/acnh/api/post/service/PostService.java
+++ b/apps/api/src/main/java/com/acnh/api/post/service/PostService.java
@@ -230,8 +230,10 @@ public class PostService {
         LocalDateTime lastBumpOrCreate = post.getBumpedAt() != null ? post.getBumpedAt() : post.getCreatedAt();
         LocalDateTime nextAvailable = lastBumpOrCreate.plusHours(BUMP_LIMIT_HOURS);
 
+        // Before: IllegalStateException → GlobalExceptionHandler에서 500으로 처리됨
+        // After: InvalidRequestException → GlobalExceptionHandler에서 400으로 처리됨
         if (LocalDateTime.now().isBefore(nextAvailable)) {
-            throw new IllegalStateException(
+            throw new InvalidRequestException(
                     String.format("끌어올리기는 %d시간에 한 번만 가능합니다. 다음 가능 시간: %s",
                             BUMP_LIMIT_HOURS, nextAvailable)
             );

--- a/apps/api/src/main/java/com/acnh/api/post/service/PostService.java
+++ b/apps/api/src/main/java/com/acnh/api/post/service/PostService.java
@@ -2,6 +2,8 @@ package com.acnh.api.post.service;
 
 import com.acnh.api.category.entity.Category;
 import com.acnh.api.category.repository.CategoryRepository;
+import com.acnh.api.common.exception.InvalidRequestException;
+import com.acnh.api.common.exception.NotFoundException;
 import com.acnh.api.member.entity.Member;
 import com.acnh.api.member.repository.MemberRepository;
 import com.acnh.api.post.dto.*;
@@ -70,7 +72,7 @@ public class PostService {
                                         String status, String currencyType, Integer minPrice, Integer maxPrice,
                                         String visitorId, Pageable pageable) {
         if (keyword == null || keyword.isBlank()) {
-            throw new IllegalArgumentException("검색어를 입력해주세요");
+            throw new InvalidRequestException("검색어를 입력해주세요");
         }
 
         String validPostType = validatePostType(postType);
@@ -116,7 +118,7 @@ public class PostService {
 
         // 카테고리 존재 확인
         categoryRepository.findByIdAndDeletedAtIsNull(request.getCategoryId())
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 카테고리입니다"));
+                .orElseThrow(() -> new NotFoundException("카테고리", request.getCategoryId()));
 
         // Enum 유효성 검증
         validatePostTypeRequired(request.getPostType());
@@ -155,7 +157,7 @@ public class PostService {
 
         // 카테고리 존재 확인
         categoryRepository.findByIdAndDeletedAtIsNull(request.getCategoryId())
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 카테고리입니다"));
+                .orElseThrow(() -> new NotFoundException("카테고리", request.getCategoryId()));
 
         // Enum 유효성 검증
         validatePostTypeRequired(request.getPostType());
@@ -250,10 +252,10 @@ public class PostService {
      */
     private Member findMemberByUuid(String visitorId) {
         if (visitorId == null || "anonymousUser".equals(visitorId)) {
-            throw new IllegalArgumentException("로그인이 필요합니다");
+            throw new InvalidRequestException("로그인이 필요합니다");
         }
         return memberRepository.findByUuidAndDeletedAtIsNull(UUID.fromString(visitorId))
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다"));
+                .orElseThrow(() -> new NotFoundException("사용자", visitorId));
     }
 
     /**
@@ -261,7 +263,7 @@ public class PostService {
      */
     private Post findPostById(Long postId) {
         return postRepository.findByIdAndDeletedAtIsNull(postId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글입니다"));
+                .orElseThrow(() -> new NotFoundException("게시글", postId));
     }
 
     /**
@@ -283,7 +285,7 @@ public class PostService {
      */
     private void validateOwnership(Post post, Long userId) {
         if (!post.getUserId().equals(userId)) {
-            throw new IllegalArgumentException("본인의 게시글만 수정/삭제할 수 있습니다");
+            throw new InvalidRequestException("본인의 게시글만 수정/삭제할 수 있습니다");
         }
     }
 
@@ -318,7 +320,7 @@ public class PostService {
         try {
             return PostType.valueOf(postType.toUpperCase()).name();
         } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException("유효하지 않은 게시글 유형입니다: " + postType);
+            throw new InvalidRequestException("유효하지 않은 게시글 유형입니다: " + postType);
         }
     }
 
@@ -327,12 +329,12 @@ public class PostService {
      */
     private void validatePostTypeRequired(String postType) {
         if (postType == null || postType.isBlank()) {
-            throw new IllegalArgumentException("게시글 유형은 필수입니다");
+            throw new InvalidRequestException("게시글 유형은 필수입니다");
         }
         try {
             PostType.valueOf(postType.toUpperCase());
         } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException("유효하지 않은 게시글 유형입니다: " + postType);
+            throw new InvalidRequestException("유효하지 않은 게시글 유형입니다: " + postType);
         }
     }
 
@@ -346,7 +348,7 @@ public class PostService {
         try {
             return PostStatus.valueOf(status.toUpperCase()).name();
         } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException("유효하지 않은 상태입니다: " + status);
+            throw new InvalidRequestException("유효하지 않은 상태입니다: " + status);
         }
     }
 
@@ -355,12 +357,12 @@ public class PostService {
      */
     private String validateStatusRequired(String status) {
         if (status == null || status.isBlank()) {
-            throw new IllegalArgumentException("상태는 필수입니다");
+            throw new InvalidRequestException("상태는 필수입니다");
         }
         try {
             return PostStatus.valueOf(status.toUpperCase()).name();
         } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException("유효하지 않은 상태입니다: " + status);
+            throw new InvalidRequestException("유효하지 않은 상태입니다: " + status);
         }
     }
 
@@ -369,12 +371,12 @@ public class PostService {
      */
     private void validateCurrencyType(String currencyType) {
         if (currencyType == null || currencyType.isBlank()) {
-            throw new IllegalArgumentException("화폐 유형은 필수입니다");
+            throw new InvalidRequestException("화폐 유형은 필수입니다");
         }
         try {
             CurrencyType.valueOf(currencyType.toUpperCase());
         } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException("유효하지 않은 화폐 유형입니다: " + currencyType);
+            throw new InvalidRequestException("유효하지 않은 화폐 유형입니다: " + currencyType);
         }
     }
 
@@ -388,7 +390,7 @@ public class PostService {
         try {
             return CurrencyType.valueOf(currencyType.toUpperCase()).name();
         } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException("유효하지 않은 화폐 유형입니다: " + currencyType);
+            throw new InvalidRequestException("유효하지 않은 화폐 유형입니다: " + currencyType);
         }
     }
 }

--- a/apps/api/src/main/java/com/acnh/api/priceoffer/controller/PriceOfferController.java
+++ b/apps/api/src/main/java/com/acnh/api/priceoffer/controller/PriceOfferController.java
@@ -36,7 +36,9 @@ public class PriceOfferController {
 
         log.info("가격 제안 요청 - postId: {}, visitorId: {}", postId, visitorId);
 
-        if (visitorId == null) {
+        // Before: visitorId == null만 체크
+        // After: "anonymousUser"도 비인증 상태로 처리 (Spring Security 기본값)
+        if (visitorId == null || "anonymousUser".equals(visitorId)) {
             return ResponseEntity.status(401).body(Map.of(
                     "error", "UNAUTHORIZED",
                     "message", "로그인이 필요합니다"
@@ -61,7 +63,9 @@ public class PriceOfferController {
 
         log.info("가격 제안 수락 요청 - offerId: {}, visitorId: {}", offerId, visitorId);
 
-        if (visitorId == null) {
+        // Before: visitorId == null만 체크
+        // After: "anonymousUser"도 비인증 상태로 처리 (Spring Security 기본값)
+        if (visitorId == null || "anonymousUser".equals(visitorId)) {
             return ResponseEntity.status(401).body(Map.of(
                     "error", "UNAUTHORIZED",
                     "message", "로그인이 필요합니다"

--- a/apps/api/src/main/java/com/acnh/api/priceoffer/controller/PriceOfferController.java
+++ b/apps/api/src/main/java/com/acnh/api/priceoffer/controller/PriceOfferController.java
@@ -43,21 +43,9 @@ public class PriceOfferController {
             ));
         }
 
-        try {
-            PriceOfferResponse response = priceOfferService.createPriceOffer(postId, request, visitorId);
-            return ResponseEntity.status(201).body(response);
-        } catch (IllegalArgumentException e) {
-            if (e.getMessage().contains("존재하지 않는")) {
-                return ResponseEntity.status(404).body(Map.of(
-                        "error", "NOT_FOUND",
-                        "message", e.getMessage()
-                ));
-            }
-            return ResponseEntity.badRequest().body(Map.of(
-                    "error", "INVALID_REQUEST",
-                    "message", e.getMessage()
-            ));
-        }
+        // GlobalExceptionHandler가 NotFoundException/InvalidRequestException 처리
+        PriceOfferResponse response = priceOfferService.createPriceOffer(postId, request, visitorId);
+        return ResponseEntity.status(201).body(response);
     }
 
     /**
@@ -80,26 +68,8 @@ public class PriceOfferController {
             ));
         }
 
-        try {
-            PriceOfferAcceptResponse response = priceOfferService.acceptPriceOffer(offerId, visitorId);
-            return ResponseEntity.ok(response);
-        } catch (IllegalArgumentException e) {
-            if (e.getMessage().contains("존재하지 않는")) {
-                return ResponseEntity.status(404).body(Map.of(
-                        "error", "NOT_FOUND",
-                        "message", e.getMessage()
-                ));
-            }
-            return ResponseEntity.badRequest().body(Map.of(
-                    "error", "INVALID_REQUEST",
-                    "message", e.getMessage()
-            ));
-        } catch (IllegalStateException e) {
-            // 이미 처리된 제안
-            return ResponseEntity.badRequest().body(Map.of(
-                    "error", "INVALID_STATE",
-                    "message", e.getMessage()
-            ));
-        }
+        // GlobalExceptionHandler가 NotFoundException/InvalidRequestException 처리
+        PriceOfferAcceptResponse response = priceOfferService.acceptPriceOffer(offerId, visitorId);
+        return ResponseEntity.ok(response);
     }
 }

--- a/apps/api/src/main/java/com/acnh/api/priceoffer/service/PriceOfferService.java
+++ b/apps/api/src/main/java/com/acnh/api/priceoffer/service/PriceOfferService.java
@@ -2,6 +2,8 @@ package com.acnh.api.priceoffer.service;
 
 import com.acnh.api.chat.entity.ChatRoom;
 import com.acnh.api.chat.repository.ChatRoomRepository;
+import com.acnh.api.common.exception.InvalidRequestException;
+import com.acnh.api.common.exception.NotFoundException;
 import com.acnh.api.member.entity.Member;
 import com.acnh.api.member.repository.MemberRepository;
 import com.acnh.api.notification.entity.Notification;
@@ -50,17 +52,17 @@ public class PriceOfferService {
 
         // 가격제안 받기 ON 체크
         if (!Boolean.TRUE.equals(post.getPriceNegotiable())) {
-            throw new IllegalArgumentException("가격 제안을 받지 않는 게시글입니다");
+            throw new InvalidRequestException("가격 제안을 받지 않는 게시글입니다");
         }
 
         // 본인 게시글 체크
         if (post.getUserId().equals(offerer.getId())) {
-            throw new IllegalArgumentException("본인 게시글에는 가격 제안을 할 수 없습니다");
+            throw new InvalidRequestException("본인 게시글에는 가격 제안을 할 수 없습니다");
         }
 
         // 거래 가능 상태 체크
         if (!"AVAILABLE".equals(post.getStatus())) {
-            throw new IllegalArgumentException("거래 가능한 게시글에만 가격 제안을 할 수 있습니다");
+            throw new InvalidRequestException("거래 가능한 게시글에만 가격 제안을 할 수 있습니다");
         }
 
         // 중복 제안 체크 (비관적 락으로 Race Condition 방지)
@@ -69,7 +71,7 @@ public class PriceOfferService {
         // After: PESSIMISTIC_WRITE 락으로 동시 요청 직렬화
         priceOfferRepository.findByPostIdAndOffererIdAndStatusWithLock(postId, offerer.getId(), "PENDING")
                 .ifPresent(existing -> {
-                    throw new IllegalArgumentException("이미 대기 중인 가격 제안이 있습니다");
+                    throw new InvalidRequestException("이미 대기 중인 가격 제안이 있습니다");
                 });
 
         // 화폐 유형 결정 및 검증 (요청에 없으면 게시글 화폐 유형 사용)
@@ -118,13 +120,13 @@ public class PriceOfferService {
 
         // 게시글 작성자 체크
         if (!priceOffer.getPostOwnerId().equals(postOwner.getId())) {
-            throw new IllegalArgumentException("게시글 작성자만 가격 제안을 수락할 수 있습니다");
+            throw new InvalidRequestException("게시글 작성자만 가격 제안을 수락할 수 있습니다");
         }
 
         // PENDING 상태 사전 검증 (명확한 에러 메시지 제공)
         if (!"PENDING".equals(priceOffer.getStatus())) {
             log.warn("가격 제안 수락 실패 - offerId: {}, currentStatus: {}", offerId, priceOffer.getStatus());
-            throw new IllegalStateException(
+            throw new InvalidRequestException(
                     String.format("대기 중인 제안만 수락할 수 있습니다 (현재 상태: %s)", priceOffer.getStatus()));
         }
 
@@ -132,7 +134,7 @@ public class PriceOfferService {
         int updatedRows = priceOfferRepository.acceptPriceOfferAtomic(offerId);
         if (updatedRows == 0) {
             log.warn("가격 제안 수락 실패 (동시 요청) - offerId: {}", offerId);
-            throw new IllegalStateException("이미 처리된 가격 제안입니다");
+            throw new InvalidRequestException("이미 처리된 가격 제안입니다");
         }
         log.info("가격 제안 수락 - offerId: {}", offerId);
 
@@ -204,19 +206,19 @@ public class PriceOfferService {
      */
     private Member findMemberByUuid(String visitorId) {
         if (visitorId == null || "anonymousUser".equals(visitorId)) {
-            throw new IllegalArgumentException("로그인이 필요합니다");
+            throw new InvalidRequestException("로그인이 필요합니다");
         }
 
-        // UUID 파싱 및 에러 메시지 정규화
+        // UUID 파싱 실패 시 원본 예외 메시지 노출 방지
         UUID uuid;
         try {
             uuid = UUID.fromString(visitorId);
         } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException("잘못된 사용자 ID 형식입니다");
+            throw new InvalidRequestException("로그인이 필요합니다");
         }
 
         return memberRepository.findByUuidAndDeletedAtIsNull(uuid)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다"));
+                .orElseThrow(() -> new NotFoundException("사용자", visitorId));
     }
 
     /**
@@ -224,7 +226,7 @@ public class PriceOfferService {
      */
     private Post findPostById(Long postId) {
         return postRepository.findByIdAndDeletedAtIsNull(postId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글입니다"));
+                .orElseThrow(() -> new NotFoundException("게시글", postId));
     }
 
     /**
@@ -232,7 +234,7 @@ public class PriceOfferService {
      */
     private PriceOffer findPriceOfferById(Long offerId) {
         return priceOfferRepository.findByIdAndDeletedAtIsNull(offerId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 가격 제안입니다"));
+                .orElseThrow(() -> new NotFoundException("가격 제안", offerId));
     }
 
     /**
@@ -243,7 +245,7 @@ public class PriceOfferService {
         try {
             CurrencyType.valueOf(currencyType);
         } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException("화폐 유형은 BELL 또는 MILE_TICKET만 가능합니다");
+            throw new InvalidRequestException("화폐 유형은 BELL 또는 MILE_TICKET만 가능합니다");
         }
     }
 }

--- a/apps/api/src/main/java/com/acnh/api/report/controller/ReportController.java
+++ b/apps/api/src/main/java/com/acnh/api/report/controller/ReportController.java
@@ -38,7 +38,9 @@ public class ReportController {
         log.info("신고 요청 - postId: {}, reasonCode: {}, visitorId: {}",
                 request.getPostId(), request.getReasonCode(), visitorId);
 
-        if (visitorId == null) {
+        // Before: visitorId == null만 체크
+        // After: "anonymousUser"도 비인증 상태로 처리 (Spring Security 기본값)
+        if (visitorId == null || "anonymousUser".equals(visitorId)) {
             return ResponseEntity.status(401).body(Map.of(
                     "error", "UNAUTHORIZED",
                     "message", "로그인이 필요합니다"

--- a/apps/api/src/main/java/com/acnh/api/review/controller/ReviewController.java
+++ b/apps/api/src/main/java/com/acnh/api/review/controller/ReviewController.java
@@ -40,22 +40,10 @@ public class ReviewController {
 
         log.info("유저 리뷰 목록 조회 요청 - userId: {}, page: {}, size: {}", userId, page, size);
 
-        try {
-            Pageable pageable = PageRequest.of(page, Math.min(size, DEFAULT_PAGE_SIZE));
-            ReviewListResponse response = reviewService.getReviewsByUserId(userId, pageable);
-            return ResponseEntity.ok(response);
-        } catch (IllegalArgumentException e) {
-            if (e.getMessage().contains("존재하지 않는")) {
-                return ResponseEntity.status(404).body(Map.of(
-                        "error", "NOT_FOUND",
-                        "message", e.getMessage()
-                ));
-            }
-            return ResponseEntity.badRequest().body(Map.of(
-                    "error", "INVALID_REQUEST",
-                    "message", e.getMessage()
-            ));
-        }
+        // GlobalExceptionHandler가 NotFoundException/InvalidRequestException 처리
+        Pageable pageable = PageRequest.of(page, Math.min(size, DEFAULT_PAGE_SIZE));
+        ReviewListResponse response = reviewService.getReviewsByUserId(userId, pageable);
+        return ResponseEntity.ok(response);
     }
 
     /**
@@ -77,21 +65,9 @@ public class ReviewController {
             ));
         }
 
-        try {
-            ReviewResponse response = reviewService.createReview(request, visitorId);
-            return ResponseEntity.status(201).body(response);
-        } catch (IllegalArgumentException e) {
-            if (e.getMessage().contains("존재하지 않는")) {
-                return ResponseEntity.status(404).body(Map.of(
-                        "error", "NOT_FOUND",
-                        "message", e.getMessage()
-                ));
-            }
-            return ResponseEntity.badRequest().body(Map.of(
-                    "error", "INVALID_REQUEST",
-                    "message", e.getMessage()
-            ));
-        }
+        // GlobalExceptionHandler가 NotFoundException/InvalidRequestException 처리
+        ReviewResponse response = reviewService.createReview(request, visitorId);
+        return ResponseEntity.status(201).body(response);
     }
 
     /**

--- a/apps/api/src/main/java/com/acnh/api/review/controller/ReviewController.java
+++ b/apps/api/src/main/java/com/acnh/api/review/controller/ReviewController.java
@@ -58,7 +58,9 @@ public class ReviewController {
         log.info("리뷰 작성 요청 - visitorId: {}, postId: {}, revieweeId: {}",
                 visitorId, request.getPostId(), request.getRevieweeId());
 
-        if (visitorId == null) {
+        // Before: visitorId == null만 체크
+        // After: "anonymousUser"도 비인증 상태로 처리 (Spring Security 기본값)
+        if (visitorId == null || "anonymousUser".equals(visitorId)) {
             return ResponseEntity.status(401).body(Map.of(
                     "error", "UNAUTHORIZED",
                     "message", "로그인이 필요합니다"

--- a/apps/api/src/main/java/com/acnh/api/review/service/ReviewService.java
+++ b/apps/api/src/main/java/com/acnh/api/review/service/ReviewService.java
@@ -1,6 +1,8 @@
 package com.acnh.api.review.service;
 
 import com.acnh.api.chat.repository.ChatRoomRepository;
+import com.acnh.api.common.exception.InvalidRequestException;
+import com.acnh.api.common.exception.NotFoundException;
 import com.acnh.api.filter.ProfanityFilter;
 import com.acnh.api.member.entity.Member;
 import com.acnh.api.member.repository.MemberRepository;
@@ -54,7 +56,7 @@ public class ReviewService {
 
         // 자기 자신에게 리뷰 불가
         if (reviewer.getId().equals(reviewee.getId())) {
-            throw new IllegalArgumentException("자기 자신에게 리뷰를 작성할 수 없습니다");
+            throw new InvalidRequestException("자기 자신에게 리뷰를 작성할 수 없습니다");
         }
 
         // 채팅 기록 확인 (리뷰어가 해당 게시글에 채팅방이 있는지)
@@ -65,7 +67,7 @@ public class ReviewService {
 
         // 중복 리뷰 검사 (post_id + reviewer_id 기준)
         if (reviewRepository.existsByPostIdAndReviewerIdAndDeletedAtIsNull(post.getId(), reviewer.getId())) {
-            throw new IllegalArgumentException("이미 해당 게시글에 리뷰를 작성하였습니다");
+            throw new InvalidRequestException("이미 해당 게시글에 리뷰를 작성하였습니다");
         }
 
         // 금칙어 검사
@@ -86,7 +88,7 @@ public class ReviewService {
         try {
             savedReview = reviewRepository.save(review);
         } catch (DataIntegrityViolationException e) {
-            throw new IllegalArgumentException("이미 해당 게시글에 리뷰를 작성하였습니다");
+            throw new InvalidRequestException("이미 해당 게시글에 리뷰를 작성하였습니다");
         }
 
         log.info("리뷰 작성 완료 - reviewId: {}, postId: {}, reviewerId: {}, revieweeId: {}",
@@ -196,7 +198,7 @@ public class ReviewService {
      */
     private Member findMemberByUuid(String visitorId) {
         if (visitorId == null || "anonymousUser".equals(visitorId)) {
-            throw new IllegalArgumentException("로그인이 필요합니다");
+            throw new InvalidRequestException("로그인이 필요합니다");
         }
 
         // UUID 파싱 실패 시 원본 예외 메시지 노출 방지
@@ -204,11 +206,11 @@ public class ReviewService {
         try {
             uuid = UUID.fromString(visitorId);
         } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException("로그인이 필요합니다");
+            throw new InvalidRequestException("로그인이 필요합니다");
         }
 
         return memberRepository.findByUuidAndDeletedAtIsNull(uuid)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다"));
+                .orElseThrow(() -> new NotFoundException("사용자", visitorId));
     }
 
     /**
@@ -216,7 +218,7 @@ public class ReviewService {
      */
     private Member findMemberById(Long memberId) {
         return memberRepository.findByIdAndDeletedAtIsNull(memberId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다"));
+                .orElseThrow(() -> new NotFoundException("사용자", memberId));
     }
 
     /**
@@ -224,7 +226,7 @@ public class ReviewService {
      */
     private Post findPostById(Long postId) {
         return postRepository.findByIdAndDeletedAtIsNull(postId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글입니다"));
+                .orElseThrow(() -> new NotFoundException("게시글", postId));
     }
 
     /**
@@ -236,14 +238,14 @@ public class ReviewService {
         // 게시글 작성자인 경우
         if (post.getUserId().equals(reviewer.getId())) {
             if (chatRoomRepository.findByPostIdAndDeletedAtIsNull(post.getId()).isEmpty()) {
-                throw new IllegalArgumentException("해당 게시글에 채팅 기록이 없습니다");
+                throw new InvalidRequestException("해당 게시글에 채팅 기록이 없습니다");
             }
             return;
         }
 
         // 채팅 요청자인 경우
         if (!chatRoomRepository.existsByPostIdAndApplicantIdAndDeletedAtIsNull(post.getId(), reviewer.getId())) {
-            throw new IllegalArgumentException("해당 게시글에 채팅 기록이 없습니다");
+            throw new InvalidRequestException("해당 게시글에 채팅 기록이 없습니다");
         }
     }
 
@@ -256,14 +258,14 @@ public class ReviewService {
         // 채팅 요청자가 리뷰하는 경우: 게시글 작성자에게만 리뷰 가능
         if (!post.getUserId().equals(reviewer.getId())) {
             if (!post.getUserId().equals(reviewee.getId())) {
-                throw new IllegalArgumentException("게시글 작성자에게만 리뷰를 작성할 수 있습니다");
+                throw new InvalidRequestException("게시글 작성자에게만 리뷰를 작성할 수 있습니다");
             }
             return;
         }
 
         // 게시글 작성자가 리뷰하는 경우: 해당 게시글에 채팅을 요청한 유저에게만 리뷰 가능
         if (!chatRoomRepository.existsByPostIdAndApplicantIdAndDeletedAtIsNull(post.getId(), reviewee.getId())) {
-            throw new IllegalArgumentException("해당 게시글에 채팅을 요청한 유저에게만 리뷰를 작성할 수 있습니다");
+            throw new InvalidRequestException("해당 게시글에 채팅을 요청한 유저에게만 리뷰를 작성할 수 있습니다");
         }
     }
 

--- a/apps/api/src/main/java/com/acnh/api/transaction/controller/TransactionController.java
+++ b/apps/api/src/main/java/com/acnh/api/transaction/controller/TransactionController.java
@@ -174,9 +174,17 @@ public class TransactionController {
             TransactionResponse response = transactionService.createTransaction(visitorId, request);
             return ResponseEntity.ok(response);
         } catch (IllegalArgumentException e) {
+            // CodeRabbit 리뷰 반영: 예외 유형별 HTTP 상태 코드 세분화
+            String message = e.getMessage();
+            if (message != null && message.contains("존재하지 않는")) {
+                return ResponseEntity.status(404).body(Map.of(
+                        "error", "NOT_FOUND",
+                        "message", message
+                ));
+            }
             return ResponseEntity.badRequest().body(Map.of(
                     "error", "INVALID_REQUEST",
-                    "message", e.getMessage()
+                    "message", message
             ));
         }
     }

--- a/apps/api/src/main/java/com/acnh/api/transaction/controller/TransactionController.java
+++ b/apps/api/src/main/java/com/acnh/api/transaction/controller/TransactionController.java
@@ -175,8 +175,9 @@ public class TransactionController {
             return ResponseEntity.ok(response);
         } catch (IllegalArgumentException e) {
             // CodeRabbit 리뷰 반영: 예외 유형별 HTTP 상태 코드 세분화
-            String message = e.getMessage();
-            if (message != null && message.contains("존재하지 않는")) {
+            // CodeRabbit 추가 리뷰 반영: null 메시지 처리
+            String message = e.getMessage() != null ? e.getMessage() : "잘못된 요청입니다";
+            if (message.contains("존재하지 않는")) {
                 return ResponseEntity.status(404).body(Map.of(
                         "error", "NOT_FOUND",
                         "message", message

--- a/apps/api/src/main/java/com/acnh/api/transaction/controller/TransactionController.java
+++ b/apps/api/src/main/java/com/acnh/api/transaction/controller/TransactionController.java
@@ -66,43 +66,37 @@ public class TransactionController {
             ));
         }
 
+        // CodeRabbit 리뷰 반영: 날짜 파싱 예외 처리
+        LocalDateTime start = null;
+        LocalDateTime end = null;
         try {
-            // CodeRabbit 리뷰 반영: 날짜 파싱 예외 처리
-            LocalDateTime start = null;
-            LocalDateTime end = null;
-            try {
-                if (startDate != null) start = LocalDate.parse(startDate).atStartOfDay();
-                if (endDate != null) end = LocalDate.parse(endDate).atTime(LocalTime.MAX);
-            } catch (DateTimeParseException e) {
-                return ResponseEntity.badRequest().body(Map.of(
-                        "error", "INVALID_DATE",
-                        "message", "날짜 형식은 YYYY-MM-DD 이어야 합니다"
-                ));
-            }
-
-            // 거래 유형 파싱
-            TransactionType transactionType = null;
-            if (type != null && !type.isEmpty()) {
-                try {
-                    transactionType = TransactionType.valueOf(type);
-                } catch (IllegalArgumentException e) {
-                    return ResponseEntity.badRequest().body(Map.of(
-                            "error", "INVALID_TYPE",
-                            "message", "유효하지 않은 거래 유형입니다"
-                    ));
-                }
-            }
-
-            Pageable pageable = PageRequest.of(page, Math.min(size, DEFAULT_PAGE_SIZE));
-            TransactionListResponse response = transactionService.getTransactions(
-                    visitorId, start, end, transactionType, pageable);
-            return ResponseEntity.ok(response);
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.status(404).body(Map.of(
-                    "error", "NOT_FOUND",
-                    "message", e.getMessage()
+            if (startDate != null) start = LocalDate.parse(startDate).atStartOfDay();
+            if (endDate != null) end = LocalDate.parse(endDate).atTime(LocalTime.MAX);
+        } catch (DateTimeParseException e) {
+            return ResponseEntity.badRequest().body(Map.of(
+                    "error", "INVALID_DATE",
+                    "message", "날짜 형식은 YYYY-MM-DD 이어야 합니다"
             ));
         }
+
+        // 거래 유형 파싱
+        TransactionType transactionType = null;
+        if (type != null && !type.isEmpty()) {
+            try {
+                transactionType = TransactionType.valueOf(type);
+            } catch (IllegalArgumentException e) {
+                return ResponseEntity.badRequest().body(Map.of(
+                        "error", "INVALID_TYPE",
+                        "message", "유효하지 않은 거래 유형입니다"
+                ));
+            }
+        }
+
+        // GlobalExceptionHandler가 NotFoundException/InvalidRequestException 처리
+        Pageable pageable = PageRequest.of(page, Math.min(size, DEFAULT_PAGE_SIZE));
+        TransactionListResponse response = transactionService.getTransactions(
+                visitorId, start, end, transactionType, pageable);
+        return ResponseEntity.ok(response);
     }
 
     /**
@@ -126,28 +120,22 @@ public class TransactionController {
             ));
         }
 
+        // CodeRabbit 리뷰 반영: 날짜 파싱 예외 처리
+        LocalDateTime start = null;
+        LocalDateTime end = null;
         try {
-            // CodeRabbit 리뷰 반영: 날짜 파싱 예외 처리
-            LocalDateTime start = null;
-            LocalDateTime end = null;
-            try {
-                if (startDate != null) start = LocalDate.parse(startDate).atStartOfDay();
-                if (endDate != null) end = LocalDate.parse(endDate).atTime(LocalTime.MAX);
-            } catch (DateTimeParseException e) {
-                return ResponseEntity.badRequest().body(Map.of(
-                        "error", "INVALID_DATE",
-                        "message", "날짜 형식은 YYYY-MM-DD 이어야 합니다"
-                ));
-            }
-
-            TransactionSummaryResponse response = transactionService.getSummary(visitorId, start, end);
-            return ResponseEntity.ok(response);
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.status(404).body(Map.of(
-                    "error", "NOT_FOUND",
-                    "message", e.getMessage()
+            if (startDate != null) start = LocalDate.parse(startDate).atStartOfDay();
+            if (endDate != null) end = LocalDate.parse(endDate).atTime(LocalTime.MAX);
+        } catch (DateTimeParseException e) {
+            return ResponseEntity.badRequest().body(Map.of(
+                    "error", "INVALID_DATE",
+                    "message", "날짜 형식은 YYYY-MM-DD 이어야 합니다"
             ));
         }
+
+        // GlobalExceptionHandler가 NotFoundException/InvalidRequestException 처리
+        TransactionSummaryResponse response = transactionService.getSummary(visitorId, start, end);
+        return ResponseEntity.ok(response);
     }
 
     /**
@@ -170,24 +158,9 @@ public class TransactionController {
             ));
         }
 
-        try {
-            TransactionResponse response = transactionService.createTransaction(visitorId, request);
-            return ResponseEntity.ok(response);
-        } catch (IllegalArgumentException e) {
-            // CodeRabbit 리뷰 반영: 예외 유형별 HTTP 상태 코드 세분화
-            // CodeRabbit 추가 리뷰 반영: null 메시지 처리
-            String message = e.getMessage() != null ? e.getMessage() : "잘못된 요청입니다";
-            if (message.contains("존재하지 않는")) {
-                return ResponseEntity.status(404).body(Map.of(
-                        "error", "NOT_FOUND",
-                        "message", message
-                ));
-            }
-            return ResponseEntity.badRequest().body(Map.of(
-                    "error", "INVALID_REQUEST",
-                    "message", message
-            ));
-        }
+        // GlobalExceptionHandler가 NotFoundException/InvalidRequestException 처리
+        TransactionResponse response = transactionService.createTransaction(visitorId, request);
+        return ResponseEntity.ok(response);
     }
 
     /**
@@ -209,14 +182,8 @@ public class TransactionController {
             ));
         }
 
-        try {
-            transactionService.deleteTransaction(visitorId, id);
-            return ResponseEntity.ok(Map.of("message", "거래 내역이 삭제되었습니다"));
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.status(404).body(Map.of(
-                    "error", "NOT_FOUND",
-                    "message", e.getMessage()
-            ));
-        }
+        // GlobalExceptionHandler가 NotFoundException/InvalidRequestException 처리
+        transactionService.deleteTransaction(visitorId, id);
+        return ResponseEntity.ok(Map.of("message", "거래 내역이 삭제되었습니다"));
     }
 }

--- a/apps/api/src/main/java/com/acnh/api/transaction/service/TransactionService.java
+++ b/apps/api/src/main/java/com/acnh/api/transaction/service/TransactionService.java
@@ -1,5 +1,7 @@
 package com.acnh.api.transaction.service;
 
+import com.acnh.api.common.exception.InvalidRequestException;
+import com.acnh.api.common.exception.NotFoundException;
 import com.acnh.api.member.entity.Member;
 import com.acnh.api.member.repository.MemberRepository;
 import com.acnh.api.post.enums.CurrencyType;
@@ -129,7 +131,7 @@ public class TransactionService {
         try {
             type = TransactionType.valueOf(request.getType());
         } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException("유효하지 않은 거래 유형입니다: " + request.getType());
+            throw new InvalidRequestException("유효하지 않은 거래 유형입니다: " + request.getType());
         }
 
         // 화폐 종류 파싱
@@ -137,7 +139,7 @@ public class TransactionService {
         try {
             currencyType = CurrencyType.valueOf(request.getCurrencyType());
         } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException("유효하지 않은 화폐 종류입니다: " + request.getCurrencyType());
+            throw new InvalidRequestException("유효하지 않은 화폐 종류입니다: " + request.getCurrencyType());
         }
 
         Transaction transaction = Transaction.builder()
@@ -169,7 +171,7 @@ public class TransactionService {
 
         Transaction transaction = transactionRepository
                 .findByIdAndUserIdAndDeletedAtIsNull(transactionId, member.getId())
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 거래 내역입니다"));
+                .orElseThrow(() -> new NotFoundException("거래 내역", transactionId));
 
         transaction.delete();
 
@@ -184,15 +186,15 @@ public class TransactionService {
      */
     private Member findMemberByUuid(String visitorId) {
         if (visitorId == null || "anonymousUser".equals(visitorId)) {
-            throw new IllegalArgumentException("로그인이 필요합니다");
+            throw new InvalidRequestException("로그인이 필요합니다");
         }
         UUID uuid;
         try {
             uuid = UUID.fromString(visitorId);
         } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException("유효하지 않은 인증 정보입니다");
+            throw new InvalidRequestException("유효하지 않은 인증 정보입니다");
         }
         return memberRepository.findByUuidAndDeletedAtIsNull(uuid)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다"));
+                .orElseThrow(() -> new NotFoundException("사용자", visitorId));
     }
 }


### PR DESCRIPTION
## Summary

CodeRabbit PR #78 리뷰에서 제안된 백엔드 개선 사항을 반영했습니다.

## Changes

### 1. SocialLoginRequest provider별 토큰 검증 추가
- **파일**: `apps/api/src/main/java/com/acnh/api/auth/dto/SocialLoginRequest.java`
- **내용**: `@AssertTrue`를 사용한 조건부 검증 추가
  - Google 로그인: `idToken` 필수
  - Kakao 로그인: `accessToken` 필수

```java
@AssertTrue(message = "Google 로그인은 idToken이 필수입니다.")
private boolean isGoogleTokenValid() {
    if (!"google".equalsIgnoreCase(provider)) return true;
    return idToken != null && !idToken.isBlank();
}

@AssertTrue(message = "Kakao 로그인은 accessToken이 필수입니다.")
private boolean isKakaoTokenValid() {
    if (!"kakao".equalsIgnoreCase(provider)) return true;
    return accessToken != null && !accessToken.isBlank();
}
```

### 2. TransactionController 예외 처리 세분화
- **파일**: `apps/api/src/main/java/com/acnh/api/transaction/controller/TransactionController.java`
- **내용**: 예외 메시지 패턴에 따라 HTTP 상태 코드 분리
  - "존재하지 않는..." → 404 Not Found
  - 기타 유효성 오류 → 400 Bad Request

## Test Plan

- [ ] Google 로그인 시 idToken 없이 요청 → 400 Bad Request 반환 확인
- [ ] Kakao 로그인 시 accessToken 없이 요청 → 400 Bad Request 반환 확인
- [ ] 존재하지 않는 사용자로 거래 생성 시 404 반환 확인
- [ ] 유효하지 않은 거래 유형으로 요청 시 400 반환 확인

## Related

- CodeRabbit PR #78 리뷰

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 소셜 로그인 검증 강화: Google/Kakao 토큰 필수 검사 추가로 잘못된 인증 입력 차단
  * 익명 사용자("anonymousUser")는 인증 실패로 처리되어 여러 엔드포인트에서 401 응답 일관화
  * 입력 검증 및 리소스 미존재 시 더 명확하고 일관된 400/404 응답 제공

* **리팩터**
  * 전역 예외 처리 도입 및 로깅 개선으로 컨트롤러·서비스 전반의 오류 응답과 메시지 일관성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->