### PR TITLE
fix: 로그아웃 후 로그인 리다이렉트 에러 수정

### DIFF
--- a/apps/app/eas.json
+++ b/apps/app/eas.json
@@ -19,7 +19,7 @@
       "env": {
         "EXPO_PUBLIC_WEB_URL": "https://ac-trading.vercel.app",
         "EXPO_PUBLIC_API_URL": "https://ac-trading-production.up.railway.app",
-        "EXPO_PUBLIC_GOOGLE_CLIENT_ID": "REDACTED_GOOGLE_CLIENT_ID",
+        "EXPO_PUBLIC_GOOGLE_CLIENT_ID": "641164748452-qlqnp5t0mai4hmiu6e4hugd9f0tjib8h.apps.googleusercontent.com",
         "EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID": "641164748452-cjnpgdkr79glqfdfh9u2qlcquskg18h2.apps.googleusercontent.com",
         "EXPO_PUBLIC_KAKAO_APP_KEY": "cdbefe8c4e6c3af0f0e3bc910290c1db"
       }
@@ -31,7 +31,7 @@
       "env": {
         "EXPO_PUBLIC_WEB_URL": "https://ac-trading.vercel.app",
         "EXPO_PUBLIC_API_URL": "https://ac-trading-production.up.railway.app",
-        "EXPO_PUBLIC_GOOGLE_CLIENT_ID": "REDACTED_GOOGLE_CLIENT_ID",
+        "EXPO_PUBLIC_GOOGLE_CLIENT_ID": "641164748452-qlqnp5t0mai4hmiu6e4hugd9f0tjib8h.apps.googleusercontent.com",
         "EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID": "641164748452-cjnpgdkr79glqfdfh9u2qlcquskg18h2.apps.googleusercontent.com",
         "EXPO_PUBLIC_KAKAO_APP_KEY": "cdbefe8c4e6c3af0f0e3bc910290c1db"
       }


### PR DESCRIPTION
## Summary
- eas.json의 preview/production 프로필에서 `EXPO_PUBLIC_GOOGLE_CLIENT_ID`가 `REDACTED_GOOGLE_CLIENT_ID` 문자열로 되어있어 Google 로그인이 불가능했던 문제 수정
- development 프로필에 남아있던 실제 Web Client ID 값으로 복구

## 변경 내용

### `apps/app/eas.json`
| 프로필 | Before | After |
|--------|--------|-------|
| preview | `REDACTED_GOOGLE_CLIENT_ID` | `641164748452-qlq...8h.apps.googleusercontent.com` |
| production | `REDACTED_GOOGLE_CLIENT_ID` | `641164748452-qlq...8h.apps.googleusercontent.com` |

> Google Client ID는 APK에 포함되는 공개 식별자로, `client_secret`과 달리 비밀값이 아닙니다.

## 코드 리뷰 과정에서 발견된 추가 사항 (이후 작업)
1. **`EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID`**: eas.json에 선언되어 있지만 코드에서 사용하지 않음 — 정리 필요
2. **`app.json`에 kakaoAppKey 하드코딩**: 플러그인 제약으로 현재 한계 있음
3. **`android/` 디렉토리 git 커밋**: EAS prebuild와 충돌 가능성 — 모니터링 필요
4. **로그아웃 후 로그인 시 Invalid Request 에러 (#72)**: WebView ↔ 네이티브 앱 간 상태 불일치 문제 조사 필요

## Test plan
- [ ] `eas build --platform android --profile preview` 빌드 성공 확인
- [ ] 빌드된 APK에서 Google 로그인 정상 동작 확인
- [ ] 빌드된 APK에서 Kakao 로그인 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 개발, 미리보기, 프로덕션 환경에서 Google 클라이언트 ID 설정이 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->