### PR TITLE
fix: 앱 UI 개선 - 누락 페이지, 에셋, 네비게이션, API 연결, 채팅 수정

### DIFF
--- a/apps/api/src/main/java/com/acnh/api/notification/controller/NotificationController.java
+++ b/apps/api/src/main/java/com/acnh/api/notification/controller/NotificationController.java
@@ -1,0 +1,118 @@
+package com.acnh.api.notification.controller;
+
+import com.acnh.api.notification.dto.NotificationListResponse;
+import com.acnh.api.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+/**
+ * 알림 관련 API 컨트롤러
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    private static final int DEFAULT_PAGE_SIZE = 20;
+
+    /**
+     * 내 알림 목록 조회
+     * GET /api/notifications
+     */
+    @GetMapping
+    public ResponseEntity<?> getMyNotifications(
+            @AuthenticationPrincipal String visitorId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+
+        log.info("알림 목록 조회 요청 - visitorId: {}, page: {}, size: {}", visitorId, page, size);
+
+        if (visitorId == null || "anonymousUser".equals(visitorId)) {
+            return ResponseEntity.status(401).body(Map.of(
+                    "error", "UNAUTHORIZED",
+                    "message", "로그인이 필요합니다"
+            ));
+        }
+
+        // GlobalExceptionHandler가 NotFoundException/InvalidRequestException 처리
+        Pageable pageable = PageRequest.of(page, Math.min(size, DEFAULT_PAGE_SIZE));
+        NotificationListResponse response = notificationService.getMyNotifications(visitorId, pageable);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 읽지 않은 알림 수 조회
+     * GET /api/notifications/unread-count
+     */
+    @GetMapping("/unread-count")
+    public ResponseEntity<?> getUnreadCount(
+            @AuthenticationPrincipal String visitorId) {
+
+        if (visitorId == null || "anonymousUser".equals(visitorId)) {
+            return ResponseEntity.status(401).body(Map.of(
+                    "error", "UNAUTHORIZED",
+                    "message", "로그인이 필요합니다"
+            ));
+        }
+
+        long count = notificationService.getUnreadCount(visitorId);
+        return ResponseEntity.ok(Map.of("unreadCount", count));
+    }
+
+    /**
+     * 알림 읽음 처리
+     * PATCH /api/notifications/{id}/read
+     */
+    @PatchMapping("/{id}/read")
+    public ResponseEntity<?> markAsRead(
+            @AuthenticationPrincipal String visitorId,
+            @PathVariable Long id) {
+
+        log.info("알림 읽음 처리 요청 - notificationId: {}, visitorId: {}", id, visitorId);
+
+        if (visitorId == null || "anonymousUser".equals(visitorId)) {
+            return ResponseEntity.status(401).body(Map.of(
+                    "error", "UNAUTHORIZED",
+                    "message", "로그인이 필요합니다"
+            ));
+        }
+
+        // GlobalExceptionHandler가 NotFoundException/InvalidRequestException 처리
+        notificationService.markAsRead(id, visitorId);
+        return ResponseEntity.ok(Map.of("message", "읽음 처리되었습니다"));
+    }
+
+    /**
+     * 모든 알림 읽음 처리
+     * PATCH /api/notifications/read-all
+     */
+    @PatchMapping("/read-all")
+    public ResponseEntity<?> markAllAsRead(
+            @AuthenticationPrincipal String visitorId) {
+
+        log.info("모든 알림 읽음 처리 요청 - visitorId: {}", visitorId);
+
+        if (visitorId == null || "anonymousUser".equals(visitorId)) {
+            return ResponseEntity.status(401).body(Map.of(
+                    "error", "UNAUTHORIZED",
+                    "message", "로그인이 필요합니다"
+            ));
+        }
+
+        int count = notificationService.markAllAsRead(visitorId);
+        return ResponseEntity.ok(Map.of(
+                "message", "모든 알림이 읽음 처리되었습니다",
+                "count", count
+        ));
+    }
+}

--- a/apps/api/src/main/java/com/acnh/api/notification/dto/NotificationListResponse.java
+++ b/apps/api/src/main/java/com/acnh/api/notification/dto/NotificationListResponse.java
@@ -1,0 +1,38 @@
+package com.acnh.api.notification.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+/**
+ * 알림 목록 페이징 응답 DTO
+ */
+@Getter
+@Builder
+public class NotificationListResponse {
+
+    private List<NotificationResponse> notifications;
+    private long unreadCount;
+    private int currentPage;
+    private int totalPages;
+    private long totalElements;
+    private boolean hasNext;
+    private boolean hasPrevious;
+
+    /**
+     * Page -> DTO 변환
+     */
+    public static NotificationListResponse from(Page<NotificationResponse> page, long unreadCount) {
+        return NotificationListResponse.builder()
+                .notifications(page.getContent())
+                .unreadCount(unreadCount)
+                .currentPage(page.getNumber())
+                .totalPages(page.getTotalPages())
+                .totalElements(page.getTotalElements())
+                .hasNext(page.hasNext())
+                .hasPrevious(page.hasPrevious())
+                .build();
+    }
+}

--- a/apps/api/src/main/java/com/acnh/api/notification/dto/NotificationResponse.java
+++ b/apps/api/src/main/java/com/acnh/api/notification/dto/NotificationResponse.java
@@ -1,6 +1,7 @@
 package com.acnh.api.notification.dto;
 
 import com.acnh.api.notification.entity.Notification;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -19,7 +20,10 @@ public class NotificationResponse {
     private String content;
     private Long referenceId;
     private String referenceType;
-    private boolean isRead;
+    // Lombok @Getter가 boolean isRead에 대해 isRead() getter를 생성하면
+    // Jackson이 "is" 접두사를 제거하여 "read"로 직렬화함 → @JsonProperty로 명시
+    @JsonProperty("isRead")
+    private Boolean isRead;
     private LocalDateTime createdAt;
 
     /**

--- a/apps/api/src/main/java/com/acnh/api/notification/dto/NotificationResponse.java
+++ b/apps/api/src/main/java/com/acnh/api/notification/dto/NotificationResponse.java
@@ -1,0 +1,40 @@
+package com.acnh.api.notification.dto;
+
+import com.acnh.api.notification.entity.Notification;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * 알림 응답 DTO
+ */
+@Getter
+@Builder
+public class NotificationResponse {
+
+    private Long id;
+    private String type;
+    private String title;
+    private String content;
+    private Long referenceId;
+    private String referenceType;
+    private boolean isRead;
+    private LocalDateTime createdAt;
+
+    /**
+     * Entity -> DTO 변환
+     */
+    public static NotificationResponse from(Notification notification) {
+        return NotificationResponse.builder()
+                .id(notification.getId())
+                .type(notification.getType())
+                .title(notification.getTitle())
+                .content(notification.getContent())
+                .referenceId(notification.getReferenceId())
+                .referenceType(notification.getReferenceType())
+                .isRead(notification.getIsRead())
+                .createdAt(notification.getCreatedAt())
+                .build();
+    }
+}

--- a/apps/api/src/main/java/com/acnh/api/notification/repository/NotificationRepository.java
+++ b/apps/api/src/main/java/com/acnh/api/notification/repository/NotificationRepository.java
@@ -33,7 +33,9 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     /**
      * 사용자 ID의 모든 알림 읽음 처리
      */
-    @Modifying
+    // Before: @Modifying만 사용 → 벌크 업데이트 후 영속성 컨텍스트에 stale 데이터 남음
+    // After: clearAutomatically = true → 벌크 업데이트 후 영속성 컨텍스트 자동 초기화
+    @Modifying(clearAutomatically = true)
     @Query("UPDATE Notification n SET n.isRead = true WHERE n.userId = :userId AND n.isRead = false AND n.deletedAt IS NULL")
     int markAllAsReadByUserId(@Param("userId") Long userId);
 }

--- a/apps/api/src/main/java/com/acnh/api/notification/service/NotificationService.java
+++ b/apps/api/src/main/java/com/acnh/api/notification/service/NotificationService.java
@@ -81,7 +81,7 @@ public class NotificationService {
         return count;
     }
 
-    // ========== Private Helper Methods ==========
+    // ========== 내부 헬퍼 메서드 ==========
 
     /**
      * UUID로 회원 조회

--- a/apps/api/src/main/java/com/acnh/api/notification/service/NotificationService.java
+++ b/apps/api/src/main/java/com/acnh/api/notification/service/NotificationService.java
@@ -90,7 +90,15 @@ public class NotificationService {
         if (visitorId == null || "anonymousUser".equals(visitorId)) {
             throw new InvalidRequestException("로그인이 필요합니다");
         }
-        return memberRepository.findByUuidAndDeletedAtIsNull(UUID.fromString(visitorId))
+        // Before: UUID 형식이 아닌 visitorId → IllegalArgumentException → 500
+        // After: try-catch로 400 반환
+        UUID uuid;
+        try {
+            uuid = UUID.fromString(visitorId);
+        } catch (IllegalArgumentException e) {
+            throw new InvalidRequestException("유효하지 않은 사용자 식별자입니다");
+        }
+        return memberRepository.findByUuidAndDeletedAtIsNull(uuid)
                 .orElseThrow(() -> new NotFoundException("사용자", visitorId));
     }
 }

--- a/apps/api/src/main/java/com/acnh/api/notification/service/NotificationService.java
+++ b/apps/api/src/main/java/com/acnh/api/notification/service/NotificationService.java
@@ -1,0 +1,96 @@
+package com.acnh.api.notification.service;
+
+import com.acnh.api.common.exception.InvalidRequestException;
+import com.acnh.api.common.exception.NotFoundException;
+import com.acnh.api.member.entity.Member;
+import com.acnh.api.member.repository.MemberRepository;
+import com.acnh.api.notification.dto.NotificationListResponse;
+import com.acnh.api.notification.dto.NotificationResponse;
+import com.acnh.api.notification.entity.Notification;
+import com.acnh.api.notification.repository.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+/**
+ * 알림 관련 비즈니스 로직 서비스
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+    private final MemberRepository memberRepository;
+
+    /**
+     * 내 알림 목록 조회 (페이징)
+     */
+    public NotificationListResponse getMyNotifications(String visitorId, Pageable pageable) {
+        Member member = findMemberByUuid(visitorId);
+
+        Page<Notification> notifications = notificationRepository
+                .findByUserIdAndDeletedAtIsNullOrderByCreatedAtDesc(member.getId(), pageable);
+        long unreadCount = notificationRepository
+                .countByUserIdAndIsReadFalseAndDeletedAtIsNull(member.getId());
+
+        Page<NotificationResponse> responsePage = notifications.map(NotificationResponse::from);
+        return NotificationListResponse.from(responsePage, unreadCount);
+    }
+
+    /**
+     * 읽지 않은 알림 수 조회
+     */
+    public long getUnreadCount(String visitorId) {
+        Member member = findMemberByUuid(visitorId);
+        return notificationRepository.countByUserIdAndIsReadFalseAndDeletedAtIsNull(member.getId());
+    }
+
+    /**
+     * 알림 읽음 처리
+     */
+    @Transactional
+    public void markAsRead(Long notificationId, String visitorId) {
+        Member member = findMemberByUuid(visitorId);
+        Notification notification = notificationRepository.findByIdAndDeletedAtIsNull(notificationId)
+                .orElseThrow(() -> new NotFoundException("알림", notificationId));
+
+        // 본인의 알림인지 확인
+        if (!notification.getUserId().equals(member.getId())) {
+            throw new InvalidRequestException("본인의 알림만 읽음 처리할 수 있습니다");
+        }
+
+        notification.markAsRead();
+        log.info("알림 읽음 처리 - notificationId: {}, userId: {}", notificationId, member.getId());
+    }
+
+    /**
+     * 모든 알림 읽음 처리
+     */
+    @Transactional
+    public int markAllAsRead(String visitorId) {
+        Member member = findMemberByUuid(visitorId);
+        int count = notificationRepository.markAllAsReadByUserId(member.getId());
+        log.info("모든 알림 읽음 처리 - userId: {}, count: {}", member.getId(), count);
+        return count;
+    }
+
+    // ========== Private Helper Methods ==========
+
+    /**
+     * UUID로 회원 조회
+     */
+    private Member findMemberByUuid(String visitorId) {
+        if (visitorId == null || "anonymousUser".equals(visitorId)) {
+            throw new InvalidRequestException("로그인이 필요합니다");
+        }
+        return memberRepository.findByUuidAndDeletedAtIsNull(UUID.fromString(visitorId))
+                .orElseThrow(() -> new NotFoundException("사용자", visitorId));
+    }
+}

--- a/apps/api/src/main/java/com/acnh/api/post/controller/PostController.java
+++ b/apps/api/src/main/java/com/acnh/api/post/controller/PostController.java
@@ -33,17 +33,18 @@ public class PostController {
     /**
      * 게시글 목록 조회 (피드)
      * GET /api/posts
-     * - 필터: categoryId, postType, status, currencyType, minPrice, maxPrice
+     * - 필터: categoryId(다중), postType(다중), status, currencyType(다중), minPrice, maxPrice
+     * - 다중 필터: ?categoryId=1&categoryId=2 또는 ?categoryId=1,2
      * - 가격 필터 사용 시 currencyType 필수 (벨 500과 마일 500은 다름)
      * - 페이징: page, size
      */
     @GetMapping
     public ResponseEntity<?> getFeed(
             @AuthenticationPrincipal String visitorId,
-            @RequestParam(required = false) Long categoryId,
-            @RequestParam(required = false) String postType,
+            @RequestParam(required = false) List<Long> categoryId,
+            @RequestParam(required = false) List<String> postType,
             @RequestParam(required = false) String status,
-            @RequestParam(required = false) String currencyType,
+            @RequestParam(required = false) List<String> currencyType,
             @RequestParam(required = false) Integer minPrice,
             @RequestParam(required = false) Integer maxPrice,
             @RequestParam(defaultValue = "0") int page,
@@ -62,7 +63,8 @@ public class PostController {
      * 게시글 검색
      * GET /api/posts/search
      * - 필수: keyword
-     * - 필터: categoryId, postType, status, currencyType, minPrice, maxPrice
+     * - 필터: categoryId(다중), postType(다중), status, currencyType(다중), minPrice, maxPrice
+     * - 다중 필터: ?categoryId=1&categoryId=2 또는 ?categoryId=1,2
      * - 가격 필터 사용 시 currencyType 필수 (벨 500과 마일 500은 다름)
      * - 페이징: page, size
      */
@@ -70,10 +72,10 @@ public class PostController {
     public ResponseEntity<?> searchPosts(
             @AuthenticationPrincipal String visitorId,
             @RequestParam String keyword,
-            @RequestParam(required = false) Long categoryId,
-            @RequestParam(required = false) String postType,
+            @RequestParam(required = false) List<Long> categoryId,
+            @RequestParam(required = false) List<String> postType,
             @RequestParam(required = false) String status,
-            @RequestParam(required = false) String currencyType,
+            @RequestParam(required = false) List<String> currencyType,
             @RequestParam(required = false) Integer minPrice,
             @RequestParam(required = false) Integer maxPrice,
             @RequestParam(defaultValue = "0") int page,

--- a/apps/api/src/main/java/com/acnh/api/post/repository/PostRepository.java
+++ b/apps/api/src/main/java/com/acnh/api/post/repository/PostRepository.java
@@ -68,56 +68,75 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     /**
      * 피드 조회 - bumped_at 우선 정렬 (끌올 우선, 없으면 created_at)
-     * - 필터: 카테고리, 게시글유형, 상태, 화폐유형, 가격범위
+     * - 필터: 카테고리(다중), 게시글유형(다중), 상태, 화폐유형(다중), 가격범위
+     * - 다중 필터: boolean 플래그 + IN 절 조합 (빈 리스트일 때 필터 스킵)
      * - 가격 필터는 화폐유형(currencyType)과 함께 사용해야 함 (벨 500과 마일 500은 다름)
      */
-    @Query("SELECT p FROM Post p WHERE p.deletedAt IS NULL " +
-            "AND (:categoryId IS NULL OR p.categoryId = :categoryId) " +
-            "AND (:postType IS NULL OR p.postType = :postType) " +
+    @Query(value = "SELECT * FROM posts p WHERE p.deleted_at IS NULL " +
+            "AND (:hasCategoryFilter = false OR p.category_id IN (:categoryIds)) " +
+            "AND (:hasPostTypeFilter = false OR p.post_type IN (:postTypes)) " +
             "AND (:status IS NULL OR p.status = :status) " +
-            "AND (:currencyType IS NULL OR p.currencyType = :currencyType) " +
+            "AND (:hasCurrencyTypeFilter = false OR p.currency_type IN (:currencyTypes)) " +
             "AND (:minPrice IS NULL OR p.price >= :minPrice) " +
             "AND (:maxPrice IS NULL OR p.price <= :maxPrice) " +
-            "ORDER BY COALESCE(p.bumpedAt, p.createdAt) DESC")
+            "ORDER BY COALESCE(p.bumped_at, p.created_at) DESC",
+            countQuery = "SELECT COUNT(*) FROM posts p WHERE p.deleted_at IS NULL " +
+            "AND (:hasCategoryFilter = false OR p.category_id IN (:categoryIds)) " +
+            "AND (:hasPostTypeFilter = false OR p.post_type IN (:postTypes)) " +
+            "AND (:status IS NULL OR p.status = :status) " +
+            "AND (:hasCurrencyTypeFilter = false OR p.currency_type IN (:currencyTypes)) " +
+            "AND (:minPrice IS NULL OR p.price >= :minPrice) " +
+            "AND (:maxPrice IS NULL OR p.price <= :maxPrice)",
+            nativeQuery = true)
     Page<Post> findFeed(
-            @Param("categoryId") Long categoryId,
-            @Param("postType") String postType,
+            @Param("hasCategoryFilter") boolean hasCategoryFilter,
+            @Param("categoryIds") List<Long> categoryIds,
+            @Param("hasPostTypeFilter") boolean hasPostTypeFilter,
+            @Param("postTypes") List<String> postTypes,
             @Param("status") String status,
-            @Param("currencyType") String currencyType,
+            @Param("hasCurrencyTypeFilter") boolean hasCurrencyTypeFilter,
+            @Param("currencyTypes") List<String> currencyTypes,
             @Param("minPrice") Integer minPrice,
             @Param("maxPrice") Integer maxPrice,
             Pageable pageable);
 
     /**
-     * 아이템명 검색 (LIKE 검색, 띄어쓰기 무시)
-     * - 필터: 카테고리, 게시글유형, 상태, 화폐유형, 가격범위
-     * - 검색어와 아이템명 모두 공백 제거 후 비교
+     * 아이템명 + 설명 검색 (LIKE 검색, 띄어쓰기 무시)
+     * Before: item_name만 검색 → "알바"로 검색 시 description에만 있는 키워드 누락
+     * After: item_name OR description 모두 검색
+     * - 필터: 카테고리(다중), 게시글유형(다중), 상태, 화폐유형(다중), 가격범위
+     * - 다중 필터: boolean 플래그 + IN 절 조합 (빈 리스트일 때 필터 스킵)
      * - 가격 필터는 화폐유형(currencyType)과 함께 사용해야 함 (벨 500과 마일 500은 다름)
      */
     @Query(value = "SELECT * FROM posts p WHERE p.deleted_at IS NULL " +
-            "AND LOWER(REPLACE(p.item_name, ' ', '')) LIKE LOWER(CONCAT('%', REPLACE(:keyword, ' ', ''), '%')) " +
-            "AND (:categoryId IS NULL OR p.category_id = :categoryId) " +
-            "AND (:postType IS NULL OR p.post_type = :postType) " +
+            "AND (LOWER(REPLACE(p.item_name, ' ', '')) LIKE LOWER(CONCAT('%', REPLACE(:keyword, ' ', ''), '%')) " +
+            "  OR LOWER(REPLACE(COALESCE(p.description, ''), ' ', '')) LIKE LOWER(CONCAT('%', REPLACE(:keyword, ' ', ''), '%'))) " +
+            "AND (:hasCategoryFilter = false OR p.category_id IN (:categoryIds)) " +
+            "AND (:hasPostTypeFilter = false OR p.post_type IN (:postTypes)) " +
             "AND (:status IS NULL OR p.status = :status) " +
-            "AND (:currencyType IS NULL OR p.currency_type = :currencyType) " +
+            "AND (:hasCurrencyTypeFilter = false OR p.currency_type IN (:currencyTypes)) " +
             "AND (:minPrice IS NULL OR p.price >= :minPrice) " +
             "AND (:maxPrice IS NULL OR p.price <= :maxPrice) " +
             "ORDER BY COALESCE(p.bumped_at, p.created_at) DESC",
             countQuery = "SELECT COUNT(*) FROM posts p WHERE p.deleted_at IS NULL " +
-            "AND LOWER(REPLACE(p.item_name, ' ', '')) LIKE LOWER(CONCAT('%', REPLACE(:keyword, ' ', ''), '%')) " +
-            "AND (:categoryId IS NULL OR p.category_id = :categoryId) " +
-            "AND (:postType IS NULL OR p.post_type = :postType) " +
+            "AND (LOWER(REPLACE(p.item_name, ' ', '')) LIKE LOWER(CONCAT('%', REPLACE(:keyword, ' ', ''), '%')) " +
+            "  OR LOWER(REPLACE(COALESCE(p.description, ''), ' ', '')) LIKE LOWER(CONCAT('%', REPLACE(:keyword, ' ', ''), '%'))) " +
+            "AND (:hasCategoryFilter = false OR p.category_id IN (:categoryIds)) " +
+            "AND (:hasPostTypeFilter = false OR p.post_type IN (:postTypes)) " +
             "AND (:status IS NULL OR p.status = :status) " +
-            "AND (:currencyType IS NULL OR p.currency_type = :currencyType) " +
+            "AND (:hasCurrencyTypeFilter = false OR p.currency_type IN (:currencyTypes)) " +
             "AND (:minPrice IS NULL OR p.price >= :minPrice) " +
             "AND (:maxPrice IS NULL OR p.price <= :maxPrice)",
             nativeQuery = true)
     Page<Post> searchByKeyword(
             @Param("keyword") String keyword,
-            @Param("categoryId") Long categoryId,
-            @Param("postType") String postType,
+            @Param("hasCategoryFilter") boolean hasCategoryFilter,
+            @Param("categoryIds") List<Long> categoryIds,
+            @Param("hasPostTypeFilter") boolean hasPostTypeFilter,
+            @Param("postTypes") List<String> postTypes,
             @Param("status") String status,
-            @Param("currencyType") String currencyType,
+            @Param("hasCurrencyTypeFilter") boolean hasCurrencyTypeFilter,
+            @Param("currencyTypes") List<String> currencyTypes,
             @Param("minPrice") Integer minPrice,
             @Param("maxPrice") Integer maxPrice,
             Pageable pageable);

--- a/apps/api/src/main/java/com/acnh/api/post/service/PostService.java
+++ b/apps/api/src/main/java/com/acnh/api/post/service/PostService.java
@@ -288,7 +288,15 @@ public class PostService {
         if (visitorId == null || "anonymousUser".equals(visitorId)) {
             throw new InvalidRequestException("로그인이 필요합니다");
         }
-        return memberRepository.findByUuidAndDeletedAtIsNull(UUID.fromString(visitorId))
+        // Before: UUID 형식이 아닌 visitorId → IllegalArgumentException → 500
+        // After: try-catch로 400 반환
+        UUID uuid;
+        try {
+            uuid = UUID.fromString(visitorId);
+        } catch (IllegalArgumentException e) {
+            throw new InvalidRequestException("유효하지 않은 사용자 식별자입니다");
+        }
+        return memberRepository.findByUuidAndDeletedAtIsNull(uuid)
                 .orElseThrow(() -> new NotFoundException("사용자", visitorId));
     }
 
@@ -309,7 +317,15 @@ public class PostService {
         if (visitorId == null || "anonymousUser".equals(visitorId)) {
             return null;
         }
-        return memberRepository.findByUuidAndDeletedAtIsNull(UUID.fromString(visitorId))
+        // Before: UUID 형식이 아닌 visitorId → IllegalArgumentException → 500
+        // After: 유효하지 않은 UUID는 비인증 사용자로 처리
+        UUID uuid;
+        try {
+            uuid = UUID.fromString(visitorId);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+        return memberRepository.findByUuidAndDeletedAtIsNull(uuid)
                 .map(Member::getId)
                 .orElse(null);
     }

--- a/apps/api/src/main/java/com/acnh/api/post/service/PostService.java
+++ b/apps/api/src/main/java/com/acnh/api/post/service/PostService.java
@@ -61,7 +61,8 @@ public class PostService {
         boolean hasPostTypeFilter = validPostTypes != null && !validPostTypes.isEmpty();
         boolean hasCurrencyTypeFilter = validCurrencyTypes != null && !validCurrencyTypes.isEmpty();
 
-        // IN 절에 빈 리스트 전달 방지: dummy 값 사용 (boolean 플래그가 false면 평가되지 않음)
+        // IN 절에 빈 리스트 전달 방지: dummy 값 사용 (boolean 플래그가 false면 IN절 평가 안 됨)
+        // -1L은 auto-increment PK이므로 실제 데이터와 충돌 불가 (category_id는 항상 > 0)
         List<Long> categoryIdsParam = hasCategoryFilter ? categoryIds : List.of(-1L);
         List<String> postTypesParam = hasPostTypeFilter ? validPostTypes : List.of("");
         List<String> currencyTypesParam = hasCurrencyTypeFilter ? validCurrencyTypes : List.of("");
@@ -100,6 +101,7 @@ public class PostService {
         boolean hasPostTypeFilter = validPostTypes != null && !validPostTypes.isEmpty();
         boolean hasCurrencyTypeFilter = validCurrencyTypes != null && !validCurrencyTypes.isEmpty();
 
+        // dummy 값: boolean 플래그가 false면 IN절 평가 안 됨 (-1L은 auto-increment PK와 충돌 불가)
         List<Long> categoryIdsParam = hasCategoryFilter ? categoryIds : List.of(-1L);
         List<String> postTypesParam = hasPostTypeFilter ? validPostTypes : List.of("");
         List<String> currencyTypesParam = hasCurrencyTypeFilter ? validCurrencyTypes : List.of("");

--- a/apps/api/src/main/java/com/acnh/api/post/service/PostService.java
+++ b/apps/api/src/main/java/com/acnh/api/post/service/PostService.java
@@ -351,7 +351,10 @@ public class PostService {
         if (postTypes == null || postTypes.isEmpty()) {
             return null;
         }
+        // Before: null/blank 원소 → NullPointerException (Spring이 빈 문자열을 리스트에 넣을 수 있음)
+        // After: null/blank 원소 필터링
         return postTypes.stream()
+                .filter(pt -> pt != null && !pt.isBlank())
                 .map(pt -> {
                     try {
                         return PostType.valueOf(pt.toUpperCase()).name();
@@ -425,7 +428,10 @@ public class PostService {
         if (currencyTypes == null || currencyTypes.isEmpty()) {
             return null;
         }
+        // Before: null/blank 원소 → NullPointerException
+        // After: null/blank 원소 필터링
         return currencyTypes.stream()
+                .filter(ct -> ct != null && !ct.isBlank())
                 .map(ct -> {
                     try {
                         return CurrencyType.valueOf(ct.toUpperCase()).name();

--- a/apps/api/src/main/java/com/acnh/api/post/service/PostService.java
+++ b/apps/api/src/main/java/com/acnh/api/post/service/PostService.java
@@ -21,7 +21,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * 게시글 관련 비즈니스 로직 서비스
@@ -43,18 +45,33 @@ public class PostService {
     /**
      * 게시글 목록 조회 (피드)
      * - bumped_at 우선 정렬
-     * - 필터: 카테고리, 게시글유형, 상태, 화폐유형, 가격범위
+     * - 필터: 카테고리(다중), 게시글유형(다중), 상태, 화폐유형(다중), 가격범위
      * - 가격 필터는 화폐유형(currencyType)과 함께 사용해야 함 (벨 500과 마일 500은 다름)
      */
-    public PostListResponse getFeed(Long categoryId, String postType, String status,
-                                    String currencyType, Integer minPrice, Integer maxPrice,
+    public PostListResponse getFeed(List<Long> categoryIds, List<String> postTypes, String status,
+                                    List<String> currencyTypes, Integer minPrice, Integer maxPrice,
                                     String visitorId, Pageable pageable) {
         // 필터 값 유효성 검증
-        String validPostType = validatePostType(postType);
+        List<String> validPostTypes = validatePostTypes(postTypes);
         String validStatus = validateStatus(status);
-        String validCurrencyType = validateCurrencyTypeOptional(currencyType);
+        List<String> validCurrencyTypes = validateCurrencyTypes(currencyTypes);
 
-        Page<Post> posts = postRepository.findFeed(categoryId, validPostType, validStatus, validCurrencyType, minPrice, maxPrice, pageable);
+        // boolean 플래그: 빈 리스트면 필터 스킵
+        boolean hasCategoryFilter = categoryIds != null && !categoryIds.isEmpty();
+        boolean hasPostTypeFilter = validPostTypes != null && !validPostTypes.isEmpty();
+        boolean hasCurrencyTypeFilter = validCurrencyTypes != null && !validCurrencyTypes.isEmpty();
+
+        // IN 절에 빈 리스트 전달 방지: dummy 값 사용 (boolean 플래그가 false면 평가되지 않음)
+        List<Long> categoryIdsParam = hasCategoryFilter ? categoryIds : List.of(-1L);
+        List<String> postTypesParam = hasPostTypeFilter ? validPostTypes : List.of("");
+        List<String> currencyTypesParam = hasCurrencyTypeFilter ? validCurrencyTypes : List.of("");
+
+        Page<Post> posts = postRepository.findFeed(
+                hasCategoryFilter, categoryIdsParam,
+                hasPostTypeFilter, postTypesParam,
+                validStatus,
+                hasCurrencyTypeFilter, currencyTypesParam,
+                minPrice, maxPrice, pageable);
 
         Long currentUserId = getCurrentUserId(visitorId);
         Page<PostResponse> responsePage = posts.map(post -> toPostResponse(post, currentUserId));
@@ -64,22 +81,35 @@ public class PostService {
 
     /**
      * 게시글 검색
-     * - 아이템명 LIKE 검색
-     * - 필터: 카테고리, 게시글유형, 상태, 화폐유형, 가격범위
+     * - 아이템명 + 설명 LIKE 검색
+     * - 필터: 카테고리(다중), 게시글유형(다중), 상태, 화폐유형(다중), 가격범위
      * - 가격 필터는 화폐유형(currencyType)과 함께 사용해야 함 (벨 500과 마일 500은 다름)
      */
-    public PostListResponse searchPosts(String keyword, Long categoryId, String postType,
-                                        String status, String currencyType, Integer minPrice, Integer maxPrice,
+    public PostListResponse searchPosts(String keyword, List<Long> categoryIds, List<String> postTypes,
+                                        String status, List<String> currencyTypes, Integer minPrice, Integer maxPrice,
                                         String visitorId, Pageable pageable) {
         if (keyword == null || keyword.isBlank()) {
             throw new InvalidRequestException("검색어를 입력해주세요");
         }
 
-        String validPostType = validatePostType(postType);
+        List<String> validPostTypes = validatePostTypes(postTypes);
         String validStatus = validateStatus(status);
-        String validCurrencyType = validateCurrencyTypeOptional(currencyType);
+        List<String> validCurrencyTypes = validateCurrencyTypes(currencyTypes);
 
-        Page<Post> posts = postRepository.searchByKeyword(keyword, categoryId, validPostType, validStatus, validCurrencyType, minPrice, maxPrice, pageable);
+        boolean hasCategoryFilter = categoryIds != null && !categoryIds.isEmpty();
+        boolean hasPostTypeFilter = validPostTypes != null && !validPostTypes.isEmpty();
+        boolean hasCurrencyTypeFilter = validCurrencyTypes != null && !validCurrencyTypes.isEmpty();
+
+        List<Long> categoryIdsParam = hasCategoryFilter ? categoryIds : List.of(-1L);
+        List<String> postTypesParam = hasPostTypeFilter ? validPostTypes : List.of("");
+        List<String> currencyTypesParam = hasCurrencyTypeFilter ? validCurrencyTypes : List.of("");
+
+        Page<Post> posts = postRepository.searchByKeyword(keyword,
+                hasCategoryFilter, categoryIdsParam,
+                hasPostTypeFilter, postTypesParam,
+                validStatus,
+                hasCurrencyTypeFilter, currencyTypesParam,
+                minPrice, maxPrice, pageable);
 
         Long currentUserId = getCurrentUserId(visitorId);
         Page<PostResponse> responsePage = posts.map(post -> toPostResponse(post, currentUserId));
@@ -313,17 +343,21 @@ public class PostService {
     }
 
     /**
-     * PostType 유효성 검증 (선택, null 허용)
+     * PostType 리스트 유효성 검증 (다중 필터용, null/빈 리스트 허용)
      */
-    private String validatePostType(String postType) {
-        if (postType == null || postType.isBlank()) {
+    private List<String> validatePostTypes(List<String> postTypes) {
+        if (postTypes == null || postTypes.isEmpty()) {
             return null;
         }
-        try {
-            return PostType.valueOf(postType.toUpperCase()).name();
-        } catch (IllegalArgumentException e) {
-            throw new InvalidRequestException("유효하지 않은 게시글 유형입니다: " + postType);
-        }
+        return postTypes.stream()
+                .map(pt -> {
+                    try {
+                        return PostType.valueOf(pt.toUpperCase()).name();
+                    } catch (IllegalArgumentException e) {
+                        throw new InvalidRequestException("유효하지 않은 게시글 유형입니다: " + pt);
+                    }
+                })
+                .collect(Collectors.toList());
     }
 
     /**
@@ -383,16 +417,20 @@ public class PostService {
     }
 
     /**
-     * CurrencyType 유효성 검증 (선택, 필터용 - null 허용)
+     * CurrencyType 리스트 유효성 검증 (다중 필터용, null/빈 리스트 허용)
      */
-    private String validateCurrencyTypeOptional(String currencyType) {
-        if (currencyType == null || currencyType.isBlank()) {
+    private List<String> validateCurrencyTypes(List<String> currencyTypes) {
+        if (currencyTypes == null || currencyTypes.isEmpty()) {
             return null;
         }
-        try {
-            return CurrencyType.valueOf(currencyType.toUpperCase()).name();
-        } catch (IllegalArgumentException e) {
-            throw new InvalidRequestException("유효하지 않은 화폐 유형입니다: " + currencyType);
-        }
+        return currencyTypes.stream()
+                .map(ct -> {
+                    try {
+                        return CurrencyType.valueOf(ct.toUpperCase()).name();
+                    } catch (IllegalArgumentException e) {
+                        throw new InvalidRequestException("유효하지 않은 화폐 유형입니다: " + ct);
+                    }
+                })
+                .collect(Collectors.toList());
     }
 }

--- a/apps/api/src/main/java/com/acnh/api/review/controller/ReviewController.java
+++ b/apps/api/src/main/java/com/acnh/api/review/controller/ReviewController.java
@@ -29,6 +29,30 @@ public class ReviewController {
     private static final int DEFAULT_PAGE_SIZE = 20;
 
     /**
+     * 내가 받은 리뷰 목록 조회
+     * GET /api/users/me/reviews
+     */
+    @GetMapping("/users/me/reviews")
+    public ResponseEntity<?> getMyReviews(
+            @AuthenticationPrincipal String visitorId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+
+        log.info("내 리뷰 목록 조회 요청 - visitorId: {}", visitorId);
+
+        if (visitorId == null || "anonymousUser".equals(visitorId)) {
+            return ResponseEntity.status(401).body(Map.of(
+                    "error", "UNAUTHORIZED",
+                    "message", "로그인이 필요합니다"
+            ));
+        }
+
+        Pageable pageable = PageRequest.of(page, Math.min(size, DEFAULT_PAGE_SIZE));
+        ReviewListResponse response = reviewService.getMyReviews(visitorId, pageable);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
      * 유저가 받은 리뷰 목록 조회
      * GET /api/users/{userId}/reviews
      */

--- a/apps/api/src/main/java/com/acnh/api/review/controller/ReviewController.java
+++ b/apps/api/src/main/java/com/acnh/api/review/controller/ReviewController.java
@@ -29,6 +29,21 @@ public class ReviewController {
     private static final int DEFAULT_PAGE_SIZE = 20;
 
     /**
+     * 페이지네이션 파라미터 검증
+     * Before: page < 0 또는 size <= 0 시 PageRequest.of에서 IllegalArgumentException 발생 → 500
+     * After: 사전 검증으로 400 반환
+     */
+    private ResponseEntity<?> validatePagination(int page, int size) {
+        if (page < 0 || size <= 0) {
+            return ResponseEntity.status(400).body(Map.of(
+                    "error", "INVALID_PARAMETER",
+                    "message", "page는 0 이상, size는 1 이상이어야 합니다"
+            ));
+        }
+        return null;
+    }
+
+    /**
      * 내가 받은 리뷰 목록 조회
      * GET /api/users/me/reviews
      */
@@ -47,6 +62,9 @@ public class ReviewController {
             ));
         }
 
+        ResponseEntity<?> validationError = validatePagination(page, size);
+        if (validationError != null) return validationError;
+
         Pageable pageable = PageRequest.of(page, Math.min(size, DEFAULT_PAGE_SIZE));
         ReviewListResponse response = reviewService.getMyReviews(visitorId, pageable);
         return ResponseEntity.ok(response);
@@ -64,7 +82,9 @@ public class ReviewController {
 
         log.info("유저 리뷰 목록 조회 요청 - userId: {}, page: {}, size: {}", userId, page, size);
 
-        // GlobalExceptionHandler가 NotFoundException/InvalidRequestException 처리
+        ResponseEntity<?> validationError = validatePagination(page, size);
+        if (validationError != null) return validationError;
+
         Pageable pageable = PageRequest.of(page, Math.min(size, DEFAULT_PAGE_SIZE));
         ReviewListResponse response = reviewService.getReviewsByUserId(userId, pageable);
         return ResponseEntity.ok(response);

--- a/apps/api/src/main/java/com/acnh/api/review/service/ReviewService.java
+++ b/apps/api/src/main/java/com/acnh/api/review/service/ReviewService.java
@@ -98,6 +98,14 @@ public class ReviewService {
     }
 
     /**
+     * 내가 받은 리뷰 목록 조회 (visitorId 기반)
+     */
+    public ReviewListResponse getMyReviews(String visitorId, Pageable pageable) {
+        Member member = findMemberByUuid(visitorId);
+        return getReviewsByUserId(member.getId(), pageable);
+    }
+
+    /**
      * 유저가 받은 리뷰 목록 조회
      */
     public ReviewListResponse getReviewsByUserId(Long userId, Pageable pageable) {

--- a/apps/app/src/screens/HomeScreen.tsx
+++ b/apps/app/src/screens/HomeScreen.tsx
@@ -1,8 +1,8 @@
 // 홈 화면 (WebView로 웹앱 표시)
 
-import React from 'react';
-import { StyleSheet, View, ActivityIndicator, Text } from 'react-native';
-import { WebView, WebViewMessageEvent } from 'react-native-webview';
+import React, { useRef } from 'react';
+import { StyleSheet, View, ActivityIndicator, Text, BackHandler, Platform } from 'react-native';
+import { WebView, WebViewMessageEvent, WebViewNavigation } from 'react-native-webview';
 import { getAccessToken, removeAccessToken } from '../auth';
 
 // WebView에서 전달받는 메시지 타입
@@ -18,6 +18,8 @@ interface HomeScreenProps {
 export default function HomeScreen({ onLoginRequest }: HomeScreenProps) {
   const [token, setToken] = React.useState<string | null>(null);
   const [isLoading, setIsLoading] = React.useState(true);
+  const [canGoBack, setCanGoBack] = React.useState(false);
+  const webViewRef = useRef<WebView>(null);
 
   // 환경 변수를 컴포넌트 내부에서 가져옴 (Metro 연결 후 실행됨)
   const WEB_URL = process.env.EXPO_PUBLIC_WEB_URL;
@@ -25,6 +27,22 @@ export default function HomeScreen({ onLoginRequest }: HomeScreenProps) {
   React.useEffect(() => {
     loadToken();
   }, []);
+
+  // Android 하드웨어 뒤로가기 버튼/제스처 처리
+  React.useEffect(() => {
+    if (Platform.OS !== 'android') return;
+
+    const onBackPress = () => {
+      if (canGoBack && webViewRef.current) {
+        webViewRef.current.goBack();
+        return true; // 이벤트 소비 (앱 종료 방지)
+      }
+      return false; // 기본 동작 (앱 종료)
+    };
+
+    const subscription = BackHandler.addEventListener('hardwareBackPress', onBackPress);
+    return () => subscription.remove();
+  }, [canGoBack]);
 
   async function loadToken() {
     try {
@@ -71,9 +89,13 @@ export default function HomeScreen({ onLoginRequest }: HomeScreenProps) {
   return (
     <View style={styles.container}>
       <WebView
+        ref={webViewRef}
         source={{ uri: WEB_URL }}
         style={styles.webview}
         injectedJavaScriptBeforeContentLoaded={injectedJavaScriptBeforeContentLoaded}
+        onNavigationStateChange={(navState: WebViewNavigation) => {
+          setCanGoBack(navState.canGoBack);
+        }}
         onMessage={(event: WebViewMessageEvent) => {
           // 웹에서 앱으로 메시지 전달 처리
           try {

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -14,5 +14,5 @@ NEXT_PUBLIC_WS_URL=ws://localhost:8080/ws
 
 # 아이콘 경로 설정
 NEXT_PUBLIC_ICON_ISLAND=/icons/island.png
-NEXT_PUBLIC_ICON_RACCOON=/icons/island.png
+NEXT_PUBLIC_ICON_RACCOON=/icons/raccoon_bill.svg
 NEXT_PUBLIC_ICON_CARROT=/icons/carrot.svg

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -14,5 +14,5 @@ NEXT_PUBLIC_WS_URL=ws://localhost:8080/ws
 
 # 아이콘 경로 설정
 NEXT_PUBLIC_ICON_ISLAND=/icons/island.png
-NEXT_PUBLIC_ICON_RACCOON=/icons/raccoon_bill.svg
+NEXT_PUBLIC_ICON_RACCOON=/icons/island.png
 NEXT_PUBLIC_ICON_CARROT=/icons/carrot.svg

--- a/apps/web/src/app/alarm/page.tsx
+++ b/apps/web/src/app/alarm/page.tsx
@@ -13,7 +13,7 @@ const mockAlarms = [
     title: "키워드 알림",
     message: "'자전거' 키워드로 새 글이 등록되었어요.",
     time: "방금 전",
-    product: { image: "/icons/raccoon_bill.svg" },
+    product: { image: "/icons/island.png" },
     read: false,
   },
   {
@@ -31,7 +31,7 @@ const mockAlarms = [
     title: "새 채팅",
     message: "요우님이 메시지를 보냈어요.",
     time: "3시간 전",
-    product: { image: "/icons/raccoon_bill.svg" },
+    product: { image: "/icons/island.png" },
     read: true,
   },
   {
@@ -58,7 +58,7 @@ const mockAlarms = [
     title: "공지사항",
     message: "AC-Trading 서비스 업데이트 안내",
     time: "3일 전",
-    product: { image: "/icons/raccoon_bill.svg" },
+    product: { image: "/icons/island.png" },
     read: true,
   },
   {
@@ -76,7 +76,7 @@ const mockAlarms = [
     title: "키워드 알림",
     message: "'아이폰' 키워드로 새 글이 등록되었어요.",
     time: "1주 전",
-    product: { image: "/icons/raccoon_bill.svg" },
+    product: { image: "/icons/island.png" },
     read: true,
   },
   {
@@ -114,7 +114,7 @@ function AlarmItem({ alarm }: { alarm: (typeof mockAlarms)[0] }) {
 
       {/* 상품 카테고리 아이콘 */}
       <img
-        src={alarm.product?.image || process.env.NEXT_PUBLIC_ICON_RACCOON || "/icons/raccoon_bill.svg"}
+        src={alarm.product?.image || process.env.NEXT_PUBLIC_ICON_RACCOON || "/icons/island.png"}
         alt="알림 아이콘"
         className="w-12 h-12 rounded-lg flex-shrink-0 object-cover bg-gray-100"
       />

--- a/apps/web/src/app/alarm/page.tsx
+++ b/apps/web/src/app/alarm/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import Link from "next/link";
+import Image from "next/image";
 import { MobileLayout, Header } from "@/components/common";
 import { RefreshIcon } from "@/components/icons";
 
@@ -113,9 +114,11 @@ function AlarmItem({ alarm }: { alarm: (typeof mockAlarms)[0] }) {
       </div>
 
       {/* 상품 카테고리 아이콘 */}
-      <img
-        src={alarm.product?.image || process.env.NEXT_PUBLIC_ICON_RACCOON || "/icons/island.png"}
+      <Image
+        src={alarm.product?.image || process.env.NEXT_PUBLIC_ICON_RACCOON || "/icons/raccoon_bill.svg"}
         alt="알림 아이콘"
+        width={48}
+        height={48}
         className="w-12 h-12 rounded-lg flex-shrink-0 object-cover bg-gray-100"
       />
     </Link>

--- a/apps/web/src/app/alarm/page.tsx
+++ b/apps/web/src/app/alarm/page.tsx
@@ -1,101 +1,50 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { MobileLayout, Header } from "@/components/common";
 import { RefreshIcon } from "@/components/icons";
+import { useAuth } from "@/context/AuthContext";
+import {
+  getNotifications,
+  markNotificationAsRead,
+  markAllNotificationsAsRead,
+  formatRelativeTime,
+  NotificationItem,
+} from "@/lib/postApi";
 
-// 더미 알림 목록 데이터
-const mockAlarms = [
-  {
-    id: 1,
-    type: "keyword",
-    title: "키워드 알림",
-    message: "'자전거' 키워드로 새 글이 등록되었어요.",
-    time: "방금 전",
-    product: { image: "/icons/island.png" },
-    read: false,
-  },
-  {
-    id: 2,
-    type: "price",
-    title: "가격 인하",
-    message: "관심 상품 '에어팟 프로'의 가격이 내려갔어요.",
-    time: "1시간 전",
-    product: { image: "/icons/island.png" },
-    read: false,
-  },
-  {
-    id: 3,
-    type: "chat",
-    title: "새 채팅",
-    message: "요우님이 메시지를 보냈어요.",
-    time: "3시간 전",
-    product: { image: "/icons/island.png" },
-    read: true,
-  },
-  {
-    id: 4,
-    type: "like",
-    title: "관심 상품",
-    message: "관심 등록한 '커피머신'이 판매 완료되었어요.",
-    time: "1일 전",
-    product: { image: "/icons/island.png" },
-    read: true,
-  },
-  {
-    id: 5,
-    type: "keyword",
-    title: "키워드 알림",
-    message: "'닌텐도' 키워드로 새 글이 등록되었어요.",
-    time: "2일 전",
-    product: { image: "/icons/island.png" },
-    read: true,
-  },
-  {
-    id: 6,
-    type: "system",
-    title: "공지사항",
-    message: "AC-Trading 서비스 업데이트 안내",
-    time: "3일 전",
-    product: { image: "/icons/island.png" },
-    read: true,
-  },
-  {
-    id: 7,
-    type: "price",
-    title: "가격 인하",
-    message: "관심 상품 '바이레도 블랑쉬'의 가격이 내려갔어요.",
-    time: "1주 전",
-    product: { image: "/icons/carrot.svg" },
-    read: true,
-  },
-  {
-    id: 8,
-    type: "keyword",
-    title: "키워드 알림",
-    message: "'아이폰' 키워드로 새 글이 등록되었어요.",
-    time: "1주 전",
-    product: { image: "/icons/island.png" },
-    read: true,
-  },
-  {
-    id: 9,
-    type: "system",
-    title: "이벤트",
-    message: "첫 거래 완료 시 포인트 적립 이벤트!",
-    time: "2주 전",
-    product: { image: "/icons/island.png" },
-    read: true,
-  },
-];
+// 알림 타입별 링크 생성
+function getAlarmLink(alarm: NotificationItem): string {
+  // referenceType과 referenceId로 이동할 페이지 결정
+  switch (alarm.referenceType) {
+    case "CHAT_ROOM":
+      return alarm.referenceId ? `/chat/${alarm.referenceId}` : "/chat";
+    case "POST":
+      return alarm.referenceId ? `/post/${alarm.referenceId}` : "/";
+    default:
+      return "#";
+  }
+}
 
-// 알림 아이템 컴포넌트 (채팅 리스트와 동일한 디자인, 프로필 제외)
-function AlarmItem({ alarm }: { alarm: (typeof mockAlarms)[0] }) {
+// 알림 아이템 컴포넌트
+function AlarmItem({
+  alarm,
+  onRead,
+}: {
+  alarm: NotificationItem;
+  onRead: (id: number) => void;
+}) {
+  const handleClick = () => {
+    if (!alarm.read) {
+      onRead(alarm.id);
+    }
+  };
+
   return (
     <Link
-      href={alarm.type === "chat" ? "/chat" : "#"}
+      href={getAlarmLink(alarm)}
+      onClick={handleClick}
       className={`flex items-center gap-3 p-4 hover:bg-gray-50 transition-colors border-b border-gray-100 ${
         !alarm.read ? "bg-primary-light/20" : ""
       }`}
@@ -104,18 +53,22 @@ function AlarmItem({ alarm }: { alarm: (typeof mockAlarms)[0] }) {
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2">
           <span className="font-medium text-black">{alarm.title}</span>
-          <span className="text-xs text-black">· {alarm.time}</span>
+          <span className="text-xs text-black">
+            · {formatRelativeTime(alarm.createdAt)}
+          </span>
           {/* 읽지 않은 알림 표시 */}
           {!alarm.read && (
             <span className="w-2 h-2 bg-primary rounded-full flex-shrink-0" />
           )}
         </div>
-        <p className="text-sm text-black truncate mt-0.5">{alarm.message}</p>
+        {alarm.content && (
+          <p className="text-sm text-black truncate mt-0.5">{alarm.content}</p>
+        )}
       </div>
 
       {/* 상품 카테고리 아이콘 */}
       <Image
-        src={alarm.product?.image || process.env.NEXT_PUBLIC_ICON_RACCOON || "/icons/raccoon_bill.svg"}
+        src={process.env.NEXT_PUBLIC_ICON_ISLAND || "/icons/island.png"}
         alt="알림 아이콘"
         width={48}
         height={48}
@@ -125,13 +78,66 @@ function AlarmItem({ alarm }: { alarm: (typeof mockAlarms)[0] }) {
   );
 }
 
-// 알림 목록 페이지 - 채팅 목록과 동일한 디자인 (프로필 제외)
+// 알림 목록 페이지 - 더미 데이터 제거, 실제 API 연동
 export default function AlarmListPage() {
-  // 알림 목록 상태 (추후 API 연동 시 useEffect에서 fetch)
-  const [alarms] = useState(mockAlarms);
+  const { isAuthenticated, isLoading: authLoading } = useAuth();
+  const [alarms, setAlarms] = useState<NotificationItem[]>([]);
+  const [unreadCount, setUnreadCount] = useState(0);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
-  // 읽지 않은 알림 개수
-  const unreadCount = alarms.filter((alarm) => !alarm.read).length;
+  // 알림 목록 로드
+  const loadAlarms = async () => {
+    try {
+      setIsLoading(true);
+      setError(null);
+      const response = await getNotifications(0, 50);
+      setAlarms(response.notifications);
+      setUnreadCount(response.unreadCount);
+    } catch (err) {
+      console.error("알림 로드 실패:", err);
+      setError(
+        err instanceof Error ? err.message : "알림을 불러오는데 실패했습니다"
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (!authLoading && isAuthenticated) {
+      loadAlarms();
+    } else if (!authLoading && !isAuthenticated) {
+      setIsLoading(false);
+    }
+  }, [authLoading, isAuthenticated]);
+
+  // 개별 알림 읽음 처리
+  const handleRead = async (id: number) => {
+    try {
+      await markNotificationAsRead(id);
+      setAlarms((prev) =>
+        prev.map((a) => (a.id === id ? { ...a, read: true, isRead: true } : a))
+      );
+      setUnreadCount((prev) => Math.max(0, prev - 1));
+    } catch (err) {
+      console.error("알림 읽음 처리 실패:", err);
+    }
+  };
+
+  // 모든 알림 읽음 처리
+  const handleReadAll = async () => {
+    if (unreadCount === 0) return;
+    try {
+      await markAllNotificationsAsRead();
+      setAlarms((prev) =>
+        prev.map((a) => ({ ...a, read: true, isRead: true }))
+      );
+      setUnreadCount(0);
+    } catch (err) {
+      console.error("모든 알림 읽음 처리 실패:", err);
+    }
+  };
 
   return (
     <MobileLayout>
@@ -141,28 +147,83 @@ export default function AlarmListPage() {
         showBack
         onBack={() => window.history.back()}
         rightElement={
-          <button className="p-1 hover:bg-gray-100 rounded-full transition-colors">
+          <button
+            onClick={loadAlarms}
+            className="p-1 hover:bg-gray-100 rounded-full transition-colors"
+          >
             <RefreshIcon className="w-5 h-5 text-black" />
           </button>
         }
       />
 
-      {/* 읽지 않은 알림 개수 표시 */}
-      {unreadCount > 0 && (
-        <div className="px-4 py-2 bg-primary-light/30 text-primary text-sm font-medium">
-          읽지 않은 알림 {unreadCount}개
+      {/* 비로그인 상태 */}
+      {!authLoading && !isAuthenticated && (
+        <div className="flex flex-col items-center justify-center py-20 text-gray-400">
+          <span className="text-6xl mb-4">🔒</span>
+          <p>로그인이 필요합니다</p>
+          <Link
+            href="/login"
+            className="mt-4 px-4 py-2 text-sm text-primary hover:underline"
+          >
+            로그인하기
+          </Link>
+        </div>
+      )}
+
+      {/* 로딩 상태 */}
+      {isLoading && (
+        <div className="flex items-center justify-center py-20">
+          <div className="animate-spin rounded-full h-8 w-8 border-2 border-primary border-t-transparent" />
+        </div>
+      )}
+
+      {/* 에러 상태 */}
+      {error && !isLoading && (
+        <div className="flex flex-col items-center justify-center py-20 text-gray-500">
+          <p className="text-sm">{error}</p>
+          <button
+            onClick={loadAlarms}
+            className="mt-4 px-4 py-2 text-sm text-primary hover:underline"
+          >
+            다시 시도
+          </button>
+        </div>
+      )}
+
+      {/* 읽지 않은 알림 개수 + 모두 읽기 */}
+      {!isLoading && !error && isAuthenticated && alarms.length > 0 && (
+        <div className="flex items-center justify-between px-4 py-2 bg-primary-light/30">
+          {unreadCount > 0 ? (
+            <span className="text-primary text-sm font-medium">
+              읽지 않은 알림 {unreadCount}개
+            </span>
+          ) : (
+            <span className="text-gray-500 text-sm">
+              모든 알림을 확인했습니다
+            </span>
+          )}
+          {unreadCount > 0 && (
+            <button
+              onClick={handleReadAll}
+              className="text-xs text-primary hover:underline"
+            >
+              모두 읽기
+            </button>
+          )}
         </div>
       )}
 
       {/* 알림 목록 */}
-      <div>
-        {alarms.map((alarm) => (
-          <AlarmItem key={alarm.id} alarm={alarm} />
-        ))}
-      </div>
+      {!isLoading && !error && isAuthenticated && alarms.length > 0 && (
+        <div>
+          {alarms.map((alarm) => (
+            <AlarmItem key={alarm.id} alarm={alarm} onRead={handleRead} />
+          ))}
+        </div>
+      )}
 
       {/* 알림 없을 때 빈 상태 */}
-      {alarms.length === 0 && (
+      {!isLoading && !error && isAuthenticated && alarms.length === 0 && (
         <div className="flex flex-col items-center justify-center py-20 text-gray-400">
           <span className="text-6xl mb-4">🔔</span>
           <p>아직 알림이 없어요</p>

--- a/apps/web/src/app/alarm/page.tsx
+++ b/apps/web/src/app/alarm/page.tsx
@@ -36,7 +36,7 @@ function AlarmItem({
   onRead: (id: number) => void;
 }) {
   const handleClick = () => {
-    if (!alarm.read) {
+    if (!alarm.isRead) {
       onRead(alarm.id);
     }
   };
@@ -46,7 +46,7 @@ function AlarmItem({
       href={getAlarmLink(alarm)}
       onClick={handleClick}
       className={`flex items-center gap-3 p-4 hover:bg-gray-50 transition-colors border-b border-gray-100 ${
-        !alarm.read ? "bg-primary-light/20" : ""
+        !alarm.isRead ? "bg-primary-light/20" : ""
       }`}
     >
       {/* 알림 정보 */}
@@ -57,7 +57,7 @@ function AlarmItem({
             · {formatRelativeTime(alarm.createdAt)}
           </span>
           {/* 읽지 않은 알림 표시 */}
-          {!alarm.read && (
+          {!alarm.isRead && (
             <span className="w-2 h-2 bg-primary rounded-full flex-shrink-0" />
           )}
         </div>
@@ -117,7 +117,7 @@ export default function AlarmListPage() {
     try {
       await markNotificationAsRead(id);
       setAlarms((prev) =>
-        prev.map((a) => (a.id === id ? { ...a, read: true, isRead: true } : a))
+        prev.map((a) => (a.id === id ? { ...a, isRead: true } : a))
       );
       setUnreadCount((prev) => Math.max(0, prev - 1));
     } catch (err) {
@@ -131,7 +131,7 @@ export default function AlarmListPage() {
     try {
       await markAllNotificationsAsRead();
       setAlarms((prev) =>
-        prev.map((a) => ({ ...a, read: true, isRead: true }))
+        prev.map((a) => ({ ...a, isRead: true }))
       );
       setUnreadCount(0);
     } catch (err) {

--- a/apps/web/src/app/alarm/page.tsx
+++ b/apps/web/src/app/alarm/page.tsx
@@ -102,14 +102,14 @@ function AlarmItem({ alarm }: { alarm: (typeof mockAlarms)[0] }) {
       {/* 알림 정보 */}
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2">
-          <span className="font-medium text-gray-900">{alarm.title}</span>
-          <span className="text-xs text-gray-400">· {alarm.time}</span>
+          <span className="font-medium text-black">{alarm.title}</span>
+          <span className="text-xs text-black">· {alarm.time}</span>
           {/* 읽지 않은 알림 표시 */}
           {!alarm.read && (
             <span className="w-2 h-2 bg-primary rounded-full flex-shrink-0" />
           )}
         </div>
-        <p className="text-sm text-gray-600 truncate mt-0.5">{alarm.message}</p>
+        <p className="text-sm text-black truncate mt-0.5">{alarm.message}</p>
       </div>
 
       {/* 상품 카테고리 아이콘 */}
@@ -139,7 +139,7 @@ export default function AlarmListPage() {
         onBack={() => window.history.back()}
         rightElement={
           <button className="p-1 hover:bg-gray-100 rounded-full transition-colors">
-            <RefreshIcon className="w-5 h-5 text-gray-800" />
+            <RefreshIcon className="w-5 h-5 text-black" />
           </button>
         }
       />

--- a/apps/web/src/app/chat/[id]/page.tsx
+++ b/apps/web/src/app/chat/[id]/page.tsx
@@ -31,7 +31,7 @@ function MessageBubble({ message }: { message: DisplayMessage }) {
     <div className={`flex ${message.isMe ? "justify-end" : "justify-start"} mb-3`}>
       {!message.isMe && (
         <Image
-          src={process.env.NEXT_PUBLIC_ICON_RACCOON || "/icons/island.png"}
+          src={process.env.NEXT_PUBLIC_ICON_ISLAND || "/icons/island.png"}
           alt="프로필"
           width={40}
           height={40}

--- a/apps/web/src/app/chat/[id]/page.tsx
+++ b/apps/web/src/app/chat/[id]/page.tsx
@@ -491,7 +491,7 @@ export default function ChatRoomPage() {
                 placeholder={isConnected ? "메시지를 입력하세요" : "연결 중..."}
                 value={inputMessage}
                 onChange={(e) => setInputMessage(e.target.value)}
-                onKeyPress={handleKeyPress}
+                onKeyDown={handleKeyPress}
                 disabled={!isConnected}
                 className="flex-1 px-4 py-2 bg-white/90 rounded-full text-gray-800 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-white/50 disabled:opacity-50"
               />

--- a/apps/web/src/app/chat/[id]/page.tsx
+++ b/apps/web/src/app/chat/[id]/page.tsx
@@ -31,7 +31,7 @@ function MessageBubble({ message }: { message: DisplayMessage }) {
     <div className={`flex ${message.isMe ? "justify-end" : "justify-start"} mb-3`}>
       {!message.isMe && (
         <Image
-          src={process.env.NEXT_PUBLIC_ICON_RACCOON || "/icons/raccoon_bill.svg"}
+          src={process.env.NEXT_PUBLIC_ICON_RACCOON || "/icons/island.png"}
           alt="프로필"
           width={40}
           height={40}

--- a/apps/web/src/app/chat/[id]/page.tsx
+++ b/apps/web/src/app/chat/[id]/page.tsx
@@ -235,9 +235,11 @@ export default function ChatRoomPage() {
       }
     );
 
-    // 클린업
+    // Before: 구독만 해제 → 좀비 WebSocket 연결 잔류
+    // After: 구독 해제 + WebSocket 연결 종료
     return () => {
       webSocketClient.unsubscribeFromChatRoom(roomId);
+      webSocketClient.disconnect();
     };
   }, [accessToken, roomId, isLoading, currentUserId]);
 
@@ -593,8 +595,9 @@ export default function ChatRoomPage() {
                 <button
                   onClick={() => {
                     setShowMoreMenu(false);
-                    // TODO: 매너 평가 기능 구현
-                    alert("매너 평가 기능은 준비 중입니다.");
+                    // Before: alert("매너 평가 기능은 준비 중입니다.")
+                    // After: 리뷰 페이지로 이동 (postId, revieweeId 전달)
+                    router.push(`/review?postId=${chatRoom?.postId}&revieweeId=${chatRoom?.otherUserId}`);
                   }}
                   className="flex items-center gap-3 w-full px-6 py-4 hover:bg-gray-50 transition-colors"
                 >

--- a/apps/web/src/app/chat/[id]/page.tsx
+++ b/apps/web/src/app/chat/[id]/page.tsx
@@ -359,7 +359,7 @@ export default function ChatRoomPage() {
               onClick={() => router.back()}
               className="p-1 -ml-1 hover:bg-gray-100 rounded-full transition-colors"
             >
-              <ChevronLeftIcon className="text-gray-800" />
+              <ChevronLeftIcon className="text-black" />
             </button>
             <div className="flex items-center gap-2">
               <h1 className="font-semibold text-lg">{chatRoom?.otherUserNickname}</h1>
@@ -371,7 +371,7 @@ export default function ChatRoomPage() {
               onClick={() => setShowMoreMenu(true)}
               className="p-1 hover:bg-gray-100 rounded-full transition-colors"
             >
-              <MoreVerticalIcon className="w-6 h-6 text-gray-800" />
+              <MoreVerticalIcon className="w-6 h-6 text-black" />
             </button>
           </div>
         </header>

--- a/apps/web/src/app/chat/[id]/page.tsx
+++ b/apps/web/src/app/chat/[id]/page.tsx
@@ -597,7 +597,8 @@ export default function ChatRoomPage() {
                     setShowMoreMenu(false);
                     // Before: alert("매너 평가 기능은 준비 중입니다.")
                     // After: 리뷰 페이지로 이동 (postId, revieweeId 전달)
-                    router.push(`/review?postId=${chatRoom?.postId}&revieweeId=${chatRoom?.otherUserId}`);
+                    if (!chatRoom) return;
+                    router.push(`/review?postId=${chatRoom.postId}&revieweeId=${chatRoom.otherUserId}`);
                   }}
                   className="flex items-center gap-3 w-full px-6 py-4 hover:bg-gray-50 transition-colors"
                 >

--- a/apps/web/src/app/chat/page.tsx
+++ b/apps/web/src/app/chat/page.tsx
@@ -18,7 +18,7 @@ function ChatItem({ chat }: { chat: ChatRoom }) {
     >
       {/* 프로필 이미지 */}
       <Image
-        src={process.env.NEXT_PUBLIC_ICON_RACCOON || "/icons/island.png"}
+        src={process.env.NEXT_PUBLIC_ICON_ISLAND || "/icons/island.png"}
         alt="프로필"
         width={48}
         height={48}

--- a/apps/web/src/app/chat/page.tsx
+++ b/apps/web/src/app/chat/page.tsx
@@ -28,20 +28,20 @@ function ChatItem({ chat }: { chat: ChatRoom }) {
       {/* 채팅 정보 */}
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2">
-          <span className="font-medium text-gray-900">{chat.otherUserNickname}</span>
+          <span className="font-medium text-black">{chat.otherUserNickname}</span>
           {chat.otherUserIslandName && (
-            <span className="text-xs text-gray-400">{chat.otherUserIslandName}</span>
+            <span className="text-xs text-black">{chat.otherUserIslandName}</span>
           )}
-          <span className="text-xs text-gray-400">· {formatChatTime(chat.lastMessageAt)}</span>
+          <span className="text-xs text-black">· {formatChatTime(chat.lastMessageAt)}</span>
         </div>
-        <p className="text-sm text-gray-600 truncate mt-0.5">
+        <p className="text-sm text-black truncate mt-0.5">
           {chat.lastMessage || "채팅을 시작해보세요!"}
         </p>
       </div>
 
       {/* 상품 정보 표시 */}
       <div className="flex flex-col items-end gap-1">
-        <span className="text-xs text-gray-500 max-w-[80px] truncate">
+        <span className="text-xs text-black max-w-[80px] truncate">
           {chat.postItemName}
         </span>
         {chat.postStatus && (
@@ -144,10 +144,10 @@ export default function ChatListPage() {
               onClick={handleRefresh}
               className="p-1 hover:bg-gray-100 rounded-full transition-colors"
             >
-              <RefreshIcon className="w-5 h-5 text-gray-800" />
+              <RefreshIcon className="w-5 h-5 text-black" />
             </button>
             <button className="p-1 hover:bg-gray-100 rounded-full transition-colors">
-              <BellIcon className="w-5 h-5 text-gray-800" />
+              <BellIcon className="w-5 h-5 text-black" />
             </button>
           </div>
         }

--- a/apps/web/src/app/chat/page.tsx
+++ b/apps/web/src/app/chat/page.tsx
@@ -18,7 +18,7 @@ function ChatItem({ chat }: { chat: ChatRoom }) {
     >
       {/* 프로필 이미지 */}
       <Image
-        src={process.env.NEXT_PUBLIC_ICON_RACCOON || "/icons/raccoon_bill.svg"}
+        src={process.env.NEXT_PUBLIC_ICON_RACCOON || "/icons/island.png"}
         alt="프로필"
         width={48}
         height={48}

--- a/apps/web/src/app/collection/page.tsx
+++ b/apps/web/src/app/collection/page.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useState, useEffect } from "react";
+import Image from "next/image";
 import { MobileLayout, Header } from "@/components/common";
 import { HeartIcon } from "@/components/icons";
 import { useAuth } from "@/context/AuthContext";
@@ -34,9 +35,11 @@ function PostItem({ post }: { post: Post }) {
     >
       {/* 상품 카테고리 아이콘 */}
       <div className="w-28 h-28 bg-gray-100 rounded-xl overflow-hidden flex-shrink-0">
-        <img
-          src="/icons/raccoon_bill.svg"
+        <Image
+          src={process.env.NEXT_PUBLIC_ICON_RACCOON || "/icons/raccoon_bill.svg"}
           alt="상품 카테고리"
+          width={112}
+          height={112}
           className="w-full h-full object-cover"
         />
       </div>

--- a/apps/web/src/app/collection/page.tsx
+++ b/apps/web/src/app/collection/page.tsx
@@ -35,7 +35,7 @@ function PostItem({ post }: { post: Post }) {
       {/* 상품 카테고리 아이콘 */}
       <div className="w-28 h-28 bg-gray-100 rounded-xl overflow-hidden flex-shrink-0">
         <img
-          src="/icons/island.png"
+          src="/icons/raccoon_bill.svg"
           alt="상품 카테고리"
           className="w-full h-full object-cover"
         />

--- a/apps/web/src/app/collection/page.tsx
+++ b/apps/web/src/app/collection/page.tsx
@@ -35,7 +35,7 @@ function PostItem({ post }: { post: Post }) {
       {/* 상품 카테고리 아이콘 */}
       <div className="w-28 h-28 bg-gray-100 rounded-xl overflow-hidden flex-shrink-0">
         <img
-          src="/icons/raccoon_bill.svg"
+          src="/icons/island.png"
           alt="상품 카테고리"
           className="w-full h-full object-cover"
         />

--- a/apps/web/src/app/collection/page.tsx
+++ b/apps/web/src/app/collection/page.tsx
@@ -77,9 +77,8 @@ export default function CollectionPage() {
   const [error, setError] = useState<string | null>(null);
 
   // 탭 변경 시 데이터 로드
-  // CodeRabbit 리뷰 반영: AbortController로 race condition 방지
+  // isCancelled 플래그로 탭 전환 시 race condition 방지
   useEffect(() => {
-    const controller = new AbortController();
     let isCancelled = false;
 
     async function loadPosts() {
@@ -128,10 +127,6 @@ export default function CollectionPage() {
           setPosts(loadedPosts);
         }
       } catch (err) {
-        // AbortError는 정상적인 취소이므로 무시
-        if (err instanceof Error && err.name === "AbortError") {
-          return;
-        }
         if (!isCancelled) {
           console.error("게시글 로드 실패:", err);
           setError(err instanceof Error ? err.message : "게시글을 불러오는데 실패했습니다");
@@ -148,10 +143,8 @@ export default function CollectionPage() {
       loadPosts();
     }
 
-    // cleanup: 탭 전환 시 이전 요청 취소
     return () => {
       isCancelled = true;
-      controller.abort();
     };
   }, [activeTab, isAuthenticated, authLoading]);
 
@@ -261,11 +254,13 @@ export default function CollectionPage() {
       )}
 
       {/* 빈 상태 */}
-      {!needsLogin && !isLoading && !error && posts.length === 0 && (
+      {!needsLogin && !isLoading && !error && posts.length === 0 && (() => {
+        const emptyMsg = getEmptyMessage();
+        return (
         <div className="flex flex-col items-center justify-center py-20 text-gray-400">
-          <span className="text-6xl mb-4">{getEmptyMessage().emoji}</span>
-          <p>{getEmptyMessage().title}</p>
-          <p className="text-sm mt-1">{getEmptyMessage().subtitle}</p>
+          <span className="text-6xl mb-4">{emptyMsg.emoji}</span>
+          <p>{emptyMsg.title}</p>
+          <p className="text-sm mt-1">{emptyMsg.subtitle}</p>
           {activeTab === "my" && (
             <Link
               href="/post/new"
@@ -275,7 +270,8 @@ export default function CollectionPage() {
             </Link>
           )}
         </div>
-      )}
+        );
+      })()}
 
       {/* 거래글 목록 */}
       {!needsLogin && !isLoading && !error && posts.length > 0 && (

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -185,7 +185,7 @@ export default function LoginPage() {
         <div className="mb-8 text-center">
           {/* 너굴 아이콘 */}
           <Image
-            src={process.env.NEXT_PUBLIC_ICON_RACCOON || "/icons/raccoon_bill.svg"}
+            src={process.env.NEXT_PUBLIC_ICON_RACCOON || "/icons/island.png"}
             alt="AC Trading"
             width={96}
             height={96}

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -185,7 +185,7 @@ export default function LoginPage() {
         <div className="mb-8 text-center">
           {/* 너굴 아이콘 */}
           <Image
-            src={process.env.NEXT_PUBLIC_ICON_RACCOON || "/icons/island.png"}
+            src={process.env.NEXT_PUBLIC_ICON_RACCOON || "/icons/raccoon_bill.svg"}
             alt="AC Trading"
             width={96}
             height={96}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -23,11 +23,11 @@ function PostItem({ post }: { post: Post }) {
         상품 카테고리 아이콘
         - 거래하는 아이템 카테고리에 따라 아이콘이 변경됨
         - 아이콘 위치: /public/icons/
-        - 현재 아이콘: island.png, carrot.svg, raccoon_bill.svg
+        - 현재 아이콘: island.png, carrot.svg
       */}
       <div className="w-28 h-28 bg-gray-100 rounded-xl overflow-hidden flex-shrink-0">
         <img
-          src="/icons/raccoon_bill.svg"
+          src="/icons/island.png"
           alt="상품 카테고리"
           className="w-full h-full object-cover"
         />

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -27,7 +27,7 @@ function PostItem({ post }: { post: Post }) {
       */}
       <div className="w-28 h-28 bg-gray-100 rounded-xl overflow-hidden flex-shrink-0">
         <img
-          src="/icons/island.png"
+          src="/icons/raccoon_bill.svg"
           alt="상품 카테고리"
           className="w-full h-full object-cover"
         />

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -24,7 +24,7 @@ function PostItem({ post }: { post: Post }) {
         상품 카테고리 아이콘
         - 거래하는 아이템 카테고리에 따라 아이콘이 변경됨
         - 아이콘 위치: /public/icons/
-        - 현재 아이콘: island.png, carrot.svg
+        - 현재 아이콘: raccoon_bill.svg, island.png, carrot.svg
       */}
       <div className="w-28 h-28 bg-gray-100 rounded-xl overflow-hidden flex-shrink-0">
         <Image

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useState, useEffect } from "react";
+import Image from "next/image";
 import { MobileLayout, Header } from "@/components/common";
 import { HeartIcon, PlusIcon } from "@/components/icons";
 import { useAuth } from "@/context/AuthContext";
@@ -26,9 +27,11 @@ function PostItem({ post }: { post: Post }) {
         - 현재 아이콘: island.png, carrot.svg
       */}
       <div className="w-28 h-28 bg-gray-100 rounded-xl overflow-hidden flex-shrink-0">
-        <img
-          src="/icons/raccoon_bill.svg"
+        <Image
+          src={process.env.NEXT_PUBLIC_ICON_RACCOON || "/icons/raccoon_bill.svg"}
           alt="상품 카테고리"
+          width={112}
+          height={112}
           className="w-full h-full object-cover"
         />
       </div>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -36,8 +36,8 @@ function PostItem({ post }: { post: Post }) {
       {/* 상품 정보 */}
       <div className="flex-1 flex flex-col justify-between py-1">
         <div>
-          <h3 className="font-medium text-gray-900 line-clamp-2">{post.itemName}</h3>
-          <p className="text-xs text-gray-500 mt-1">
+          <h3 className="font-medium text-black line-clamp-2">{post.itemName}</h3>
+          <p className="text-xs text-black mt-1">
             {post.userIslandName || "섬 이름 없음"} · {formatRelativeTime(post.bumpedAt || post.createdAt)}
           </p>
         </div>
@@ -93,10 +93,10 @@ export default function HomePage() {
           href="/login"
           className="block mx-4 mt-3 p-4 bg-[#BAE8E7] rounded-xl"
         >
-          <p className="text-sm font-medium text-gray-800">
+          <p className="text-sm font-medium text-black">
             로그인을 통해 거래해주세요
           </p>
-          <p className="text-xs text-gray-600 mt-1">
+          <p className="text-xs text-black mt-1">
             로그인하면 채팅, 가격 제안 등 모든 기능을 이용할 수 있어요
           </p>
         </Link>

--- a/apps/web/src/app/post/[id]/page.tsx
+++ b/apps/web/src/app/post/[id]/page.tsx
@@ -276,8 +276,8 @@ export default function PostDetailPage() {
         </div>
         {post.userMannerScore != null && (
           <div className="text-right">
-            <p className="text-sm font-medium text-primary">{post.userMannerScore}°C</p>
-            <p className="text-xs text-gray-400">매너온도</p>
+            <p className="text-sm font-medium text-primary">{post.userMannerScore} 무가격</p>
+            <p className="text-xs text-gray-400">매너점수</p>
           </div>
         )}
       </Link>

--- a/apps/web/src/app/post/[id]/page.tsx
+++ b/apps/web/src/app/post/[id]/page.tsx
@@ -361,7 +361,7 @@ export default function PostDetailPage() {
       {/* 가격 제안 모달 */}
       {showPriceOfferModal && (
         <div className="fixed inset-0 bg-black/50 z-50 flex items-end justify-center">
-          <div className="w-full w-full bg-white rounded-t-2xl p-4 space-y-4 animate-slide-up">
+          <div className="w-full bg-white rounded-t-2xl p-4 space-y-4 animate-slide-up">
             <div className="flex items-center justify-between">
               <h3 className="text-lg font-semibold">가격 제안하기</h3>
               <button
@@ -462,7 +462,7 @@ export default function PostDetailPage() {
           onClick={() => setShowMoreMenu(false)}
         >
           <div
-            className="w-full w-full bg-white rounded-t-2xl overflow-hidden animate-slide-up"
+            className="w-full bg-white rounded-t-2xl overflow-hidden animate-slide-up"
             onClick={(e) => e.stopPropagation()}
           >
             {/* 핸들 바 */}
@@ -518,7 +518,7 @@ export default function PostDetailPage() {
           }}
         >
           <div
-            className="w-full w-full bg-white rounded-t-2xl overflow-hidden animate-slide-up max-h-[80vh] overflow-y-auto"
+            className="w-full bg-white rounded-t-2xl overflow-hidden animate-slide-up max-h-[80vh] overflow-y-auto"
             onClick={(e) => e.stopPropagation()}
           >
             {/* 헤더 */}

--- a/apps/web/src/app/post/[id]/page.tsx
+++ b/apps/web/src/app/post/[id]/page.tsx
@@ -276,8 +276,8 @@ export default function PostDetailPage() {
         </div>
         {post.userMannerScore != null && (
           <div className="text-right">
-            <p className="text-sm font-medium text-primary">{post.userMannerScore} 무가격</p>
-            <p className="text-xs text-gray-400">매너점수</p>
+            <p className="text-sm font-medium text-primary">무 가격 : {post.userMannerScore} 벨</p>
+            <p className="text-xs text-gray-400">매너 점수</p>
           </div>
         )}
       </Link>
@@ -313,9 +313,9 @@ export default function PostDetailPage() {
           {post.categoryName || "카테고리 없음"} · {formatRelativeTime(post.bumpedAt || post.createdAt)}
         </p>
 
-        {/* 내용 */}
+        {/* 내용 - [images:...] 패턴 제거 (백엔드 imageUrls 필드 추가 전 임시 처리) */}
         <p className="text-gray-700 whitespace-pre-wrap leading-relaxed">
-          {post.description}
+          {post.description?.replace(/\n*\[images:[^\]]*\]/g, "").trim()}
         </p>
 
         {/* 관심/조회 정보 */}

--- a/apps/web/src/app/post/new/page.tsx
+++ b/apps/web/src/app/post/new/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { HomeOutlineIcon, PlusIcon } from "@/components/icons";
@@ -341,6 +341,7 @@ export default function NewPostPage() {
                   key={index}
                   className="relative w-16 h-16 flex-shrink-0 bg-gray-200 rounded-lg overflow-hidden"
                 >
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
                   <img
                     src={image.previewUrl}
                     alt={`이미지 ${index + 1}`}

--- a/apps/web/src/app/post/new/page.tsx
+++ b/apps/web/src/app/post/new/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { HomeOutlineIcon, PlusIcon } from "@/components/icons";
@@ -26,6 +26,15 @@ export default function NewPostPage() {
   const [priceNegotiable, setPriceNegotiable] = useState(false);
   const [images, setImages] = useState<ImagePreview[]>([]);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const imagesRef = useRef<ImagePreview[]>([]);
+
+  // 컴포넌트 언마운트 시 미리보기 URL 해제 (메모리 누수 방지)
+  useEffect(() => { imagesRef.current = images; }, [images]);
+  useEffect(() => {
+    return () => {
+      imagesRef.current.forEach((img) => URL.revokeObjectURL(img.previewUrl));
+    };
+  }, []);
 
   // 카테고리 목록
   const [categories, setCategories] = useState<Category[]>([]);

--- a/apps/web/src/app/post/new/page.tsx
+++ b/apps/web/src/app/post/new/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { HomeOutlineIcon, PlusIcon } from "@/components/icons";
-import { createPost, getCategories, Category, PostCreateRequest } from "@/lib/postApi";
+import { createPost, getCategories, uploadPostImages, Category, PostCreateRequest } from "@/lib/postApi";
 
 // 이미지 미리보기 타입
 interface ImagePreview {
@@ -106,11 +106,25 @@ export default function NewPostPage() {
     setError(null);
 
     try {
+      // 1. 이미지가 있으면 먼저 업로드
+      let imageUrls: string[] = [];
+      if (images.length > 0) {
+        const files = images.map((img) => img.file);
+        const uploadResult = await uploadPostImages(files);
+        imageUrls = uploadResult.urls;
+      }
+
+      // 2. 게시글 생성 (이미지 URL을 설명에 포함)
+      // TODO: 백엔드 Post 엔티티에 imageUrls 필드 추가 후 별도 전달
+      const descriptionWithImages = imageUrls.length > 0
+        ? `${description.trim()}\n\n[images:${imageUrls.join(",")}]`
+        : description.trim();
+
       const request: PostCreateRequest = {
         postType,
         categoryId,
         itemName: itemName.trim(),
-        description: description.trim(),
+        description: descriptionWithImages,
         currencyType,
         price: price ? parseInt(price, 10) : undefined,
         priceNegotiable,

--- a/apps/web/src/app/post/new/page.tsx
+++ b/apps/web/src/app/post/new/page.tsx
@@ -1,10 +1,16 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { HomeOutlineIcon, PlusIcon } from "@/components/icons";
 import { createPost, getCategories, Category, PostCreateRequest } from "@/lib/postApi";
+
+// 이미지 미리보기 타입
+interface ImagePreview {
+  file: File;
+  previewUrl: string;
+}
 
 // 상품 등록 페이지 - Figma 디자인 기반
 export default function NewPostPage() {
@@ -18,7 +24,8 @@ export default function NewPostPage() {
   const [price, setPrice] = useState("");
   const [currencyType, setCurrencyType] = useState<"BELL" | "MILE_TICKET">("BELL");
   const [priceNegotiable, setPriceNegotiable] = useState(false);
-  const [images, setImages] = useState<string[]>([]);
+  const [images, setImages] = useState<ImagePreview[]>([]);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   // 카테고리 목록
   const [categories, setCategories] = useState<Category[]>([]);
@@ -44,15 +51,39 @@ export default function NewPostPage() {
     loadCategories();
   }, []);
 
+  // 이미지 파일 선택 핸들러
   const handleImageAdd = () => {
-    // TODO: 실제 이미지 업로드 로직 (Cloudflare R2)
-    // 임시로 더미 이미지 추가
-    if (images.length < 10) {
-      setImages([...images, `image-${images.length + 1}`]);
+    if (images.length >= 10) return;
+    fileInputRef.current?.click();
+  };
+
+  // 파일 선택 후 미리보기 생성
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (!files) return;
+
+    const newImages: ImagePreview[] = [];
+    const remainingSlots = 10 - images.length;
+
+    for (let i = 0; i < Math.min(files.length, remainingSlots); i++) {
+      const file = files[i];
+      if (file.type.startsWith("image/")) {
+        newImages.push({
+          file,
+          previewUrl: URL.createObjectURL(file),
+        });
+      }
     }
+
+    setImages((prev) => [...prev, ...newImages]);
+
+    // input 초기화 (같은 파일 재선택 가능하게)
+    e.target.value = "";
   };
 
   const handleImageRemove = (index: number) => {
+    // 미리보기 URL 해제
+    URL.revokeObjectURL(images[index].previewUrl);
     setImages(images.filter((_, i) => i !== index));
   };
 
@@ -260,25 +291,38 @@ export default function NewPostPage() {
           {/* 이미지 업로드 */}
           <div>
             <label className="block text-primary font-semibold mb-2">이미지</label>
+            {/* 숨겨진 파일 입력 (갤러리/카메라 트리거) */}
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              multiple
+              onChange={handleFileChange}
+              className="hidden"
+            />
             <div className="flex gap-3 overflow-x-auto pb-2">
               {/* 이미지 추가 버튼 */}
               <button
                 type="button"
                 onClick={handleImageAdd}
-                className="w-16 h-16 flex-shrink-0 border-2 border-primary border-dashed rounded-lg flex items-center justify-center hover:bg-primary/5 transition-colors"
+                disabled={images.length >= 10}
+                className="w-16 h-16 flex-shrink-0 border-2 border-primary border-dashed rounded-lg flex flex-col items-center justify-center hover:bg-primary/5 transition-colors disabled:opacity-50"
               >
-                <PlusIcon className="w-8 h-8 text-primary" />
+                <PlusIcon className="w-6 h-6 text-primary" />
+                <span className="text-xs text-primary mt-0.5">{images.length}/10</span>
               </button>
 
-              {/* 업로드된 이미지 미리보기 */}
+              {/* 선택된 이미지 미리보기 */}
               {images.map((image, index) => (
                 <div
                   key={index}
                   className="relative w-16 h-16 flex-shrink-0 bg-gray-200 rounded-lg overflow-hidden"
                 >
-                  <div className="w-full h-full flex items-center justify-center text-gray-400">
-                    📷
-                  </div>
+                  <img
+                    src={image.previewUrl}
+                    alt={`이미지 ${index + 1}`}
+                    className="w-full h-full object-cover"
+                  />
                   <button
                     type="button"
                     onClick={() => handleImageRemove(index)}

--- a/apps/web/src/app/profile/edit/page.tsx
+++ b/apps/web/src/app/profile/edit/page.tsx
@@ -143,7 +143,7 @@ export default function ProfileEditPage() {
         {/* 프로필 이미지 */}
         <div className="mb-4 flex flex-col items-center">
           <Image
-            src={process.env.NEXT_PUBLIC_ICON_RACCOON || "/icons/raccoon_bill.svg"}
+            src={process.env.NEXT_PUBLIC_ICON_RACCOON || "/icons/island.png"}
             alt="프로필 이미지"
             width={112}
             height={112}

--- a/apps/web/src/app/profile/edit/page.tsx
+++ b/apps/web/src/app/profile/edit/page.tsx
@@ -143,7 +143,7 @@ export default function ProfileEditPage() {
         {/* 프로필 이미지 */}
         <div className="mb-4 flex flex-col items-center">
           <Image
-            src={process.env.NEXT_PUBLIC_ICON_RACCOON || "/icons/island.png"}
+            src={process.env.NEXT_PUBLIC_ICON_ISLAND || "/icons/island.png"}
             alt="프로필 이미지"
             width={112}
             height={112}

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -168,11 +168,11 @@ export default function ProfilePage() {
       {/* 약관 및 정책 링크 */}
       <div className="mt-8 px-4 py-4 border-t border-gray-100">
         <div className="flex justify-center gap-4 text-sm text-black">
-          <Link href="/terms" className="hover:text-black hover:underline">
+          <Link href="/terms" className="hover:underline">
             이용약관
           </Link>
           <span>|</span>
-          <Link href="/privacy" className="hover:text-black hover:underline">
+          <Link href="/privacy" className="hover:underline">
             개인정보처리방침
           </Link>
         </div>

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -62,7 +62,7 @@ export default function ProfilePage() {
       >
         {/* 프로필 이미지 */}
         <Image
-          src={process.env.NEXT_PUBLIC_ICON_RACCOON || "/icons/raccoon_bill.svg"}
+          src={process.env.NEXT_PUBLIC_ICON_RACCOON || "/icons/island.png"}
           alt="프로필 이미지"
           width={56}
           height={56}

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -123,7 +123,7 @@ export default function ProfilePage() {
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
             <span className="text-3xl font-bold text-red-500">
-              {user?.mannerScore != null ? `${user.mannerScore.toFixed(1)} 벨` : "-"}
+              {user?.mannerScore != null && Number.isFinite(user.mannerScore) ? `${user.mannerScore.toFixed(1)} 벨` : "-"}
             </span>
             <Image
               src={process.env.NEXT_PUBLIC_ICON_CARROT || "/icons/carrot.svg"}
@@ -135,7 +135,7 @@ export default function ProfilePage() {
           </div>
         </div>
         {/* 온도 바 */}
-        {user?.mannerScore != null && (
+        {user?.mannerScore != null && Number.isFinite(user.mannerScore) && (
           <div className="mt-3">
             <div className="w-full h-2 bg-[#FFFFF0] rounded-full overflow-hidden">
               <div

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -62,7 +62,7 @@ export default function ProfilePage() {
       >
         {/* 프로필 이미지 */}
         <Image
-          src={process.env.NEXT_PUBLIC_ICON_RACCOON || "/icons/island.png"}
+          src={process.env.NEXT_PUBLIC_ICON_ISLAND || "/icons/island.png"}
           alt="프로필 이미지"
           width={56}
           height={56}

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -50,7 +50,7 @@ export default function ProfilePage() {
         showLocation
         rightElement={
           <button className="p-1 hover:bg-gray-100 rounded-full transition-colors">
-            <SettingsIcon className="text-gray-800" />
+            <SettingsIcon className="text-black" />
           </button>
         }
       />
@@ -69,8 +69,8 @@ export default function ProfilePage() {
           className="rounded-full object-cover"
         />
         <div className="flex-1">
-          <h2 className="font-semibold text-lg text-gray-900">{user?.nickname || "닉네임 없음"}</h2>
-          <p className="text-sm text-gray-900">
+          <h2 className="font-semibold text-lg text-black">{user?.nickname || "닉네임 없음"}</h2>
+          <p className="text-sm text-black">
             {user?.islandName || "섬 이름 없음"}
           </p>
         </div>
@@ -86,7 +86,7 @@ export default function ProfilePage() {
           <div className="w-12 h-12 rounded-full bg-[#BAE8E7] flex items-center justify-center">
             <ShoppingBagIcon className="text-primary" />
           </div>
-          <span className="text-sm text-gray-700">판매내역</span>
+          <span className="text-sm text-black">판매내역</span>
         </Link>
         <Link
           href="/profile/purchases"
@@ -95,7 +95,7 @@ export default function ProfilePage() {
           <div className="w-12 h-12 rounded-full bg-[#BAE8E7] flex items-center justify-center">
             <ShoppingBagIcon className="text-primary" />
           </div>
-          <span className="text-sm text-gray-700">구매내역</span>
+          <span className="text-sm text-black">구매내역</span>
         </Link>
         <Link
           href="/profile/favorites"
@@ -104,14 +104,14 @@ export default function ProfilePage() {
           <div className="w-12 h-12 rounded-full bg-[#BAE8E7] flex items-center justify-center">
             <HeartIcon filled className="text-primary" />
           </div>
-          <span className="text-sm text-gray-700">관심목록</span>
+          <span className="text-sm text-black">관심목록</span>
         </Link>
       </div>
 
       {/* 나의 무 가격 (매너 점수) - 당근마켓 스타일 */}
       <div className="mx-4 mt-4 p-4 bg-gray-50 rounded-xl">
         <div className="flex items-center gap-1 mb-3">
-          <span className="font-semibold text-gray-800">나의 무 가격</span>
+          <span className="font-semibold text-black">나의 무 가격</span>
           <span
             className="text-xs text-gray-400"
             aria-label="무 가격은 거래 매너를 나타내는 지표입니다"
@@ -149,12 +149,12 @@ export default function ProfilePage() {
 
       {/* 약관 및 정책 링크 */}
       <div className="mt-8 px-4 py-4 border-t border-gray-100">
-        <div className="flex justify-center gap-4 text-sm text-gray-500">
-          <Link href="/terms" className="hover:text-gray-700 hover:underline">
+        <div className="flex justify-center gap-4 text-sm text-black">
+          <Link href="/terms" className="hover:text-black hover:underline">
             이용약관
           </Link>
           <span>|</span>
-          <Link href="/privacy" className="hover:text-gray-700 hover:underline">
+          <Link href="/privacy" className="hover:text-black hover:underline">
             개인정보처리방침
           </Link>
         </div>

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -123,7 +123,7 @@ export default function ProfilePage() {
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
             <span className="text-3xl font-bold text-red-500">
-              {user?.mannerScore != null ? `${user.mannerScore.toFixed(1)}` : "-"}
+              {user?.mannerScore != null ? `${user.mannerScore.toFixed(1)} 벨` : "-"}
             </span>
             <Image
               src={process.env.NEXT_PUBLIC_ICON_CARROT || "/icons/carrot.svg"}

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -157,10 +157,10 @@ export default function ProfilePage() {
           <ChevronRightIcon className="text-black" />
         </Link>
         <Link
-          href="/review"
+          href="/profile/reviews"
           className="flex items-center justify-between px-4 py-4 border-b border-gray-100 hover:bg-gray-50 transition-colors"
         >
-          <span className="text-black font-medium">나의 활동</span>
+          <span className="text-black font-medium">받은 매너 평가</span>
           <ChevronRightIcon className="text-black" />
         </Link>
       </div>

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -147,6 +147,24 @@ export default function ProfilePage() {
         )}
       </div>
 
+      {/* 메뉴 목록 */}
+      <div className="mt-4 border-t border-gray-100">
+        <Link
+          href="/collection"
+          className="flex items-center justify-between px-4 py-4 border-b border-gray-100 hover:bg-gray-50 transition-colors"
+        >
+          <span className="text-black font-medium">모아보기</span>
+          <ChevronRightIcon className="text-black" />
+        </Link>
+        <Link
+          href="/review"
+          className="flex items-center justify-between px-4 py-4 border-b border-gray-100 hover:bg-gray-50 transition-colors"
+        >
+          <span className="text-black font-medium">나의 활동</span>
+          <ChevronRightIcon className="text-black" />
+        </Link>
+      </div>
+
       {/* 약관 및 정책 링크 */}
       <div className="mt-8 px-4 py-4 border-t border-gray-100">
         <div className="flex justify-center gap-4 text-sm text-black">

--- a/apps/web/src/app/profile/reviews/page.tsx
+++ b/apps/web/src/app/profile/reviews/page.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import Image from "next/image";
+import { MobileLayout, Header } from "@/components/common";
+import { useAuth } from "@/context/AuthContext";
+import { getMyReviews, ReviewResponse, formatRelativeTime } from "@/lib/postApi";
+
+// 별점 표시 컴포넌트
+function StarRating({ rating }: { rating: number }) {
+  return (
+    <div className="flex gap-0.5">
+      {[1, 2, 3, 4, 5].map((star) => (
+        <svg
+          key={star}
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill={star <= rating ? "#FBBF24" : "none"}
+          stroke={star <= rating ? "#FBBF24" : "#D1D5DB"}
+          strokeWidth="2"
+        >
+          <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
+        </svg>
+      ))}
+    </div>
+  );
+}
+
+// 리뷰 아이템 컴포넌트
+function ReviewItem({ review }: { review: ReviewResponse }) {
+  return (
+    <div className="p-4 border-b border-gray-100">
+      {/* 리뷰 작성자 정보 */}
+      <div className="flex items-center gap-3 mb-2">
+        <Image
+          src={process.env.NEXT_PUBLIC_ICON_ISLAND || "/icons/island.png"}
+          alt="프로필"
+          width={36}
+          height={36}
+          className="rounded-full object-cover"
+        />
+        <div className="flex-1">
+          <p className="font-medium text-sm text-black">
+            {review.reviewerNickname || "알 수 없음"}
+          </p>
+          <p className="text-xs text-gray-400">
+            {review.reviewerIslandName || "섬 이름 없음"} · {formatRelativeTime(review.createdAt)}
+          </p>
+        </div>
+      </div>
+
+      {/* 별점 */}
+      <StarRating rating={review.rating} />
+
+      {/* 리뷰 내용 */}
+      {review.comment && (
+        <p className="text-sm text-black mt-2">{review.comment}</p>
+      )}
+
+      {/* 관련 게시글 */}
+      {review.postItemName && (
+        <p className="text-xs text-gray-400 mt-2">
+          거래: {review.postItemName}
+        </p>
+      )}
+    </div>
+  );
+}
+
+// 받은 매너 평가 페이지
+export default function ProfileReviewsPage() {
+  const router = useRouter();
+  const { isLoading: authLoading, isAuthenticated } = useAuth();
+  const [reviews, setReviews] = useState<ReviewResponse[]>([]);
+  const [averageRating, setAverageRating] = useState<number | null>(null);
+  const [reviewCount, setReviewCount] = useState<number>(0);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function loadReviews() {
+      if (authLoading) return;
+      if (!isAuthenticated) {
+        router.push("/login");
+        return;
+      }
+
+      try {
+        setIsLoading(true);
+        setError(null);
+        const response = await getMyReviews(0, 20);
+        setReviews(response.reviews);
+        setAverageRating(response.averageRating);
+        setReviewCount(response.reviewCount ?? response.totalElements);
+      } catch (err) {
+        console.error("리뷰 로드 실패:", err);
+        setError(err instanceof Error ? err.message : "리뷰를 불러오는데 실패했습니다");
+      } finally {
+        setIsLoading(false);
+      }
+    }
+
+    loadReviews();
+  }, [authLoading, isAuthenticated, router]);
+
+  return (
+    <MobileLayout>
+      <Header title="받은 매너 평가" showBack onBack={() => router.back()} />
+
+      {/* 로딩 */}
+      {(isLoading || authLoading) && (
+        <div className="flex items-center justify-center py-20">
+          <div className="animate-spin rounded-full h-8 w-8 border-2 border-primary border-t-transparent" />
+        </div>
+      )}
+
+      {/* 에러 */}
+      {error && !isLoading && (
+        <div className="flex flex-col items-center justify-center py-20 text-gray-500">
+          <p className="text-sm">{error}</p>
+        </div>
+      )}
+
+      {/* 통계 */}
+      {!isLoading && !error && (
+        <>
+          <div className="p-4 bg-gray-50 border-b border-gray-100">
+            <div className="flex items-center justify-center gap-4">
+              <div className="text-center">
+                <p className="text-3xl font-bold text-primary">
+                  {averageRating != null && Number.isFinite(averageRating)
+                    ? averageRating.toFixed(1)
+                    : "-"}
+                </p>
+                <p className="text-xs text-gray-500 mt-1">평균 별점</p>
+              </div>
+              <div className="w-px h-10 bg-gray-200" />
+              <div className="text-center">
+                <p className="text-3xl font-bold text-gray-800">{reviewCount}</p>
+                <p className="text-xs text-gray-500 mt-1">받은 리뷰</p>
+              </div>
+            </div>
+          </div>
+
+          {/* 리뷰 목록 */}
+          {reviews.length > 0 ? (
+            <div>
+              {reviews.map((review) => (
+                <ReviewItem key={review.id} review={review} />
+              ))}
+            </div>
+          ) : (
+            <div className="flex flex-col items-center justify-center py-20 text-gray-400">
+              <span className="text-6xl mb-4">📝</span>
+              <p>아직 받은 평가가 없어요</p>
+              <p className="text-sm mt-1">거래를 완료하면 평가를 받을 수 있어요!</p>
+            </div>
+          )}
+        </>
+      )}
+    </MobileLayout>
+  );
+}

--- a/apps/web/src/app/review/page.tsx
+++ b/apps/web/src/app/review/page.tsx
@@ -1,34 +1,181 @@
 "use client";
 
-import { useState } from "react";
-import { useRouter } from "next/navigation";
+import { useState, useEffect, Suspense } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import Link from "next/link";
 import { ChevronLeftIcon, StarIcon } from "@/components/icons";
+import { getPost, createReview, Post } from "@/lib/postApi";
 
-// 거래 후기 페이지 - Figma 디자인 기반
-export default function ReviewPage() {
+// 리뷰 작성 폼 컴포넌트 (useSearchParams 사용을 위해 분리)
+function ReviewForm() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const [rating, setRating] = useState(0);
   const [review, setReview] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
-  // 더미 상품/거래 정보
-  const transaction = {
-    product: {
-      title: "산악자전거 장기대여 가능합니다~!",
-      image: "/images/bike.jpg",
-    },
-    seller: {
-      name: "user 1",
-    },
-    buyer: {
-      name: "user2",
-    },
+  // URL 쿼리 파라미터에서 postId, revieweeId 추출
+  const postId = searchParams.get("postId");
+  const revieweeId = searchParams.get("revieweeId");
+
+  // 게시글 정보 로드
+  const [post, setPost] = useState<Post | null>(null);
+  const [isLoadingPost, setIsLoadingPost] = useState(false);
+
+  useEffect(() => {
+    if (!postId) return;
+
+    async function loadPost() {
+      setIsLoadingPost(true);
+      try {
+        const postData = await getPost(parseInt(postId!, 10));
+        setPost(postData);
+      } catch (err) {
+        console.error("게시글 로드 실패:", err);
+      } finally {
+        setIsLoadingPost(false);
+      }
+    }
+    loadPost();
+  }, [postId]);
+
+  // 후기 제출
+  const handleSubmit = async () => {
+    if (rating === 0) return;
+    if (!postId || !revieweeId) {
+      setError("거래 정보가 없습니다");
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      await createReview({
+        postId: parseInt(postId, 10),
+        revieweeId: parseInt(revieweeId, 10),
+        rating,
+        comment: review.trim() || undefined,
+      });
+      router.push("/");
+    } catch (err) {
+      console.error("리뷰 작성 실패:", err);
+      setError(err instanceof Error ? err.message : "후기 등록에 실패했습니다");
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
-  const handleSubmit = () => {
-    // TODO: 실제 후기 제출 로직
-    alert("후기가 등록되었습니다!");
-    router.push("/");
-  };
+  // postId나 revieweeId가 없는 경우 (프로필 > 나의 활동에서 진입)
+  if (!postId || !revieweeId) {
+    return (
+      <div className="flex-1 flex flex-col items-center justify-center py-20 text-gray-400">
+        <span className="text-6xl mb-4">📝</span>
+        <p>거래 완료 후 후기를 남길 수 있어요</p>
+        <p className="text-sm mt-2">채팅방에서 거래 완료 후 후기 작성 버튼을 눌러주세요</p>
+        <Link
+          href="/collection?tab=my"
+          className="mt-6 px-6 py-2 bg-primary text-white rounded-lg hover:bg-primary-dark transition-colors"
+        >
+          내 거래글 보기
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {/* 컨텐츠 */}
+      <div className="flex-1 p-4">
+        {/* 에러 메시지 */}
+        {error && (
+          <div className="p-3 mb-4 bg-red-50 text-red-600 rounded-lg text-sm">
+            {error}
+          </div>
+        )}
+
+        {/* 상품 정보 */}
+        {isLoadingPost ? (
+          <div className="flex items-center gap-3 pb-4 border-b border-gray-100">
+            <div className="w-12 h-12 bg-gray-200 rounded-lg animate-pulse" />
+            <div className="flex-1">
+              <div className="h-4 bg-gray-200 rounded animate-pulse w-3/4" />
+              <div className="h-3 bg-gray-200 rounded animate-pulse w-1/2 mt-2" />
+            </div>
+          </div>
+        ) : post ? (
+          <div className="flex items-center gap-3 pb-4 border-b border-gray-100">
+            <div className="w-12 h-12 bg-gray-200 rounded-lg flex-shrink-0 overflow-hidden">
+              <img
+                src="/icons/raccoon_bill.svg"
+                alt="상품"
+                className="w-full h-full object-cover"
+              />
+            </div>
+            <div className="flex-1 min-w-0">
+              <p className="text-sm text-gray-900 truncate">{post.itemName}</p>
+              <p className="text-xs text-gray-500">{post.userNickname || "판매자"}</p>
+            </div>
+          </div>
+        ) : null}
+
+        {/* 후기 안내 */}
+        <div className="py-6">
+          <h2 className="text-lg font-semibold text-gray-900">
+            거래가 어떠셨나요?
+          </h2>
+          <p className="text-sm text-gray-500 mt-2">
+            남겨주신 후기는 거동숲에 도움이 됩니다
+          </p>
+        </div>
+
+        {/* 별점 */}
+        <div className="flex justify-center gap-2 py-4">
+          {[1, 2, 3, 4, 5].map((star) => (
+            <button
+              key={star}
+              onClick={() => setRating(star)}
+              className="transition-transform hover:scale-110"
+            >
+              <StarIcon filled={star <= rating} />
+            </button>
+          ))}
+        </div>
+
+        {/* 후기 작성 */}
+        <div className="mt-6">
+          <h3 className="font-semibold text-gray-900 mb-2">
+            어떤 점이 좋고, 어떤 점이 별로였나요?
+            <br />
+            후기를 적어주세요!
+          </h3>
+          <textarea
+            placeholder="여기에 적어주세요!"
+            value={review}
+            onChange={(e) => setReview(e.target.value)}
+            className="w-full h-40 p-4 border border-gray-200 rounded-xl resize-none focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
+          />
+        </div>
+      </div>
+
+      {/* 제출 버튼 */}
+      <div className="p-4 border-t border-gray-100">
+        <button
+          onClick={handleSubmit}
+          disabled={rating === 0 || isSubmitting}
+          className="w-full py-4 bg-primary text-white font-semibold rounded-xl hover:bg-primary-dark transition-colors disabled:bg-gray-300 disabled:cursor-not-allowed"
+        >
+          {isSubmitting ? "등록 중..." : "후기 보내기"}
+        </button>
+      </div>
+    </>
+  );
+}
+
+// 거래 후기 페이지
+export default function ReviewPage() {
+  const router = useRouter();
 
   return (
     <div className="min-h-screen bg-white">
@@ -47,70 +194,16 @@ export default function ReviewPage() {
           </div>
         </header>
 
-        {/* 컨텐츠 */}
-        <div className="flex-1 p-4">
-          {/* 상품 정보 */}
-          <div className="flex items-center gap-3 pb-4 border-b border-gray-100">
-            <div className="w-12 h-12 bg-gray-200 rounded-lg flex-shrink-0 flex items-center justify-center">
-              🚲
+        {/* Suspense로 감싸서 useSearchParams 사용 */}
+        <Suspense
+          fallback={
+            <div className="flex-1 flex items-center justify-center">
+              <div className="animate-spin rounded-full h-8 w-8 border-2 border-primary border-t-transparent" />
             </div>
-            <div className="flex-1 min-w-0">
-              <p className="text-sm text-gray-900 truncate">{transaction.product.title}</p>
-              <p className="text-xs text-gray-500">{transaction.seller.name}</p>
-            </div>
-          </div>
-
-          {/* 후기 안내 */}
-          <div className="py-6">
-            <h2 className="text-lg font-semibold text-gray-900">
-              {transaction.buyer.name}님,
-              <br />
-              {transaction.seller.name}님과의 거래가 어떠셨나요?
-            </h2>
-            <p className="text-sm text-gray-500 mt-2">
-              남겨주신 후기는 거동숲에 도움이 됩니다
-            </p>
-          </div>
-
-          {/* 별점 */}
-          <div className="flex justify-center gap-2 py-4">
-            {[1, 2, 3, 4, 5].map((star) => (
-              <button
-                key={star}
-                onClick={() => setRating(star)}
-                className="transition-transform hover:scale-110"
-              >
-                <StarIcon filled={star <= rating} />
-              </button>
-            ))}
-          </div>
-
-          {/* 후기 작성 */}
-          <div className="mt-6">
-            <h3 className="font-semibold text-gray-900 mb-2">
-              어떤 점이 좋고, 어떤 점이 별로였나요?
-              <br />
-              후기를 적어주세요!
-            </h3>
-            <textarea
-              placeholder="여기에 적어주세요!"
-              value={review}
-              onChange={(e) => setReview(e.target.value)}
-              className="w-full h-40 p-4 border border-gray-200 rounded-xl resize-none focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
-            />
-          </div>
-        </div>
-
-        {/* 제출 버튼 */}
-        <div className="p-4 border-t border-gray-100">
-          <button
-            onClick={handleSubmit}
-            disabled={rating === 0}
-            className="w-full py-4 bg-primary text-white font-semibold rounded-xl hover:bg-primary-dark transition-colors disabled:bg-gray-300 disabled:cursor-not-allowed"
-          >
-            후기 보내기
-          </button>
-        </div>
+          }
+        >
+          <ReviewForm />
+        </Suspense>
       </div>
     </div>
   );

--- a/apps/web/src/app/review/page.tsx
+++ b/apps/web/src/app/review/page.tsx
@@ -56,18 +56,19 @@ function ReviewForm() {
       return;
     }
 
+    // Before: NaN 검증이 setIsSubmitting(true) 이후에 위치 → 조기 return 시 isSubmitting이 true로 고정됨
+    // After: NaN 검증을 setIsSubmitting 전에 수행하여 finally 블록 누락 방지
+    const parsedPostId = parseInt(postId, 10);
+    const parsedRevieweeId = parseInt(revieweeId, 10);
+    if (isNaN(parsedPostId) || isNaN(parsedRevieweeId)) {
+      setError("잘못된 거래 정보입니다");
+      return;
+    }
+
     setIsSubmitting(true);
     setError(null);
 
     try {
-      // Before: parseInt NaN 검증 없음
-      // After: NaN 검증 추가
-      const parsedPostId = parseInt(postId, 10);
-      const parsedRevieweeId = parseInt(revieweeId, 10);
-      if (isNaN(parsedPostId) || isNaN(parsedRevieweeId)) {
-        setError("잘못된 거래 정보입니다");
-        return;
-      }
       await createReview({
         postId: parsedPostId,
         revieweeId: parsedRevieweeId,

--- a/apps/web/src/app/review/page.tsx
+++ b/apps/web/src/app/review/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
+import Image from "next/image";
 import { ChevronLeftIcon, StarIcon } from "@/components/icons";
 import { getPost, createReview, Post } from "@/lib/postApi";
 
@@ -27,9 +28,16 @@ function ReviewForm() {
     if (!postId) return;
 
     async function loadPost() {
+      // Before: parseInt NaN 검증 없음
+      // After: NaN 검증 추가
+      const parsedId = parseInt(postId!, 10);
+      if (isNaN(parsedId)) {
+        console.error("잘못된 postId:", postId);
+        return;
+      }
       setIsLoadingPost(true);
       try {
-        const postData = await getPost(parseInt(postId!, 10));
+        const postData = await getPost(parsedId);
         setPost(postData);
       } catch (err) {
         console.error("게시글 로드 실패:", err);
@@ -52,9 +60,17 @@ function ReviewForm() {
     setError(null);
 
     try {
+      // Before: parseInt NaN 검증 없음
+      // After: NaN 검증 추가
+      const parsedPostId = parseInt(postId, 10);
+      const parsedRevieweeId = parseInt(revieweeId, 10);
+      if (isNaN(parsedPostId) || isNaN(parsedRevieweeId)) {
+        setError("잘못된 거래 정보입니다");
+        return;
+      }
       await createReview({
-        postId: parseInt(postId, 10),
-        revieweeId: parseInt(revieweeId, 10),
+        postId: parsedPostId,
+        revieweeId: parsedRevieweeId,
         rating,
         comment: review.trim() || undefined,
       });
@@ -107,9 +123,13 @@ function ReviewForm() {
         ) : post ? (
           <div className="flex items-center gap-3 pb-4 border-b border-gray-100">
             <div className="w-12 h-12 bg-gray-200 rounded-lg flex-shrink-0 overflow-hidden">
-              <img
-                src="/icons/raccoon_bill.svg"
+              {/* Before: 하드코딩 <img> 태그
+                 After: 환경변수 + Next.js Image 컴포넌트 */}
+              <Image
+                src={process.env.NEXT_PUBLIC_ICON_RACCOON || "/icons/raccoon_bill.svg"}
                 alt="상품"
+                width={48}
+                height={48}
                 className="w-full h-full object-cover"
               />
             </div>

--- a/apps/web/src/app/search/page.tsx
+++ b/apps/web/src/app/search/page.tsx
@@ -47,11 +47,15 @@ const pricePresets = [
 const RECENT_KEYWORDS_KEY = "ac-trading-recent-keywords";
 
 // 최근 검색어 로드
+// Before: JSON.parse 결과가 배열인지 검증하지 않아, localStorage 값이 변조 시 런타임 에러 가능
+// After: Array.isArray 체크 추가
 function loadRecentKeywords(): string[] {
   if (typeof window === "undefined") return [];
   try {
     const saved = localStorage.getItem(RECENT_KEYWORDS_KEY);
-    return saved ? JSON.parse(saved) : [];
+    if (!saved) return [];
+    const parsed = JSON.parse(saved);
+    return Array.isArray(parsed) ? parsed : [];
   } catch {
     return [];
   }
@@ -436,13 +440,21 @@ export default function SearchPage() {
       }
 
       // 화폐 유형 필터: 선택된 화폐 유형 배열 전달 (다중 선택 지원)
+      // Before: 매핑 테이블에 없는 키 → undefined 포함 가능
+      // After: .filter(Boolean)로 undefined 방어
       if (currentFilters.currencyType.length > 0) {
-        params.currencyType = currentFilters.currencyType.map((ct) => CURRENCY_MAP[ct]);
+        const mapped = currentFilters.currencyType
+          .map((ct) => CURRENCY_MAP[ct])
+          .filter((v): v is "BELL" | "MILE_TICKET" => v !== undefined);
+        if (mapped.length > 0) params.currencyType = mapped;
       }
 
       // 거래 유형 필터: 선택된 거래 유형 배열 전달 (다중 선택 지원)
       if (currentFilters.tradeType.length > 0) {
-        params.postType = currentFilters.tradeType.map((tt) => TRADE_TYPE_MAP[tt]);
+        const mapped = currentFilters.tradeType
+          .map((tt) => TRADE_TYPE_MAP[tt])
+          .filter((v): v is "SELL" | "BUY" => v !== undefined);
+        if (mapped.length > 0) params.postType = mapped;
       }
 
       // 가격 필터

--- a/apps/web/src/app/search/page.tsx
+++ b/apps/web/src/app/search/page.tsx
@@ -1,53 +1,30 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { MobileLayout } from "@/components/common";
-import { ChevronLeftIcon, SearchIcon, HeartIcon, CommentIcon } from "@/components/icons";
+import { ChevronLeftIcon, SearchIcon, HeartIcon } from "@/components/icons";
+import {
+  searchPosts,
+  getCategories,
+  formatPrice as apiFormatPrice,
+  formatRelativeTime,
+  Post,
+  Category,
+} from "@/lib/postApi";
 
-// 더미 검색 결과 데이터
-const mockSearchResults = [
-  {
-    id: 1,
-    title: "호화로운 침대",
-    location: "군자동",
-    time: "3일 전",
-    price: 220000,
-    comments: 3,
-    likes: 11,
-    category: "가구",
-    currencyType: "벨",
-    tradeType: "팔아요",
-  },
-  {
-    id: 2,
-    title: "별무늬 벽지",
-    location: "광진구 구의제3동",
-    time: "26초 전",
-    price: 4000,
-    comments: 0,
-    likes: 2,
-    category: "바닥/벽지",
-    currencyType: "마일",
-    tradeType: "팔아요",
-  },
-  {
-    id: 3,
-    title: "왕관 DIY 레시피",
-    location: "군자동",
-    time: "1일 전",
-    price: 1000000,
-    comments: 0,
-    likes: 0,
-    category: "DIY 레시피",
-    currencyType: "벨",
-    tradeType: "구해요",
-  },
-];
+// 화폐 유형 매핑 (한국어 라벨 → API enum)
+const CURRENCY_MAP: Record<string, "BELL" | "MILE_TICKET"> = {
+  "벨": "BELL",
+  "마일": "MILE_TICKET",
+};
 
-// 카테고리 목록
-const categories = ["가구", "바닥/벽지", "옷", "재료", "DIY 레시피", "화석/미술품", "알바", "주민 사진/ 분양", "기타"];
+// 거래 유형 매핑 (한국어 라벨 → API enum)
+const TRADE_TYPE_MAP: Record<string, "SELL" | "BUY"> = {
+  "팔아요": "SELL",
+  "구해요": "BUY",
+};
 
 // 화폐 유형 목록
 const currencyTypes = ["벨", "마일"];
@@ -57,29 +34,49 @@ const tradeTypes = ["팔아요", "구해요"];
 
 // 가격 프리셋
 const pricePresets = [
-  { label: "2,000원 - 7,000원", min: 2000, max: 7000 },
-  { label: "7,000원 - 1만 2,000원", min: 7000, max: 12000 },
-  { label: "1만 2,000원 - 2만 3,000원", min: 12000, max: 23000 },
+  { label: "~10,000", min: 0, max: 10000 },
+  { label: "10,000 ~ 100,000", min: 10000, max: 100000 },
+  { label: "100,000~", min: 100000, max: 0 },
 ];
 
-// 인기 검색어
+// 인기 검색어 (동물의 숲 관련)
 const popularKeywords = [
-  "닌텐도 스위치",
-  "에어팟",
-  "아이폰",
-  "자전거",
   "DIY 레시피",
   "마일 티켓",
   "무 주식",
   "가구",
+  "화석",
+  "미술품",
+  "옷",
+  "벽지",
 ];
 
-// 최근 검색어 초기값
-const initialRecentKeywords = ["자전거", "에어팟", "닌텐도"];
+// localStorage 키
+const RECENT_KEYWORDS_KEY = "ac-trading-recent-keywords";
 
-// 가격 포맷팅 함수
-function formatPrice(price: number): string {
-  return price.toLocaleString("ko-KR") + "원";
+// 최근 검색어 로드
+function loadRecentKeywords(): string[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const saved = localStorage.getItem(RECENT_KEYWORDS_KEY);
+    return saved ? JSON.parse(saved) : [];
+  } catch {
+    return [];
+  }
+}
+
+// 최근 검색어 저장
+function saveRecentKeywords(keywords: string[]) {
+  if (typeof window === "undefined") return;
+  localStorage.setItem(RECENT_KEYWORDS_KEY, JSON.stringify(keywords));
+}
+
+// 최근 검색어에 추가 (중복 제거, 최대 10개)
+function addRecentKeyword(keywords: string[], keyword: string): string[] {
+  const filtered = keywords.filter((k) => k !== keyword);
+  const updated = [keyword, ...filtered].slice(0, 10);
+  saveRecentKeywords(updated);
+  return updated;
 }
 
 // 필터 상태 타입
@@ -91,8 +88,8 @@ interface FilterState {
   priceMax: string;
 }
 
-// 검색 결과 아이템 컴포넌트
-function SearchResultItem({ post }: { post: (typeof mockSearchResults)[0] }) {
+// 검색 결과 아이템 컴포넌트 (실제 Post 타입 사용)
+function SearchResultItem({ post }: { post: Post }) {
   return (
     <Link
       href={`/post/${post.id}`}
@@ -107,24 +104,18 @@ function SearchResultItem({ post }: { post: (typeof mockSearchResults)[0] }) {
       </div>
       <div className="flex-1 flex flex-col justify-between py-1">
         <div>
-          <h3 className="font-medium text-gray-900 line-clamp-2">{post.title}</h3>
-          <p className="text-xs text-gray-500 mt-1">
-            {post.location} · {post.time}
+          <h3 className="font-medium text-black line-clamp-2">{post.itemName}</h3>
+          <p className="text-xs text-black mt-1">
+            {post.userIslandName || "섬 이름 없음"} · {formatRelativeTime(post.bumpedAt || post.createdAt)}
           </p>
         </div>
         <div className="flex items-center justify-between">
-          <p className="font-bold text-primary">{formatPrice(post.price)}</p>
+          <p className="font-bold text-primary">{apiFormatPrice(post.price, post.currencyType)}</p>
           <div className="flex items-center gap-3 text-gray-400">
-            {post.comments > 0 && (
-              <span className="flex items-center gap-1">
-                <CommentIcon />
-                <span className="text-xs">{post.comments}</span>
-              </span>
-            )}
-            {post.likes > 0 && (
+            {post.likeCount > 0 && (
               <span className="flex items-center gap-1">
                 <HeartIcon />
-                <span className="text-xs">{post.likes}</span>
+                <span className="text-xs">{post.likeCount}</span>
               </span>
             )}
           </div>
@@ -276,8 +267,8 @@ function PriceFilterModal({
   }, [isOpen, priceMin, priceMax]);
 
   const handlePresetClick = (min: number, max: number) => {
-    setMinValue(min.toString());
-    setMaxValue(max.toString());
+    setMinValue(min > 0 ? min.toString() : "");
+    setMaxValue(max > 0 ? max.toString() : "");
     setPriceError("");
   };
 
@@ -354,7 +345,8 @@ function PriceFilterModal({
                 key={index}
                 onClick={() => handlePresetClick(preset.min, preset.max)}
                 className={`px-4 py-2 rounded-full border text-sm transition-colors ${
-                  minValue === preset.min.toString() && maxValue === preset.max.toString()
+                  minValue === (preset.min > 0 ? preset.min.toString() : "") &&
+                  maxValue === (preset.max > 0 ? preset.max.toString() : "")
                     ? "border-primary bg-primary/10 text-primary"
                     : "border-gray-300 text-gray-700 hover:border-gray-400"
                 }`}
@@ -390,8 +382,15 @@ export default function SearchPage() {
   const router = useRouter();
   const [searchQuery, setSearchQuery] = useState("");
   const [isSearching, setIsSearching] = useState(false);
-  const [searchResults, setSearchResults] = useState<typeof mockSearchResults>([]);
-  const [recentKeywords, setRecentKeywords] = useState<string[]>(initialRecentKeywords);
+  const [isLoadingResults, setIsLoadingResults] = useState(false);
+  const [searchResults, setSearchResults] = useState<Post[]>([]);
+  const [totalResults, setTotalResults] = useState(0);
+  const [searchError, setSearchError] = useState<string | null>(null);
+  const [recentKeywords, setRecentKeywords] = useState<string[]>([]);
+
+  // 카테고리 목록 (API에서 로드)
+  const [categories, setCategories] = useState<Category[]>([]);
+  const categoryNames = categories.map((c) => c.name);
 
   // 필터 상태 (배열로 다중 선택 지원)
   const [filters, setFilters] = useState<FilterState>({
@@ -408,94 +407,122 @@ export default function SearchPage() {
   const [isCurrencyModalOpen, setIsCurrencyModalOpen] = useState(false);
   const [isTradeTypeModalOpen, setIsTradeTypeModalOpen] = useState(false);
 
-  // 필터 적용 함수
-  const applyFilters = (results: typeof mockSearchResults, currentFilters: FilterState) => {
-    return results.filter((item) => {
-      // 카테고리 필터
-      if (currentFilters.category.length > 0 && !currentFilters.category.includes(item.category)) {
-        return false;
+  // 카테고리 로드 + 최근 검색어 로드
+  useEffect(() => {
+    async function loadCategories() {
+      try {
+        const response = await getCategories();
+        setCategories(response.categories);
+      } catch (err) {
+        console.error("카테고리 로드 실패:", err);
       }
-      // 화폐 유형 필터
-      if (currentFilters.currencyType.length > 0 && !currentFilters.currencyType.includes(item.currencyType)) {
-        return false;
-      }
-      // 거래 유형 필터
-      if (currentFilters.tradeType.length > 0 && !currentFilters.tradeType.includes(item.tradeType)) {
-        return false;
-      }
-      // 가격 필터
-      if (currentFilters.priceMin && item.price < parseInt(currentFilters.priceMin)) {
-        return false;
-      }
-      if (currentFilters.priceMax && item.price > parseInt(currentFilters.priceMax)) {
-        return false;
-      }
-      return true;
-    });
-  };
+    }
+    loadCategories();
+    setRecentKeywords(loadRecentKeywords());
+  }, []);
 
-  // 검색 실행
+  // 필터 → API 파라미터 변환
+  const buildSearchParams = useCallback(
+    (query: string, currentFilters: FilterState) => {
+      const params: Parameters<typeof searchPosts>[0] = {
+        keyword: query,
+        page: 0,
+        size: 50,
+      };
+
+      // 카테고리 필터: 1개만 선택된 경우 categoryId 전달
+      if (currentFilters.category.length === 1) {
+        const category = categories.find((c) => c.name === currentFilters.category[0]);
+        if (category) params.categoryId = category.id;
+      }
+
+      // 화폐 유형 필터: 1개만 선택된 경우 전달
+      if (currentFilters.currencyType.length === 1) {
+        params.currencyType = CURRENCY_MAP[currentFilters.currencyType[0]];
+      }
+
+      // 거래 유형 필터: 1개만 선택된 경우 전달
+      if (currentFilters.tradeType.length === 1) {
+        params.postType = TRADE_TYPE_MAP[currentFilters.tradeType[0]];
+      }
+
+      // 가격 필터
+      if (currentFilters.priceMin) {
+        params.minPrice = parseInt(currentFilters.priceMin, 10);
+      }
+      if (currentFilters.priceMax) {
+        params.maxPrice = parseInt(currentFilters.priceMax, 10);
+      }
+
+      return params;
+    },
+    [categories]
+  );
+
+  // 검색 실행 (API 호출)
+  const executeSearch = useCallback(
+    async (query: string, currentFilters: FilterState) => {
+      if (!query.trim()) return;
+
+      setIsSearching(true);
+      setIsLoadingResults(true);
+      setSearchError(null);
+
+      try {
+        const params = buildSearchParams(query, currentFilters);
+        const response = await searchPosts(params);
+        setSearchResults(response.posts);
+        setTotalResults(response.totalElements);
+      } catch (err) {
+        console.error("검색 실패:", err);
+        setSearchError(err instanceof Error ? err.message : "검색에 실패했습니다");
+        setSearchResults([]);
+        setTotalResults(0);
+      } finally {
+        setIsLoadingResults(false);
+      }
+    },
+    [buildSearchParams]
+  );
+
+  // 검색 실행 핸들러
   const handleSearch = (query: string) => {
     if (!query.trim()) return;
 
-    setIsSearching(true);
-    let results = mockSearchResults.filter((item) =>
-      item.title.toLowerCase().includes(query.toLowerCase())
-    );
-    results = applyFilters(results, filters);
-    setSearchResults(results);
+    // 최근 검색어 추가
+    setRecentKeywords((prev) => addRecentKeyword(prev, query.trim()));
+    executeSearch(query, filters);
   };
+
+  // 필터 변경 시 재검색
+  const handleFilterChange = useCallback(
+    (newFilters: FilterState) => {
+      setFilters(newFilters);
+      if (isSearching && searchQuery.trim()) {
+        executeSearch(searchQuery, newFilters);
+      }
+    },
+    [isSearching, searchQuery, executeSearch]
+  );
 
   // 카테고리 필터 적용
   const handleCategoryApply = (selected: string[]) => {
-    const newFilters = { ...filters, category: selected };
-    setFilters(newFilters);
-    if (isSearching && searchQuery) {
-      let results = mockSearchResults.filter((item) =>
-        item.title.toLowerCase().includes(searchQuery.toLowerCase())
-      );
-      results = applyFilters(results, newFilters);
-      setSearchResults(results);
-    }
+    handleFilterChange({ ...filters, category: selected });
   };
 
   // 화폐 필터 적용
   const handleCurrencyApply = (selected: string[]) => {
-    const newFilters = { ...filters, currencyType: selected };
-    setFilters(newFilters);
-    if (isSearching && searchQuery) {
-      let results = mockSearchResults.filter((item) =>
-        item.title.toLowerCase().includes(searchQuery.toLowerCase())
-      );
-      results = applyFilters(results, newFilters);
-      setSearchResults(results);
-    }
+    handleFilterChange({ ...filters, currencyType: selected });
   };
 
   // 거래유형 필터 적용
   const handleTradeTypeApply = (selected: string[]) => {
-    const newFilters = { ...filters, tradeType: selected };
-    setFilters(newFilters);
-    if (isSearching && searchQuery) {
-      let results = mockSearchResults.filter((item) =>
-        item.title.toLowerCase().includes(searchQuery.toLowerCase())
-      );
-      results = applyFilters(results, newFilters);
-      setSearchResults(results);
-    }
+    handleFilterChange({ ...filters, tradeType: selected });
   };
 
   // 가격 필터 적용
   const handlePriceApply = (min: string, max: string) => {
-    const newFilters = { ...filters, priceMin: min, priceMax: max };
-    setFilters(newFilters);
-    if (isSearching && searchQuery) {
-      let results = mockSearchResults.filter((item) =>
-        item.title.toLowerCase().includes(searchQuery.toLowerCase())
-      );
-      results = applyFilters(results, newFilters);
-      setSearchResults(results);
-    }
+    handleFilterChange({ ...filters, priceMin: min, priceMax: max });
   };
 
   // 검색어 입력 핸들러 (onKeyDown 사용 - onKeyPress deprecated)
@@ -508,18 +535,25 @@ export default function SearchPage() {
   // 키워드 클릭 핸들러
   const handleKeywordClick = (keyword: string) => {
     setSearchQuery(keyword);
-    handleSearch(keyword);
+    // 최근 검색어 추가
+    setRecentKeywords((prev) => addRecentKeyword(prev, keyword));
+    executeSearch(keyword, filters);
   };
 
   // 최근 검색어 개별 삭제
   const handleRemoveKeyword = (e: React.MouseEvent, keyword: string) => {
     e.stopPropagation();
-    setRecentKeywords((prev) => prev.filter((k) => k !== keyword));
+    setRecentKeywords((prev) => {
+      const updated = prev.filter((k) => k !== keyword);
+      saveRecentKeywords(updated);
+      return updated;
+    });
   };
 
   // 최근 검색어 전체 삭제
   const handleClearAllKeywords = () => {
     setRecentKeywords([]);
+    saveRecentKeywords([]);
   };
 
   // 검색어 초기화
@@ -527,6 +561,8 @@ export default function SearchPage() {
     setSearchQuery("");
     setIsSearching(false);
     setSearchResults([]);
+    setTotalResults(0);
+    setSearchError(null);
   };
 
   // 필터 라벨 함수들
@@ -550,13 +586,13 @@ export default function SearchPage() {
 
   const getPriceLabel = () => {
     if (filters.priceMin && filters.priceMax) {
-      return `${parseInt(filters.priceMin).toLocaleString()}원 - ${parseInt(filters.priceMax).toLocaleString()}원`;
+      return `${parseInt(filters.priceMin).toLocaleString()} - ${parseInt(filters.priceMax).toLocaleString()}`;
     }
     if (filters.priceMin) {
-      return `${parseInt(filters.priceMin).toLocaleString()}원 이상`;
+      return `${parseInt(filters.priceMin).toLocaleString()} 이상`;
     }
     if (filters.priceMax) {
-      return `${parseInt(filters.priceMax).toLocaleString()}원 이하`;
+      return `${parseInt(filters.priceMax).toLocaleString()} 이하`;
     }
     return "가격";
   };
@@ -618,8 +654,7 @@ export default function SearchPage() {
                 <h2 className="font-semibold text-gray-900">최근 검색어</h2>
                 <button
                   onClick={handleClearAllKeywords}
-                  disabled={recentKeywords.length === 0}
-                  className="text-sm text-gray-400 hover:text-gray-600 disabled:opacity-50 disabled:cursor-not-allowed"
+                  className="text-sm text-gray-400 hover:text-gray-600"
                 >
                   전체 삭제
                 </button>
@@ -676,7 +711,7 @@ export default function SearchPage() {
           <div className="px-4 py-3 bg-gray-50 border-b border-gray-100">
             <p className="text-sm text-gray-600">
               <span className="font-semibold text-primary">&quot;{searchQuery}&quot;</span> 검색 결과{" "}
-              <span className="font-semibold">{searchResults.length}</span>건
+              <span className="font-semibold">{totalResults}</span>건
             </p>
           </div>
 
@@ -743,14 +778,37 @@ export default function SearchPage() {
             </button>
           </div>
 
+          {/* 로딩 상태 */}
+          {isLoadingResults && (
+            <div className="flex items-center justify-center py-20">
+              <div className="animate-spin rounded-full h-8 w-8 border-2 border-primary border-t-transparent" />
+            </div>
+          )}
+
+          {/* 에러 상태 */}
+          {searchError && !isLoadingResults && (
+            <div className="flex flex-col items-center justify-center py-20 text-gray-500">
+              <p className="text-sm">{searchError}</p>
+              <button
+                onClick={() => executeSearch(searchQuery, filters)}
+                className="mt-4 px-4 py-2 text-sm text-primary hover:underline"
+              >
+                다시 시도
+              </button>
+            </div>
+          )}
+
           {/* 결과 목록 */}
-          {searchResults.length > 0 ? (
+          {!isLoadingResults && !searchError && searchResults.length > 0 && (
             <div>
               {searchResults.map((post) => (
                 <SearchResultItem key={post.id} post={post} />
               ))}
             </div>
-          ) : (
+          )}
+
+          {/* 빈 결과 */}
+          {!isLoadingResults && !searchError && searchResults.length === 0 && (
             <div className="flex flex-col items-center justify-center py-20 text-gray-400">
               <span className="text-6xl mb-4">🔍</span>
               <p>검색 결과가 없어요</p>
@@ -760,12 +818,12 @@ export default function SearchPage() {
         </div>
       )}
 
-      {/* 카테고리 필터 모달 */}
+      {/* 카테고리 필터 모달 - API에서 로드한 카테고리 사용 */}
       <CheckboxFilterModal
         isOpen={isCategoryModalOpen}
         onClose={() => setIsCategoryModalOpen(false)}
         title="카테고리"
-        options={categories}
+        options={categoryNames}
         selected={filters.category}
         onApply={handleCategoryApply}
       />

--- a/apps/web/src/app/search/page.tsx
+++ b/apps/web/src/app/search/page.tsx
@@ -100,7 +100,7 @@ function SearchResultItem({ post }: { post: (typeof mockSearchResults)[0] }) {
     >
       <div className="w-28 h-28 bg-gray-100 rounded-xl overflow-hidden flex-shrink-0">
         <img
-          src="/icons/raccoon_bill.svg"
+          src="/icons/island.png"
           alt="상품 카테고리"
           className="w-full h-full object-cover"
         />

--- a/apps/web/src/app/search/page.tsx
+++ b/apps/web/src/app/search/page.tsx
@@ -391,7 +391,10 @@ export default function SearchPage() {
   const categoryNames = categories.map((c) => c.name);
 
   // 인기 검색어: 카테고리명 기반 동적 생성
-  const popularKeywords = categoryNames;
+  // Before: 카테고리 로드 전 빈 배열 → "인기 검색어" 섹션 비어 보임
+  // After: 카테고리 로드 전 기본 키워드 표시
+  const defaultKeywords = ["가구", "옷", "벽지", "바닥", "잡화", "레시피", "화석", "미술품"];
+  const popularKeywords = categoryNames.length > 0 ? categoryNames : defaultKeywords;
 
   // 필터 상태 (배열로 다중 선택 지원)
   const [filters, setFilters] = useState<FilterState>({

--- a/apps/web/src/app/search/page.tsx
+++ b/apps/web/src/app/search/page.tsx
@@ -41,16 +41,7 @@ const pricePresets = [
 ];
 
 // 인기 검색어 (동물의 숲 관련)
-const popularKeywords = [
-  "DIY 레시피",
-  "마일 티켓",
-  "무 주식",
-  "가구",
-  "화석",
-  "미술품",
-  "옷",
-  "벽지",
-];
+// 인기 검색어: 카테고리 로드 후 동적 생성 (하드코딩 제거)
 
 // localStorage 키
 const RECENT_KEYWORDS_KEY = "ac-trading-recent-keywords";
@@ -394,6 +385,9 @@ export default function SearchPage() {
   // 카테고리 목록 (API에서 로드)
   const [categories, setCategories] = useState<Category[]>([]);
   const categoryNames = categories.map((c) => c.name);
+
+  // 인기 검색어: 카테고리명 기반 동적 생성
+  const popularKeywords = categoryNames;
 
   // 필터 상태 (배열로 다중 선택 지원)
   const [filters, setFilters] = useState<FilterState>({

--- a/apps/web/src/app/search/page.tsx
+++ b/apps/web/src/app/search/page.tsx
@@ -100,7 +100,7 @@ function SearchResultItem({ post }: { post: (typeof mockSearchResults)[0] }) {
     >
       <div className="w-28 h-28 bg-gray-100 rounded-xl overflow-hidden flex-shrink-0">
         <img
-          src="/icons/island.png"
+          src="/icons/raccoon_bill.svg"
           alt="상품 카테고리"
           className="w-full h-full object-cover"
         />

--- a/apps/web/src/app/search/page.tsx
+++ b/apps/web/src/app/search/page.tsx
@@ -447,8 +447,10 @@ export default function SearchPage() {
         size: 50,
       };
 
-      // 카테고리 필터: 선택된 카테고리 ID 배열 전달 (다중 선택 지원)
-      if (currentFilters.category.length > 0) {
+      // 카테고리 필터: API에서 로드한 카테고리가 있을 때만 ID 매핑 시도
+      // Before: categories 빈 배열(API 실패) 시 find가 항상 undefined → 선택한 필터가 무시됨
+      // After: categories가 비어있으면 카테고리 필터 스킵
+      if (currentFilters.category.length > 0 && categories.length > 0) {
         const categoryIds = currentFilters.category
           .map((name) => categories.find((c) => c.name === name)?.id)
           .filter((id): id is number => id !== undefined);
@@ -754,16 +756,19 @@ export default function SearchPage() {
 
           {/* 필터 탭 */}
           <div className="flex gap-2 px-4 py-3 overflow-x-auto border-b border-gray-100 bg-white">
-            {/* 카테고리 필터 */}
+            {/* 카테고리 필터 - API 로드 실패 시 비활성화 (ID 매핑 불가) */}
             <button
-              onClick={() => setIsCategoryModalOpen(true)}
+              onClick={() => categories.length > 0 && setIsCategoryModalOpen(true)}
+              disabled={categories.length === 0}
               className={`px-3 py-1.5 rounded-full text-sm border transition-colors flex items-center gap-1 whitespace-nowrap ${
-                filters.category.length > 0
-                  ? "border-primary bg-primary/10 text-primary"
-                  : "border-gray-300 text-gray-700"
+                categories.length === 0
+                  ? "border-gray-200 text-gray-400 cursor-not-allowed"
+                  : filters.category.length > 0
+                    ? "border-primary bg-primary/10 text-primary"
+                    : "border-gray-300 text-gray-700"
               }`}
             >
-              {getCategoryLabel()}
+              {categories.length === 0 ? "카테고리" : getCategoryLabel()}
               <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
                 <path d="M6 9l6 6 6-6" />
               </svg>

--- a/apps/web/src/app/search/page.tsx
+++ b/apps/web/src/app/search/page.tsx
@@ -62,9 +62,15 @@ function loadRecentKeywords(): string[] {
 }
 
 // 최근 검색어 저장
+// Before: localStorage.setItem에 try/catch 없음 → Safari 개인정보 보호 모드나 용량 초과 시 예외 발생
+// After: try/catch 추가
 function saveRecentKeywords(keywords: string[]) {
   if (typeof window === "undefined") return;
-  localStorage.setItem(RECENT_KEYWORDS_KEY, JSON.stringify(keywords));
+  try {
+    localStorage.setItem(RECENT_KEYWORDS_KEY, JSON.stringify(keywords));
+  } catch {
+    // Safari 개인정보 보호 모드 또는 localStorage 용량 초과 시 무시
+  }
 }
 
 // 최근 검색어에 추가 (중복 제거, 최대 10개)

--- a/apps/web/src/app/search/page.tsx
+++ b/apps/web/src/app/search/page.tsx
@@ -394,13 +394,11 @@ export default function SearchPage() {
 
   // 카테고리 목록 (API에서 로드)
   const [categories, setCategories] = useState<Category[]>([]);
-  const categoryNames = categories.map((c) => c.name);
+  const defaultCategoryNames = ["가구", "옷", "벽지", "바닥", "잡화", "레시피", "화석", "미술품"];
+  const categoryNames = categories.length > 0 ? categories.map((c) => c.name) : defaultCategoryNames;
 
   // 인기 검색어: 카테고리명 기반 동적 생성
-  // Before: 카테고리 로드 전 빈 배열 → "인기 검색어" 섹션 비어 보임
-  // After: 카테고리 로드 전 기본 키워드 표시
-  const defaultKeywords = ["가구", "옷", "벽지", "바닥", "잡화", "레시피", "화석", "미술품"];
-  const popularKeywords = categoryNames.length > 0 ? categoryNames : defaultKeywords;
+  const popularKeywords = categoryNames;
 
   // 필터 상태 (배열로 다중 선택 지원)
   const [filters, setFilters] = useState<FilterState>({
@@ -417,19 +415,28 @@ export default function SearchPage() {
   const [isCurrencyModalOpen, setIsCurrencyModalOpen] = useState(false);
   const [isTradeTypeModalOpen, setIsTradeTypeModalOpen] = useState(false);
 
+  // 카테고리 로드 실패 상태
+  const [categoryError, setCategoryError] = useState(false);
+
+  // 카테고리 로드 함수 (재시도 가능)
+  // Before: 카테고리 로드 실패 시 빈 배열 → 필터 모달에 빈 목록
+  // After: 실패 시 기본 카테고리 유지 + 재시도 경로 제공
+  const loadCategories = useCallback(async () => {
+    try {
+      setCategoryError(false);
+      const response = await getCategories();
+      setCategories(response.categories);
+    } catch (err) {
+      console.error("카테고리 로드 실패:", err);
+      setCategoryError(true);
+    }
+  }, []);
+
   // 카테고리 로드 + 최근 검색어 로드
   useEffect(() => {
-    async function loadCategories() {
-      try {
-        const response = await getCategories();
-        setCategories(response.categories);
-      } catch (err) {
-        console.error("카테고리 로드 실패:", err);
-      }
-    }
     loadCategories();
     setRecentKeywords(loadRecentKeywords());
-  }, []);
+  }, [loadCategories]);
 
   // 필터 → API 파라미터 변환
   const buildSearchParams = useCallback(
@@ -708,7 +715,17 @@ export default function SearchPage() {
 
           {/* 인기 검색어 */}
           <div>
-            <h2 className="font-semibold text-gray-900 mb-3">인기 검색어</h2>
+            <div className="flex items-center gap-2 mb-3">
+              <h2 className="font-semibold text-gray-900">인기 검색어</h2>
+              {categoryError && (
+                <button
+                  onClick={loadCategories}
+                  className="text-xs text-primary hover:underline"
+                >
+                  새로고침
+                </button>
+              )}
+            </div>
             <div className="flex flex-wrap gap-2">
               {popularKeywords.map((keyword, index) => (
                 <button
@@ -838,11 +855,11 @@ export default function SearchPage() {
         </div>
       )}
 
-      {/* 카테고리 필터 모달 - API에서 로드한 카테고리 사용 */}
+      {/* 카테고리 필터 모달 */}
       <CheckboxFilterModal
         isOpen={isCategoryModalOpen}
         onClose={() => setIsCategoryModalOpen(false)}
-        title="카테고리"
+        title={categoryError ? "카테고리 (기본 목록)" : "카테고리"}
         options={categoryNames}
         selected={filters.category}
         onApply={handleCategoryApply}

--- a/apps/web/src/app/search/page.tsx
+++ b/apps/web/src/app/search/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
+import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { MobileLayout } from "@/components/common";
 import { ChevronLeftIcon, SearchIcon, HeartIcon } from "@/components/icons";
@@ -96,9 +97,11 @@ function SearchResultItem({ post }: { post: Post }) {
       className="flex gap-4 p-4 border-b border-gray-100 hover:bg-gray-50 transition-colors"
     >
       <div className="w-28 h-28 bg-gray-100 rounded-xl overflow-hidden flex-shrink-0">
-        <img
-          src="/icons/raccoon_bill.svg"
+        <Image
+          src={process.env.NEXT_PUBLIC_ICON_RACCOON || "/icons/raccoon_bill.svg"}
           alt="상품 카테고리"
+          width={112}
+          height={112}
           className="w-full h-full object-cover"
         />
       </div>

--- a/apps/web/src/app/search/page.tsx
+++ b/apps/web/src/app/search/page.tsx
@@ -427,20 +427,22 @@ export default function SearchPage() {
         size: 50,
       };
 
-      // 카테고리 필터: 1개만 선택된 경우 categoryId 전달
-      if (currentFilters.category.length === 1) {
-        const category = categories.find((c) => c.name === currentFilters.category[0]);
-        if (category) params.categoryId = category.id;
+      // 카테고리 필터: 선택된 카테고리 ID 배열 전달 (다중 선택 지원)
+      if (currentFilters.category.length > 0) {
+        const categoryIds = currentFilters.category
+          .map((name) => categories.find((c) => c.name === name)?.id)
+          .filter((id): id is number => id !== undefined);
+        if (categoryIds.length > 0) params.categoryId = categoryIds;
       }
 
-      // 화폐 유형 필터: 1개만 선택된 경우 전달
-      if (currentFilters.currencyType.length === 1) {
-        params.currencyType = CURRENCY_MAP[currentFilters.currencyType[0]];
+      // 화폐 유형 필터: 선택된 화폐 유형 배열 전달 (다중 선택 지원)
+      if (currentFilters.currencyType.length > 0) {
+        params.currencyType = currentFilters.currencyType.map((ct) => CURRENCY_MAP[ct]);
       }
 
-      // 거래 유형 필터: 1개만 선택된 경우 전달
-      if (currentFilters.tradeType.length === 1) {
-        params.postType = TRADE_TYPE_MAP[currentFilters.tradeType[0]];
+      // 거래 유형 필터: 선택된 거래 유형 배열 전달 (다중 선택 지원)
+      if (currentFilters.tradeType.length > 0) {
+        params.postType = currentFilters.tradeType.map((tt) => TRADE_TYPE_MAP[tt]);
       }
 
       // 가격 필터

--- a/apps/web/src/app/search/page.tsx
+++ b/apps/web/src/app/search/page.tsx
@@ -37,7 +37,7 @@ const tradeTypes = ["팔아요", "구해요"];
 const pricePresets = [
   { label: "~10,000", min: 0, max: 10000 },
   { label: "10,000 ~ 100,000", min: 10000, max: 100000 },
-  { label: "100,000~", min: 100000, max: 0 },
+  { label: "100,000~", min: 100000, max: 0 },  // max: 0 = 상한 없음
 ];
 
 // 인기 검색어 (동물의 숲 관련)
@@ -600,13 +600,13 @@ export default function SearchPage() {
 
   const getPriceLabel = () => {
     if (filters.priceMin && filters.priceMax) {
-      return `${parseInt(filters.priceMin).toLocaleString()} - ${parseInt(filters.priceMax).toLocaleString()}`;
+      return `${parseInt(filters.priceMin, 10).toLocaleString()} - ${parseInt(filters.priceMax, 10).toLocaleString()}`;
     }
     if (filters.priceMin) {
-      return `${parseInt(filters.priceMin).toLocaleString()} 이상`;
+      return `${parseInt(filters.priceMin, 10).toLocaleString()} 이상`;
     }
     if (filters.priceMax) {
-      return `${parseInt(filters.priceMax).toLocaleString()} 이하`;
+      return `${parseInt(filters.priceMax, 10).toLocaleString()} 이하`;
     }
     return "가격";
   };

--- a/apps/web/src/app/user/[id]/page.tsx
+++ b/apps/web/src/app/user/[id]/page.tsx
@@ -150,7 +150,7 @@ export default function UserProfilePage() {
       <div className="flex items-center gap-4 p-4">
         {/* 프로필 이미지 */}
         <Image
-          src={process.env.NEXT_PUBLIC_ICON_RACCOON || "/icons/raccoon_bill.svg"}
+          src={process.env.NEXT_PUBLIC_ICON_RACCOON || "/icons/island.png"}
           alt="프로필 이미지"
           width={56}
           height={56}

--- a/apps/web/src/app/user/[id]/page.tsx
+++ b/apps/web/src/app/user/[id]/page.tsx
@@ -179,7 +179,7 @@ export default function UserProfilePage() {
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
             <span className="text-3xl font-bold text-red-500">
-              {userProfile.mannerScore != null ? `${userProfile.mannerScore.toFixed(1)} 벨` : "-"}
+              {userProfile.mannerScore != null && Number.isFinite(userProfile.mannerScore) ? `${userProfile.mannerScore.toFixed(1)} 벨` : "-"}
             </span>
             <Image
               src={process.env.NEXT_PUBLIC_ICON_CARROT || "/icons/carrot.svg"}
@@ -191,7 +191,7 @@ export default function UserProfilePage() {
           </div>
         </div>
         {/* 온도 바 */}
-        {userProfile.mannerScore != null && (
+        {userProfile.mannerScore != null && Number.isFinite(userProfile.mannerScore) && (
           <div className="mt-3">
             <div className="w-full h-2 bg-[#FFFFF0] rounded-full overflow-hidden">
               <div

--- a/apps/web/src/app/user/[id]/page.tsx
+++ b/apps/web/src/app/user/[id]/page.tsx
@@ -179,7 +179,7 @@ export default function UserProfilePage() {
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
             <span className="text-3xl font-bold text-red-500">
-              {userProfile.mannerScore != null ? `${userProfile.mannerScore.toFixed(1)}` : "-"}
+              {userProfile.mannerScore != null ? `${userProfile.mannerScore.toFixed(1)} 벨` : "-"}
             </span>
             <Image
               src={process.env.NEXT_PUBLIC_ICON_CARROT || "/icons/carrot.svg"}

--- a/apps/web/src/app/user/[id]/page.tsx
+++ b/apps/web/src/app/user/[id]/page.tsx
@@ -150,7 +150,7 @@ export default function UserProfilePage() {
       <div className="flex items-center gap-4 p-4">
         {/* 프로필 이미지 */}
         <Image
-          src={process.env.NEXT_PUBLIC_ICON_RACCOON || "/icons/island.png"}
+          src={process.env.NEXT_PUBLIC_ICON_ISLAND || "/icons/island.png"}
           alt="프로필 이미지"
           width={56}
           height={56}

--- a/apps/web/src/components/common/BottomNav.tsx
+++ b/apps/web/src/components/common/BottomNav.tsx
@@ -36,7 +36,7 @@ export default function BottomNav() {
               <Icon active={isActive} />
               <span
                 className={`text-xs ${
-                  isActive ? "text-primary font-medium" : "text-gray-500"
+                  isActive ? "text-primary font-medium" : "text-black"
                 }`}
               >
                 {item.label}

--- a/apps/web/src/components/common/BottomNav.tsx
+++ b/apps/web/src/components/common/BottomNav.tsx
@@ -8,7 +8,7 @@ import { HomeIcon, ChatIcon, UserIcon } from "../icons";
 const navItems = [
   { href: "/", label: "홈", icon: HomeIcon },
   { href: "/chat", label: "채팅", icon: ChatIcon },
-  { href: "/profile", label: "나의 당근", icon: UserIcon },
+  { href: "/profile", label: "내 프로필", icon: UserIcon },
 ];
 
 export default function BottomNav() {

--- a/apps/web/src/components/common/Header.tsx
+++ b/apps/web/src/components/common/Header.tsx
@@ -40,15 +40,15 @@ export default function Header({
               onClick={onBack}
               className="p-1 -ml-1 hover:bg-gray-100 rounded-full transition-colors"
             >
-              <ChevronLeftIcon className="text-gray-800" />
+              <ChevronLeftIcon className="text-black" />
             </button>
           )}
           {showLocation ? (
-            <span className="font-semibold text-lg text-gray-900">
+            <span className="font-semibold text-lg text-black">
               {isAuthenticated && user?.islandName ? user.islandName : "내 섬"}
             </span>
           ) : (
-            title && <h1 className="font-semibold text-lg text-gray-900">{title}</h1>
+            title && <h1 className="font-semibold text-lg text-black">{title}</h1>
           )}
         </div>
 
@@ -56,17 +56,17 @@ export default function Header({
         <div className="flex items-center gap-3">
           {showSearch && (
             <Link href="/search" className="p-1 hover:bg-gray-100 rounded-full transition-colors">
-              <SearchIcon className="text-gray-800" />
+              <SearchIcon className="text-black" />
             </Link>
           )}
           {showMenu && (
             <button className="p-1 hover:bg-gray-100 rounded-full transition-colors">
-              <MenuIcon className="text-gray-800" />
+              <MenuIcon className="text-black" />
             </button>
           )}
           {showBell && (
             <Link href="/alarm" className="p-1 hover:bg-gray-100 rounded-full transition-colors">
-              <BellIcon className="text-gray-800" />
+              <BellIcon className="text-black" />
             </Link>
           )}
 
@@ -92,7 +92,7 @@ export default function Header({
                   )}
                   <button
                     onClick={logout}
-                    className="text-sm text-gray-500 hover:text-gray-700"
+                    className="text-sm text-black hover:text-black"
                   >
                     로그아웃
                   </button>

--- a/apps/web/src/components/icons/index.tsx
+++ b/apps/web/src/components/icons/index.tsx
@@ -106,9 +106,9 @@ export const ChevronRightIcon = ({ className = "" }: { className?: string }) => 
   </svg>
 );
 
-// 찜 아이콘 - 심플 나뭇잎 (저작권 무료)
-// Before: 동물의 숲 스타일 나뭇잎 (leaf_logo.svg 기반)
-// After: 심플한 나뭇잎 아이콘 (저작권 문제 없음)
+// 찜 아이콘 - 하트 모양 (저작권 무료)
+// Before: 나뭇잎 모양 아이콘 (닌텐도 저작권 우려)
+// After: 일반 하트 아이콘 (저작권 문제 없음)
 export const HeartIcon = ({ filled = false, className = "" }: { filled?: boolean; className?: string }) => (
   <svg
     width="20"
@@ -118,18 +118,12 @@ export const HeartIcon = ({ filled = false, className = "" }: { filled?: boolean
     className={className}
   >
     <path
-      d="M11 20C11 20 3 14.5 3 9C3 6 5.5 3 9 3C11.5 3 12 5 12 5C12 5 12.5 3 15 3C18.5 3 21 6 21 9C21 14.5 13 20 13 20"
+      d="M12 21.35L10.55 20.03C5.4 15.36 2 12.28 2 8.5C2 5.42 4.42 3 7.5 3C9.24 3 10.91 3.81 12 5.09C13.09 3.81 14.76 3 16.5 3C19.58 3 22 5.42 22 8.5C22 12.28 18.6 15.36 13.45 20.04L12 21.35Z"
       fill={filled ? "#7ECEC5" : "none"}
       stroke={filled ? "#7ECEC5" : "#9CA3AF"}
       strokeWidth="2"
       strokeLinecap="round"
       strokeLinejoin="round"
-    />
-    <path
-      d="M12 5V19"
-      stroke={filled ? "#5BBFB3" : "#9CA3AF"}
-      strokeWidth="1.5"
-      strokeLinecap="round"
     />
   </svg>
 );

--- a/apps/web/src/components/icons/index.tsx
+++ b/apps/web/src/components/icons/index.tsx
@@ -106,9 +106,9 @@ export const ChevronRightIcon = ({ className = "" }: { className?: string }) => 
   </svg>
 );
 
-// 찜 아이콘 - 하트 모양 (저작권 무료)
-// Before: 나뭇잎 모양 아이콘 (닌텐도 저작권 우려)
-// After: 일반 하트 아이콘 (저작권 문제 없음)
+// 찜 아이콘 - 보타니컬 나뭇잎 (저작권 무료)
+// Before: 하트 아이콘
+// After: 일반 나뭇잎 아이콘 (닌텐도 관련 아님, 저작권 문제 없음)
 export const HeartIcon = ({ filled = false, className = "" }: { filled?: boolean; className?: string }) => (
   <svg
     width="20"
@@ -117,13 +117,21 @@ export const HeartIcon = ({ filled = false, className = "" }: { filled?: boolean
     xmlns="http://www.w3.org/2000/svg"
     className={className}
   >
+    {/* 나뭇잎 몸체 */}
     <path
-      d="M12 21.35L10.55 20.03C5.4 15.36 2 12.28 2 8.5C2 5.42 4.42 3 7.5 3C9.24 3 10.91 3.81 12 5.09C13.09 3.81 14.76 3 16.5 3C19.58 3 22 5.42 22 8.5C22 12.28 18.6 15.36 13.45 20.04L12 21.35Z"
+      d="M17 8C8 10 5.9 16.17 3.82 21.34L5.71 22L6.66 19.7C7.14 19.87 7.64 20 8.17 20C12.76 20 17.5 14.5 17.5 8.5L17 8Z"
       fill={filled ? "#7ECEC5" : "none"}
       stroke={filled ? "#7ECEC5" : "#9CA3AF"}
       strokeWidth="2"
       strokeLinecap="round"
       strokeLinejoin="round"
+    />
+    {/* 나뭇잎 줄기 */}
+    <path
+      d="M8 17C12 14 15 10 17 8"
+      stroke={filled ? "#5BBFB3" : "#9CA3AF"}
+      strokeWidth="1.5"
+      strokeLinecap="round"
     />
   </svg>
 );

--- a/apps/web/src/lib/postApi.ts
+++ b/apps/web/src/lib/postApi.ts
@@ -985,3 +985,79 @@ export async function deleteTransaction(id: number): Promise<{ message: string }
     method: 'DELETE',
   });
 }
+
+// ========== 알림 타입 정의 ==========
+
+// 알림 응답 타입
+export interface NotificationItem {
+  id: number;
+  type: string;
+  title: string;
+  content: string | null;
+  referenceId: number | null;
+  referenceType: string | null;
+  isRead: boolean;
+  // read 프로퍼티를 isRead의 별칭으로 사용 (프론트 호환)
+  read: boolean;
+  createdAt: string;
+}
+
+// 알림 목록 응답 타입
+export interface NotificationListResponse {
+  notifications: NotificationItem[];
+  unreadCount: number;
+  currentPage: number;
+  totalPages: number;
+  totalElements: number;
+  hasNext: boolean;
+  hasPrevious: boolean;
+}
+
+// ========== 알림 API 함수 ==========
+
+/**
+ * 내 알림 목록 조회
+ * GET /api/notifications
+ */
+export async function getNotifications(page = 0, size = 20): Promise<NotificationListResponse> {
+  const data = await fetchWithAuth<NotificationListResponse>(
+    `${API_URL}/api/notifications?page=${page}&size=${size}`
+  );
+  // isRead → read 별칭 매핑
+  data.notifications = data.notifications.map((n) => ({
+    ...n,
+    read: n.isRead ?? n.read,
+  }));
+  return data;
+}
+
+/**
+ * 읽지 않은 알림 수 조회
+ * GET /api/notifications/unread-count
+ */
+export async function getUnreadNotificationCount(): Promise<number> {
+  const data = await fetchWithAuth<{ unreadCount: number }>(
+    `${API_URL}/api/notifications/unread-count`
+  );
+  return data.unreadCount;
+}
+
+/**
+ * 알림 읽음 처리
+ * PATCH /api/notifications/{id}/read
+ */
+export async function markNotificationAsRead(id: number): Promise<{ message: string }> {
+  return fetchWithAuth<{ message: string }>(`${API_URL}/api/notifications/${id}/read`, {
+    method: 'PATCH',
+  });
+}
+
+/**
+ * 모든 알림 읽음 처리
+ * PATCH /api/notifications/read-all
+ */
+export async function markAllNotificationsAsRead(): Promise<{ message: string; count: number }> {
+  return fetchWithAuth<{ message: string; count: number }>(`${API_URL}/api/notifications/read-all`, {
+    method: 'PATCH',
+  });
+}

--- a/apps/web/src/lib/postApi.ts
+++ b/apps/web/src/lib/postApi.ts
@@ -996,9 +996,9 @@ export interface NotificationItem {
   content: string | null;
   referenceId: number | null;
   referenceType: string | null;
+  // Before: Lombok boolean isRead → Jackson이 "read"로 직렬화
+  // After: @JsonProperty("isRead") 추가하여 "isRead"로 직렬화
   isRead: boolean;
-  // read 프로퍼티를 isRead의 별칭으로 사용 (프론트 호환)
-  read: boolean;
   createdAt: string;
 }
 
@@ -1020,15 +1020,9 @@ export interface NotificationListResponse {
  * GET /api/notifications
  */
 export async function getNotifications(page = 0, size = 20): Promise<NotificationListResponse> {
-  const data = await fetchWithAuth<NotificationListResponse>(
+  return fetchWithAuth<NotificationListResponse>(
     `${API_URL}/api/notifications?page=${page}&size=${size}`
   );
-  // isRead → read 별칭 매핑
-  data.notifications = data.notifications.map((n) => ({
-    ...n,
-    read: n.isRead ?? n.read,
-  }));
-  return data;
 }
 
 /**

--- a/apps/web/src/lib/postApi.ts
+++ b/apps/web/src/lib/postApi.ts
@@ -299,6 +299,44 @@ async function fetchWithAuth<T>(
   return response.json();
 }
 
+// ========== 이미지 업로드 API 함수 ==========
+
+// 이미지 업로드 응답 타입
+export interface ImageUploadResponse {
+  urls: string[];
+  uploadedCount: number;
+}
+
+/**
+ * 게시글 이미지 업로드
+ * POST /api/images/posts (multipart/form-data)
+ */
+export async function uploadPostImages(files: File[]): Promise<ImageUploadResponse> {
+  const accessToken = getAccessToken();
+  const formData = new FormData();
+  files.forEach((file) => formData.append('files', file));
+
+  // multipart/form-data는 Content-Type 헤더를 설정하지 않음 (브라우저가 boundary 자동 설정)
+  const response = await fetch(`${API_URL}/api/images/posts`, {
+    method: 'POST',
+    headers: {
+      ...(accessToken && { Authorization: `Bearer ${accessToken}` }),
+    },
+    credentials: 'include',
+    body: formData,
+  });
+
+  if (!response.ok) {
+    const errorData: ApiError = await response.json().catch(() => ({
+      error: 'UPLOAD_FAILED',
+      message: '이미지 업로드에 실패했습니다',
+    }));
+    throw new Error(errorData.message);
+  }
+
+  return response.json();
+}
+
 // ========== 카테고리 API 함수 ==========
 
 /**

--- a/apps/web/src/lib/postApi.ts
+++ b/apps/web/src/lib/postApi.ts
@@ -393,13 +393,14 @@ export async function getPosts(params?: {
 /**
  * 게시글 검색
  * GET /api/posts/search
+ * - 다중 필터 지원: categoryId, postType, currencyType은 배열로 전달 가능
  */
 export async function searchPosts(params: {
   keyword: string;
-  categoryId?: number;
-  postType?: 'SELL' | 'BUY';
+  categoryId?: number[];
+  postType?: ('SELL' | 'BUY')[];
   status?: 'AVAILABLE' | 'RESERVED' | 'COMPLETED';
-  currencyType?: 'BELL' | 'MILE_TICKET';
+  currencyType?: ('BELL' | 'MILE_TICKET')[];
   minPrice?: number;
   maxPrice?: number;
   page?: number;
@@ -408,10 +409,11 @@ export async function searchPosts(params: {
   const searchParams = new URLSearchParams();
 
   searchParams.set('keyword', params.keyword);
-  if (params.categoryId) searchParams.set('categoryId', String(params.categoryId));
-  if (params.postType) searchParams.set('postType', params.postType);
+  // 다중 필터: 같은 키를 여러 번 append (?categoryId=1&categoryId=2)
+  if (params.categoryId) params.categoryId.forEach((id) => searchParams.append('categoryId', String(id)));
+  if (params.postType) params.postType.forEach((pt) => searchParams.append('postType', pt));
   if (params.status) searchParams.set('status', params.status);
-  if (params.currencyType) searchParams.set('currencyType', params.currencyType);
+  if (params.currencyType) params.currencyType.forEach((ct) => searchParams.append('currencyType', ct));
   if (params.minPrice !== undefined) searchParams.set('minPrice', String(params.minPrice));
   if (params.maxPrice !== undefined) searchParams.set('maxPrice', String(params.maxPrice));
   if (params.page !== undefined) searchParams.set('page', String(params.page));

--- a/apps/web/src/lib/postApi.ts
+++ b/apps/web/src/lib/postApi.ts
@@ -147,6 +147,8 @@ export interface ReviewListResponse {
   totalElements: number;
   hasNext: boolean;
   hasPrevious: boolean;
+  averageRating: number | null;
+  reviewCount: number | null;
 }
 
 // ========== 채팅 타입 정의 ==========
@@ -563,6 +565,19 @@ export async function createReview(request: ReviewCreateRequest): Promise<Review
     method: 'POST',
     body: JSON.stringify(request),
   });
+}
+
+/**
+ * 내가 받은 리뷰 목록 조회
+ * GET /api/users/me/reviews
+ */
+export async function getMyReviews(
+  page = 0,
+  size = 20
+): Promise<ReviewListResponse> {
+  return fetchWithAuth<ReviewListResponse>(
+    `${API_URL}/api/users/me/reviews?page=${page}&size=${size}`
+  );
 }
 
 /**

--- a/apps/web/src/lib/websocket.ts
+++ b/apps/web/src/lib/websocket.ts
@@ -34,15 +34,13 @@ class WebSocketClient {
   private client: Client | null = null;
   private subscriptions: Map<string, StompSubscription> = new Map();
   private accessToken: string | null = null;
-  private reconnectAttempts = 0;
-  private maxReconnectAttempts = 5;
   private onConnectCallback: (() => void) | null = null;
   private onDisconnectCallback: (() => void) | null = null;
 
   // 연결
   // Before: 기존 client가 연결 실패 상태일 때 정리 안 함 → 좀비 클라이언트 생성
   // After: 기존 client를 deactivate 후 새로 생성, STOMP.js 내장 재연결 활용
-  connect(accessToken: string, onConnect?: () => void, onDisconnect?: () => void): void {
+  async connect(accessToken: string, onConnect?: () => void, onDisconnect?: () => void): Promise<void> {
     // 이미 연결된 상태면 콜백만 업데이트 후 호출
     if (this.client?.connected) {
       console.log('WebSocket 이미 연결됨');
@@ -52,11 +50,12 @@ class WebSocketClient {
       return;
     }
 
-    // 기존 클라이언트가 있으면 정리 (연결 중이거나 실패한 상태)
+    // Before: deactivate()가 비동기인데 await 없이 호출 → 두 개의 연결이 동시에 존재할 수 있음
+    // After: await로 이전 클라이언트 정리 완료 후 새 클라이언트 생성
     if (this.client) {
       console.log('기존 WebSocket 클라이언트 정리');
       try {
-        this.client.deactivate();
+        await this.client.deactivate();
       } catch (e) {
         console.warn('WebSocket deactivate 실패:', e);
       }
@@ -66,7 +65,6 @@ class WebSocketClient {
     this.accessToken = accessToken;
     this.onConnectCallback = onConnect || null;
     this.onDisconnectCallback = onDisconnect || null;
-    this.reconnectAttempts = 0;
 
     this.client = new Client({
       // SockJS를 통한 연결
@@ -90,7 +88,6 @@ class WebSocketClient {
       // 연결 성공
       onConnect: () => {
         console.log('WebSocket 연결 성공');
-        this.reconnectAttempts = 0;
         this.onConnectCallback?.();
       },
 
@@ -108,11 +105,9 @@ class WebSocketClient {
         console.error('에러 상세:', frame.body);
       },
 
-      // WebSocket 에러
+      // WebSocket 에러 - STOMP.js가 reconnectDelay로 자동 재연결 시도
       onWebSocketError: (event) => {
         console.error('WebSocket 에러:', event);
-        this.reconnectAttempts++;
-        // STOMP.js가 reconnectDelay로 자동 재연결 시도
         this.onDisconnectCallback?.();
       },
 

--- a/apps/web/src/lib/websocket.ts
+++ b/apps/web/src/lib/websocket.ts
@@ -100,11 +100,12 @@ class WebSocketClient {
         this.onDisconnectCallback?.();
       },
 
-      // 에러 처리
+      // STOMP 프로토콜 에러 (구독 권한 거부 등 - 연결 해제가 아닐 수 있음)
+      // Before: onDisconnectCallback 호출 → UI에 "연결 해제" 잘못 표시
+      // After: 에러 로깅만 수행, 실제 연결 해제는 onDisconnect/onWebSocketClose에서 처리
       onStompError: (frame) => {
         console.error('STOMP 에러:', frame.headers['message']);
         console.error('에러 상세:', frame.body);
-        this.onDisconnectCallback?.();
       },
 
       // WebSocket 에러

--- a/apps/web/src/lib/websocket.ts
+++ b/apps/web/src/lib/websocket.ts
@@ -40,16 +40,33 @@ class WebSocketClient {
   private onDisconnectCallback: (() => void) | null = null;
 
   // 연결
+  // Before: 기존 client가 연결 실패 상태일 때 정리 안 함 → 좀비 클라이언트 생성
+  // After: 기존 client를 deactivate 후 새로 생성, STOMP.js 내장 재연결 활용
   connect(accessToken: string, onConnect?: () => void, onDisconnect?: () => void): void {
+    // 이미 연결된 상태면 콜백만 업데이트 후 호출
     if (this.client?.connected) {
       console.log('WebSocket 이미 연결됨');
+      this.onConnectCallback = onConnect || null;
+      this.onDisconnectCallback = onDisconnect || null;
       onConnect?.();
       return;
+    }
+
+    // 기존 클라이언트가 있으면 정리 (연결 중이거나 실패한 상태)
+    if (this.client) {
+      console.log('기존 WebSocket 클라이언트 정리');
+      try {
+        this.client.deactivate();
+      } catch (e) {
+        console.warn('WebSocket deactivate 실패:', e);
+      }
+      this.client = null;
     }
 
     this.accessToken = accessToken;
     this.onConnectCallback = onConnect || null;
     this.onDisconnectCallback = onDisconnect || null;
+    this.reconnectAttempts = 0;
 
     this.client = new Client({
       // SockJS를 통한 연결
@@ -67,7 +84,7 @@ class WebSocketClient {
         }
       },
 
-      // 재연결 설정
+      // STOMP.js 내장 재연결 (5초 간격)
       reconnectDelay: 5000,
 
       // 연결 성공
@@ -87,30 +104,25 @@ class WebSocketClient {
       onStompError: (frame) => {
         console.error('STOMP 에러:', frame.headers['message']);
         console.error('에러 상세:', frame.body);
+        this.onDisconnectCallback?.();
       },
 
       // WebSocket 에러
       onWebSocketError: (event) => {
         console.error('WebSocket 에러:', event);
-        this.handleReconnect();
+        this.reconnectAttempts++;
+        // STOMP.js가 reconnectDelay로 자동 재연결 시도
+        this.onDisconnectCallback?.();
       },
 
       // WebSocket 종료
       onWebSocketClose: () => {
         console.log('WebSocket 종료');
-        this.handleReconnect();
+        this.onDisconnectCallback?.();
       },
     });
 
     this.client.activate();
-  }
-
-  // 재연결 처리
-  private handleReconnect(): void {
-    if (this.reconnectAttempts < this.maxReconnectAttempts && this.accessToken) {
-      this.reconnectAttempts++;
-      console.log(`WebSocket 재연결 시도 (${this.reconnectAttempts}/${this.maxReconnectAttempts})`);
-    }
   }
 
   // 연결 해제


### PR DESCRIPTION
## Summary

앱 UI 전반의 이슈 수정 및 mock 데이터를 실제 API로 교체하는 작업입니다.

## 변경사항

### 1. UI/UX 개선
- **헤더/탭 텍스트 색상**: 회색(gray-500) → 검정색(gray-900)으로 변경하여 가독성 개선
- **하단 탭 라벨**: "나의 당근" → "내 프로필"로 변경 (당근마켓 명칭 제거)
- **매너 점수 표시**: 온도(°C) → "무가격"으로 변경 (동물의 숲 테마에 맞춤)
- **찜 아이콘**: 하트 → 보타니컬 나뭇잎 SVG로 교체 (동물의 숲 테마)
- **기본 이미지**: island.png → raccoon_bill.svg 복원 (자체 제작 이미지)

### 2. 누락 페이지/네비게이션 연결
- **프로필 탭**: 모아보기(`/collection`), 나의 활동(`/review`) 메뉴 링크 연결
- **매너 평가하기**: 채팅 더보기 메뉴에서 "준비 중" alert → 리뷰 페이지(`/review?postId&revieweeId`)로 이동

### 3. Mock 데이터 → 실제 API 교체

#### 검색 페이지 (`search/page.tsx`)
- `mockSearchResults` 제거 → `searchPosts()` API 호출
- 카테고리 목록: 하드코딩 배열 → `getCategories()` API로 로드
- 필터 변경 시 서버사이드 재검색 (거래유형, 화폐유형, 카테고리, 가격범위)
- 최근 검색어 localStorage 저장/관리
- 로딩/에러 상태 처리

#### 리뷰 페이지 (`review/page.tsx`)
- 더미 `transaction` 객체 제거 → URL 쿼리 파라미터(`postId`, `revieweeId`)로 데이터 수신
- `getPost()` API로 거래 아이템 정보 로드
- `createReview()` API 호출로 실제 후기 등록
- 파라미터 없이 접근 시 안내 메시지 표시 (프로필 "나의 활동"에서 접근 등)

#### 게시글 이미지 업로드 (`post/new/page.tsx`, `postApi.ts`)
- `uploadPostImages()` 함수 추가 (multipart/form-data → Cloudflare R2)
- 게시글 작성 시 이미지 업로드 후 URL을 description에 임시 저장 (`[images:url1,url2]`)
- 이미지 추가 버튼에 실제 파일 선택기(갤러리) 연동

### 4. 채팅 WebSocket 연결 문제 수정

#### 증상
채팅방 진입 시 "연결 중..."만 표시되고 메시지 전송 불가

#### 원인 및 수정 (`websocket.ts`)
- **좀비 클라이언트**: `connect()` 호출 시 기존 client가 연결 중/실패 상태면 정리 안 됨 → `deactivate()` 후 재생성하도록 수정
- **빈 재연결 함수**: `handleReconnect()`가 카운터만 증가시키고 실제 재연결 안 함 → 제거하고 STOMP.js 내장 `reconnectDelay: 5000` 활용
- **에러 시 UI 동기화 누락**: `onStompError`, `onWebSocketError`, `onWebSocketClose`에서 `onDisconnectCallback` 호출 추가

#### 클린업 수정 (`chat/[id]/page.tsx`)
- 채팅방 나갈 때 구독만 해제 → 구독 해제 + `disconnect()` 호출 (좀비 TCP 연결 방지)

### 5. 앱 네이티브 (apps/app)
- Android 하드웨어 뒤로가기 버튼/제스처 → WebView `goBack()` 연동

## 변경 파일 목록

### 웹 (apps/web)
| 파일 | 변경 내용 |
|---|---|
| `src/app/page.tsx` | 기본 이미지 raccoon_bill.svg 복원 |
| `src/app/login/page.tsx` | 기본 이미지 raccoon_bill.svg 복원 |
| `src/app/search/page.tsx` | mock 데이터 → searchPosts API 교체 |
| `src/app/review/page.tsx` | 더미 데이터 → createReview API 교체 |
| `src/app/collection/page.tsx` | 기본 이미지 raccoon_bill.svg 복원 |
| `src/app/post/new/page.tsx` | 이미지 업로드 + 파일 선택기 연동 |
| `src/app/post/[id]/page.tsx` | 매너점수 °C → 무가격, 찜 아이콘 변경 |
| `src/app/chat/[id]/page.tsx` | WebSocket cleanup, 매너평가→리뷰 연결 |
| `src/app/profile/page.tsx` | 모아보기/나의활동 링크, 탭 라벨 변경 |
| `src/lib/postApi.ts` | uploadPostImages() 함수 추가 |
| `src/lib/websocket.ts` | 좀비 client 정리, 재연결 로직 수정 |
| `src/components/common/BottomNav.tsx` | 탭 라벨/텍스트 색상 변경 |
| `src/components/common/Header.tsx` | 헤더 텍스트 색상 변경 |
| `src/components/icons/index.tsx` | 보타니컬 나뭇잎 SVG 아이콘 추가 |
| `.env.example` | 기본 이미지 경로 업데이트 |

### 앱 (apps/app)
| 파일 | 변경 내용 |
|---|---|
| `src/screens/HomeScreen.tsx` | Android BackHandler WebView 연동 |

## 알려진 제한사항
- **이미지 URL 임시 저장**: Post 엔티티에 imageUrls 필드가 없어서 description 끝에 `[images:url1,url2]` 형태로 임시 저장 → 백엔드 Post 엔티티 수정 필요
- **알림 페이지**: 백엔드 API 미구현 (NotificationController/Service 없음) → #102 이슈로 분리

## Test plan
- [ ] 검색 페이지에서 키워드 검색 → 실제 API 결과 표시 확인
- [ ] 검색 필터 (거래유형, 화폐, 카테고리, 가격) 작동 확인
- [ ] 리뷰 페이지에서 채팅 → 매너평가하기 → 리뷰 작성 → 제출 확인
- [ ] 게시글 작성 시 이미지 선택 → 업로드 → R2 저장 확인
- [ ] 채팅방 진입 → WebSocket 연결 → 메시지 송수신 확인
- [ ] 채팅방 나가기 → WebSocket 정상 종료 확인
- [ ] 하단 탭 "내 프로필" 라벨 확인
- [ ] 프로필 → 모아보기/나의 활동 링크 작동 확인
- [ ] Android 뒤로가기 버튼 → WebView 뒤로가기 작동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #101

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 포스트 작성 시 다중 이미지 업로드·미리보기 및 이미지 업로드 지원 추가
  * 알림 목록, 미확인 카운트 조회 및 읽음 처리 UI/기능 추가
  * 프로필에서 받은 리뷰(내 리뷰) 조회 페이지 추가
  * 카테고리·화폐·거래유형 다중 필터 기반 검색 및 카테고리 로딩 적용
  * 채팅·리뷰 관련 UI/네비게이션 개선

* **Bug Fixes**
  * Android 하드웨어 뒤로가기(WebView) 처리 개선
  * 웹소켓 연결/종료 정리 및 안정성 향상
  * 알람·검색 등에서 로딩·오류 상태 처리 개선

* **Style**
  * 전반 텍스트·아이콘 색상을 검정으로 통일 및 일부 아이콘·레이블 변경
<!-- end of auto-generated comment: release notes by coderabbit.ai -->