### PR TITLE
fix: UI 버그 수정 - 이미지 표시, 찜 아이콘, 프로필, 채팅 WebSocket

### DIFF
--- a/apps/web/src/app/account-book/page.tsx
+++ b/apps/web/src/app/account-book/page.tsx
@@ -310,7 +310,7 @@ function AddTransactionModal({
                 className="flex-1 px-4 py-3 focus:outline-none text-gray-900"
               />
               <span className="px-4 text-primary font-medium">
-                {currencyType === "BELL" ? "벨" : "마일"}
+                {currencyType === "BELL" ? "덩" : "마일"}
               </span>
             </div>
           </div>

--- a/apps/web/src/app/post/[id]/page.tsx
+++ b/apps/web/src/app/post/[id]/page.tsx
@@ -11,6 +11,7 @@ import {
   formatRelativeTime,
   getStatusLabel,
   extractImageUrls,
+  isSafeImageUrl,
   stripImagePattern,
   Post,
   createPriceOffer,
@@ -33,16 +34,6 @@ const REPORT_REASONS: { code: ReportReasonCode; label: string }[] = [
   { code: "EXTERNAL_MESSENGER", label: "외부 메신저 유도" },
   { code: "OTHER", label: "기타" },
 ];
-
-// 허용된 프로토콜만 통과시키는 이미지 URL 검증
-function isSafeImageUrl(url: string): boolean {
-  try {
-    const parsed = new URL(url);
-    return ["https:", "http:"].includes(parsed.protocol);
-  } catch {
-    return false;
-  }
-}
 
 // 상품 상세 페이지 - Figma 디자인 기반
 export default function PostDetailPage() {

--- a/apps/web/src/app/post/[id]/page.tsx
+++ b/apps/web/src/app/post/[id]/page.tsx
@@ -516,7 +516,7 @@ export default function PostDetailPage() {
                   placeholder="제안할 가격을 입력하세요"
                 />
                 <span className="px-4 text-primary font-medium">
-                  {offerCurrencyType === "BELL" ? "벨" : "마일"}
+                  {offerCurrencyType === "BELL" ? "덩" : "마일"}
                 </span>
               </div>
             </div>

--- a/apps/web/src/app/post/new/page.tsx
+++ b/apps/web/src/app/post/new/page.tsx
@@ -289,7 +289,7 @@ export default function NewPostPage() {
                 placeholder="가격을 입력해주세요"
               />
               <span className="px-4 text-primary font-medium">
-                {currencyType === "BELL" ? "벨" : "마일"}
+                {currencyType === "BELL" ? "덩" : "마일"}
               </span>
             </div>
           </div>

--- a/apps/web/src/app/profile/favorites/page.tsx
+++ b/apps/web/src/app/profile/favorites/page.tsx
@@ -20,7 +20,7 @@ function FavoriteItem({
   const formatPrice = (price: number | null, currencyType: string | null) => {
     if (price === null) return "가격 미정";
     if (currencyType === "MILE_TICKET") return `마일 티켓 ${price}장`;
-    return `${price.toLocaleString()} 벨`;
+    return `${price.toLocaleString()} 덩`;
   };
 
   // 거래 상태 배지

--- a/apps/web/src/app/profile/favorites/page.tsx
+++ b/apps/web/src/app/profile/favorites/page.tsx
@@ -6,7 +6,7 @@ import Image from "next/image";
 import { MobileLayout, Header } from "@/components/common";
 import { HeartIcon } from "@/components/icons";
 import { useAuth } from "@/context/AuthContext";
-import { getMyLikes, extractImageUrls, Post, togglePostLike } from "@/lib/postApi";
+import { getMyLikes, extractImageUrls, isSafeImageUrl, Post, togglePostLike } from "@/lib/postApi";
 
 // 관심 상품 아이템 컴포넌트
 function FavoriteItem({
@@ -43,7 +43,7 @@ function FavoriteItem({
     }
   };
 
-  const thumbnailUrl = extractImageUrls(post.description)[0];
+  const thumbnailUrl = extractImageUrls(post.description).filter(isSafeImageUrl)[0];
 
   return (
     <div className="flex items-center gap-3 p-4 hover:bg-gray-50 transition-colors border-b border-gray-100">

--- a/apps/web/src/app/profile/purchases/page.tsx
+++ b/apps/web/src/app/profile/purchases/page.tsx
@@ -8,6 +8,7 @@ import { useAuth } from "@/context/AuthContext";
 import {
   getMyPosts,
   extractImageUrls,
+  isSafeImageUrl,
   formatPrice,
   formatRelativeTime,
   Post,
@@ -26,7 +27,7 @@ const STATUS_FILTERS: { value: StatusFilter; label: string }[] = [
 
 // 구매 게시글 아이템 컴포넌트
 function PurchaseItem({ post }: { post: Post }) {
-  const thumbnailUrl = extractImageUrls(post.description)[0];
+  const thumbnailUrl = extractImageUrls(post.description).filter(isSafeImageUrl)[0];
 
   // 상태 배지
   const getStatusBadge = (status: string) => {

--- a/apps/web/src/app/profile/purchases/page.tsx
+++ b/apps/web/src/app/profile/purchases/page.tsx
@@ -1,0 +1,228 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Link from "next/link";
+import Image from "next/image";
+import { MobileLayout, Header } from "@/components/common";
+import { useAuth } from "@/context/AuthContext";
+import {
+  getMyPosts,
+  extractImageUrls,
+  formatPrice,
+  formatRelativeTime,
+  Post,
+} from "@/lib/postApi";
+
+// 상태 필터 타입
+type StatusFilter = "ALL" | "AVAILABLE" | "RESERVED" | "COMPLETED";
+
+// 상태 필터 옵션
+const STATUS_FILTERS: { value: StatusFilter; label: string }[] = [
+  { value: "ALL", label: "전체" },
+  { value: "AVAILABLE", label: "구매중" },
+  { value: "RESERVED", label: "예약중" },
+  { value: "COMPLETED", label: "거래완료" },
+];
+
+// 구매 게시글 아이템 컴포넌트
+function PurchaseItem({ post }: { post: Post }) {
+  const thumbnailUrl = extractImageUrls(post.description)[0];
+
+  // 상태 배지
+  const getStatusBadge = (status: string) => {
+    switch (status) {
+      case "AVAILABLE":
+        return (
+          <span className="px-2 py-0.5 bg-[#5BBFB3]/10 text-[#5BBFB3] text-xs rounded-full">
+            구매중
+          </span>
+        );
+      case "RESERVED":
+        return (
+          <span className="px-2 py-0.5 bg-yellow-100 text-yellow-700 text-xs rounded-full">
+            예약중
+          </span>
+        );
+      case "COMPLETED":
+        return (
+          <span className="px-2 py-0.5 bg-gray-200 text-gray-600 text-xs rounded-full">
+            거래완료
+          </span>
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <Link
+      href={`/post/${post.id}`}
+      className="flex items-center gap-3 p-4 hover:bg-gray-50 transition-colors border-b border-gray-100"
+    >
+      {/* 썸네일 */}
+      {thumbnailUrl ? (
+        <img
+          src={thumbnailUrl}
+          alt={post.itemName}
+          className="w-20 h-20 rounded-lg object-cover bg-gray-100 flex-shrink-0"
+        />
+      ) : (
+        <Image
+          src={process.env.NEXT_PUBLIC_ICON_ISLAND || "/icons/island.png"}
+          alt={post.itemName}
+          width={80}
+          height={80}
+          className="w-20 h-20 rounded-lg object-cover bg-gray-100 flex-shrink-0"
+        />
+      )}
+
+      {/* 게시글 정보 */}
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          {getStatusBadge(post.status)}
+          <span className="text-sm text-gray-400">{post.categoryName}</span>
+        </div>
+        <h3 className="font-medium text-gray-900 truncate mt-1">{post.itemName}</h3>
+        <p className="text-primary font-semibold mt-1">
+          {formatPrice(post.price, post.currencyType)}
+        </p>
+        <p className="text-xs text-gray-400 mt-0.5">
+          {formatRelativeTime(post.bumpedAt || post.createdAt)}
+        </p>
+      </div>
+    </Link>
+  );
+}
+
+// 구매내역 페이지
+export default function PurchasesPage() {
+  const { isAuthenticated } = useAuth();
+  const [posts, setPosts] = useState<Post[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("ALL");
+
+  // 내 구매 게시글 불러오기
+  useEffect(() => {
+    async function fetchPurchasePosts() {
+      if (!isAuthenticated) {
+        setLoading(false);
+        return;
+      }
+
+      try {
+        const response = await getMyPosts(0, 100);
+        // postType === 'BUY'인 게시글만 필터링
+        const purchasePosts = response.posts.filter((post) => post.postType === "BUY");
+        setPosts(purchasePosts);
+      } catch (err) {
+        console.error("구매내역 조회 실패:", err);
+        setError("구매내역을 불러오는데 실패했습니다.");
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    fetchPurchasePosts();
+  }, [isAuthenticated]);
+
+  // 상태 필터 적용
+  const filteredPosts = statusFilter === "ALL"
+    ? posts
+    : posts.filter((post) => post.status === statusFilter);
+
+  // 로그인 필요
+  if (!isAuthenticated) {
+    return (
+      <MobileLayout>
+        <Header title="구매내역" showBack onBack={() => window.history.back()} />
+        <div className="flex flex-col items-center justify-center py-20 text-gray-400">
+          <Image
+            src={process.env.NEXT_PUBLIC_ICON_ISLAND || "/icons/island.png"}
+            alt="로그인 필요"
+            width={120}
+            height={120}
+            className="mb-4 opacity-50"
+          />
+          <p>로그인이 필요한 서비스입니다</p>
+          <Link
+            href="/login"
+            className="mt-4 px-6 py-2 bg-primary text-white rounded-full text-sm"
+          >
+            로그인하기
+          </Link>
+        </div>
+      </MobileLayout>
+    );
+  }
+
+  return (
+    <MobileLayout>
+      <Header title="구매내역" showBack onBack={() => window.history.back()} />
+
+      {/* 상태 필터 탭 */}
+      <div className="flex border-b border-gray-100 px-4">
+        {STATUS_FILTERS.map((filter) => (
+          <button
+            key={filter.value}
+            onClick={() => setStatusFilter(filter.value)}
+            className={`flex-1 py-3 text-sm font-medium transition-colors ${
+              statusFilter === filter.value
+                ? "text-primary border-b-2 border-primary"
+                : "text-gray-400"
+            }`}
+          >
+            {filter.label}
+          </button>
+        ))}
+      </div>
+
+      {/* 로딩 상태 */}
+      {loading && (
+        <div className="flex items-center justify-center py-20">
+          <div className="w-8 h-8 border-4 border-primary border-t-transparent rounded-full animate-spin" />
+        </div>
+      )}
+
+      {/* 에러 상태 */}
+      {error && (
+        <div className="flex flex-col items-center justify-center py-20 text-gray-400">
+          <p>{error}</p>
+        </div>
+      )}
+
+      {/* 게시글 목록 */}
+      {!loading && !error && filteredPosts.length > 0 && (
+        <div>
+          <div className="px-4 py-2 bg-gray-50 text-gray-500 text-sm">
+            총 {filteredPosts.length}개
+          </div>
+          {filteredPosts.map((post) => (
+            <PurchaseItem key={post.id} post={post} />
+          ))}
+        </div>
+      )}
+
+      {/* 빈 상태 */}
+      {!loading && !error && filteredPosts.length === 0 && (
+        <div className="flex flex-col items-center justify-center py-20 text-gray-400">
+          <Image
+            src={process.env.NEXT_PUBLIC_ICON_ISLAND || "/icons/island.png"}
+            alt="빈 구매내역"
+            width={120}
+            height={120}
+            className="mb-4 opacity-50"
+          />
+          <p className="text-lg">아직 구매 게시글이 없어요</p>
+          <p className="text-sm mt-1">필요한 물품을 구해보세요!</p>
+          <Link
+            href="/post/new"
+            className="mt-4 px-6 py-2 bg-primary text-white rounded-full text-sm"
+          >
+            글쓰기
+          </Link>
+        </div>
+      )}
+    </MobileLayout>
+  );
+}

--- a/apps/web/src/app/profile/purchases/page.tsx
+++ b/apps/web/src/app/profile/purchases/page.tsx
@@ -25,35 +25,35 @@ const STATUS_FILTERS: { value: StatusFilter; label: string }[] = [
   { value: "COMPLETED", label: "거래완료" },
 ];
 
+// 상태 배지 (컴포넌트 외부 - 매 렌더링마다 재생성 방지)
+function getStatusBadge(status: string) {
+  switch (status) {
+    case "AVAILABLE":
+      return (
+        <span className="px-2 py-0.5 bg-[#5BBFB3]/10 text-[#5BBFB3] text-xs rounded-full">
+          구매중
+        </span>
+      );
+    case "RESERVED":
+      return (
+        <span className="px-2 py-0.5 bg-yellow-100 text-yellow-700 text-xs rounded-full">
+          예약중
+        </span>
+      );
+    case "COMPLETED":
+      return (
+        <span className="px-2 py-0.5 bg-gray-200 text-gray-600 text-xs rounded-full">
+          거래완료
+        </span>
+      );
+    default:
+      return null;
+  }
+}
+
 // 구매 게시글 아이템 컴포넌트
 function PurchaseItem({ post }: { post: Post }) {
   const thumbnailUrl = extractImageUrls(post.description).filter(isSafeImageUrl)[0];
-
-  // 상태 배지
-  const getStatusBadge = (status: string) => {
-    switch (status) {
-      case "AVAILABLE":
-        return (
-          <span className="px-2 py-0.5 bg-[#5BBFB3]/10 text-[#5BBFB3] text-xs rounded-full">
-            구매중
-          </span>
-        );
-      case "RESERVED":
-        return (
-          <span className="px-2 py-0.5 bg-yellow-100 text-yellow-700 text-xs rounded-full">
-            예약중
-          </span>
-        );
-      case "COMPLETED":
-        return (
-          <span className="px-2 py-0.5 bg-gray-200 text-gray-600 text-xs rounded-full">
-            거래완료
-          </span>
-        );
-      default:
-        return null;
-    }
-  };
 
   return (
     <Link
@@ -105,6 +105,8 @@ export default function PurchasesPage() {
 
   // 내 구매 게시글 불러오기
   useEffect(() => {
+    let cancelled = false;
+
     async function fetchPurchasePosts() {
       if (!isAuthenticated) {
         setLoading(false);
@@ -113,18 +115,21 @@ export default function PurchasesPage() {
 
       try {
         const response = await getMyPosts(0, 100);
+        if (cancelled) return;
         // postType === 'BUY'인 게시글만 필터링
         const purchasePosts = response.posts.filter((post) => post.postType === "BUY");
         setPosts(purchasePosts);
       } catch (err) {
+        if (cancelled) return;
         console.error("구매내역 조회 실패:", err);
         setError("구매내역을 불러오는데 실패했습니다.");
       } finally {
-        setLoading(false);
+        if (!cancelled) setLoading(false);
       }
     }
 
     fetchPurchasePosts();
+    return () => { cancelled = true; };
   }, [isAuthenticated]);
 
   // 상태 필터 적용
@@ -178,22 +183,16 @@ export default function PurchasesPage() {
         ))}
       </div>
 
-      {/* 로딩 상태 */}
-      {loading && (
+      {/* 컨텐츠 영역 - early return 패턴으로 상태별 배타적 렌더링 */}
+      {loading ? (
         <div className="flex items-center justify-center py-20">
           <div className="w-8 h-8 border-4 border-primary border-t-transparent rounded-full animate-spin" />
         </div>
-      )}
-
-      {/* 에러 상태 */}
-      {error && (
+      ) : error ? (
         <div className="flex flex-col items-center justify-center py-20 text-gray-400">
           <p>{error}</p>
         </div>
-      )}
-
-      {/* 게시글 목록 */}
-      {!loading && !error && filteredPosts.length > 0 && (
+      ) : filteredPosts.length > 0 ? (
         <div>
           <div className="px-4 py-2 bg-gray-50 text-gray-500 text-sm">
             총 {filteredPosts.length}개
@@ -202,10 +201,7 @@ export default function PurchasesPage() {
             <PurchaseItem key={post.id} post={post} />
           ))}
         </div>
-      )}
-
-      {/* 빈 상태 */}
-      {!loading && !error && filteredPosts.length === 0 && (
+      ) : (
         <div className="flex flex-col items-center justify-center py-20 text-gray-400">
           <Image
             src={process.env.NEXT_PUBLIC_ICON_ISLAND || "/icons/island.png"}

--- a/apps/web/src/app/profile/sales/page.tsx
+++ b/apps/web/src/app/profile/sales/page.tsx
@@ -10,7 +10,6 @@ import {
   extractImageUrls,
   formatPrice,
   formatRelativeTime,
-  getStatusLabel,
   Post,
 } from "@/lib/postApi";
 

--- a/apps/web/src/app/profile/sales/page.tsx
+++ b/apps/web/src/app/profile/sales/page.tsx
@@ -8,6 +8,7 @@ import { useAuth } from "@/context/AuthContext";
 import {
   getMyPosts,
   extractImageUrls,
+  isSafeImageUrl,
   formatPrice,
   formatRelativeTime,
   Post,
@@ -26,7 +27,7 @@ const STATUS_FILTERS: { value: StatusFilter; label: string }[] = [
 
 // 판매 게시글 아이템 컴포넌트
 function SalesItem({ post }: { post: Post }) {
-  const thumbnailUrl = extractImageUrls(post.description)[0];
+  const thumbnailUrl = extractImageUrls(post.description).filter(isSafeImageUrl)[0];
 
   // 상태 배지
   const getStatusBadge = (status: string) => {

--- a/apps/web/src/app/profile/sales/page.tsx
+++ b/apps/web/src/app/profile/sales/page.tsx
@@ -25,35 +25,35 @@ const STATUS_FILTERS: { value: StatusFilter; label: string }[] = [
   { value: "COMPLETED", label: "거래완료" },
 ];
 
+// 상태 배지 (컴포넌트 외부 - 매 렌더링마다 재생성 방지)
+function getStatusBadge(status: string) {
+  switch (status) {
+    case "AVAILABLE":
+      return (
+        <span className="px-2 py-0.5 bg-primary/10 text-primary text-xs rounded-full">
+          판매중
+        </span>
+      );
+    case "RESERVED":
+      return (
+        <span className="px-2 py-0.5 bg-yellow-100 text-yellow-700 text-xs rounded-full">
+          예약중
+        </span>
+      );
+    case "COMPLETED":
+      return (
+        <span className="px-2 py-0.5 bg-gray-200 text-gray-600 text-xs rounded-full">
+          거래완료
+        </span>
+      );
+    default:
+      return null;
+  }
+}
+
 // 판매 게시글 아이템 컴포넌트
 function SalesItem({ post }: { post: Post }) {
   const thumbnailUrl = extractImageUrls(post.description).filter(isSafeImageUrl)[0];
-
-  // 상태 배지
-  const getStatusBadge = (status: string) => {
-    switch (status) {
-      case "AVAILABLE":
-        return (
-          <span className="px-2 py-0.5 bg-primary/10 text-primary text-xs rounded-full">
-            판매중
-          </span>
-        );
-      case "RESERVED":
-        return (
-          <span className="px-2 py-0.5 bg-yellow-100 text-yellow-700 text-xs rounded-full">
-            예약중
-          </span>
-        );
-      case "COMPLETED":
-        return (
-          <span className="px-2 py-0.5 bg-gray-200 text-gray-600 text-xs rounded-full">
-            거래완료
-          </span>
-        );
-      default:
-        return null;
-    }
-  };
 
   return (
     <Link
@@ -105,6 +105,8 @@ export default function SalesPage() {
 
   // 내 판매 게시글 불러오기
   useEffect(() => {
+    let cancelled = false;
+
     async function fetchSalesPosts() {
       if (!isAuthenticated) {
         setLoading(false);
@@ -113,18 +115,21 @@ export default function SalesPage() {
 
       try {
         const response = await getMyPosts(0, 100);
+        if (cancelled) return;
         // postType === 'SELL'인 게시글만 필터링
         const salesPosts = response.posts.filter((post) => post.postType === "SELL");
         setPosts(salesPosts);
       } catch (err) {
+        if (cancelled) return;
         console.error("판매내역 조회 실패:", err);
         setError("판매내역을 불러오는데 실패했습니다.");
       } finally {
-        setLoading(false);
+        if (!cancelled) setLoading(false);
       }
     }
 
     fetchSalesPosts();
+    return () => { cancelled = true; };
   }, [isAuthenticated]);
 
   // 상태 필터 적용
@@ -178,22 +183,16 @@ export default function SalesPage() {
         ))}
       </div>
 
-      {/* 로딩 상태 */}
-      {loading && (
+      {/* 컨텐츠 영역 - early return 패턴으로 상태별 배타적 렌더링 */}
+      {loading ? (
         <div className="flex items-center justify-center py-20">
           <div className="w-8 h-8 border-4 border-primary border-t-transparent rounded-full animate-spin" />
         </div>
-      )}
-
-      {/* 에러 상태 */}
-      {error && (
+      ) : error ? (
         <div className="flex flex-col items-center justify-center py-20 text-gray-400">
           <p>{error}</p>
         </div>
-      )}
-
-      {/* 게시글 목록 */}
-      {!loading && !error && filteredPosts.length > 0 && (
+      ) : filteredPosts.length > 0 ? (
         <div>
           <div className="px-4 py-2 bg-gray-50 text-gray-500 text-sm">
             총 {filteredPosts.length}개
@@ -202,10 +201,7 @@ export default function SalesPage() {
             <SalesItem key={post.id} post={post} />
           ))}
         </div>
-      )}
-
-      {/* 빈 상태 */}
-      {!loading && !error && filteredPosts.length === 0 && (
+      ) : (
         <div className="flex flex-col items-center justify-center py-20 text-gray-400">
           <Image
             src={process.env.NEXT_PUBLIC_ICON_ISLAND || "/icons/island.png"}

--- a/apps/web/src/app/profile/sales/page.tsx
+++ b/apps/web/src/app/profile/sales/page.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Link from "next/link";
+import Image from "next/image";
+import { MobileLayout, Header } from "@/components/common";
+import { useAuth } from "@/context/AuthContext";
+import {
+  getMyPosts,
+  extractImageUrls,
+  formatPrice,
+  formatRelativeTime,
+  getStatusLabel,
+  Post,
+} from "@/lib/postApi";
+
+// 상태 필터 타입
+type StatusFilter = "ALL" | "AVAILABLE" | "RESERVED" | "COMPLETED";
+
+// 상태 필터 옵션
+const STATUS_FILTERS: { value: StatusFilter; label: string }[] = [
+  { value: "ALL", label: "전체" },
+  { value: "AVAILABLE", label: "판매중" },
+  { value: "RESERVED", label: "예약중" },
+  { value: "COMPLETED", label: "거래완료" },
+];
+
+// 판매 게시글 아이템 컴포넌트
+function SalesItem({ post }: { post: Post }) {
+  const thumbnailUrl = extractImageUrls(post.description)[0];
+
+  // 상태 배지
+  const getStatusBadge = (status: string) => {
+    switch (status) {
+      case "AVAILABLE":
+        return (
+          <span className="px-2 py-0.5 bg-primary/10 text-primary text-xs rounded-full">
+            판매중
+          </span>
+        );
+      case "RESERVED":
+        return (
+          <span className="px-2 py-0.5 bg-yellow-100 text-yellow-700 text-xs rounded-full">
+            예약중
+          </span>
+        );
+      case "COMPLETED":
+        return (
+          <span className="px-2 py-0.5 bg-gray-200 text-gray-600 text-xs rounded-full">
+            거래완료
+          </span>
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <Link
+      href={`/post/${post.id}`}
+      className="flex items-center gap-3 p-4 hover:bg-gray-50 transition-colors border-b border-gray-100"
+    >
+      {/* 썸네일 */}
+      {thumbnailUrl ? (
+        <img
+          src={thumbnailUrl}
+          alt={post.itemName}
+          className="w-20 h-20 rounded-lg object-cover bg-gray-100 flex-shrink-0"
+        />
+      ) : (
+        <Image
+          src={process.env.NEXT_PUBLIC_ICON_ISLAND || "/icons/island.png"}
+          alt={post.itemName}
+          width={80}
+          height={80}
+          className="w-20 h-20 rounded-lg object-cover bg-gray-100 flex-shrink-0"
+        />
+      )}
+
+      {/* 게시글 정보 */}
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          {getStatusBadge(post.status)}
+          <span className="text-sm text-gray-400">{post.categoryName}</span>
+        </div>
+        <h3 className="font-medium text-gray-900 truncate mt-1">{post.itemName}</h3>
+        <p className="text-primary font-semibold mt-1">
+          {formatPrice(post.price, post.currencyType)}
+        </p>
+        <p className="text-xs text-gray-400 mt-0.5">
+          {formatRelativeTime(post.bumpedAt || post.createdAt)}
+        </p>
+      </div>
+    </Link>
+  );
+}
+
+// 판매내역 페이지
+export default function SalesPage() {
+  const { isAuthenticated } = useAuth();
+  const [posts, setPosts] = useState<Post[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("ALL");
+
+  // 내 판매 게시글 불러오기
+  useEffect(() => {
+    async function fetchSalesPosts() {
+      if (!isAuthenticated) {
+        setLoading(false);
+        return;
+      }
+
+      try {
+        const response = await getMyPosts(0, 100);
+        // postType === 'SELL'인 게시글만 필터링
+        const salesPosts = response.posts.filter((post) => post.postType === "SELL");
+        setPosts(salesPosts);
+      } catch (err) {
+        console.error("판매내역 조회 실패:", err);
+        setError("판매내역을 불러오는데 실패했습니다.");
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    fetchSalesPosts();
+  }, [isAuthenticated]);
+
+  // 상태 필터 적용
+  const filteredPosts = statusFilter === "ALL"
+    ? posts
+    : posts.filter((post) => post.status === statusFilter);
+
+  // 로그인 필요
+  if (!isAuthenticated) {
+    return (
+      <MobileLayout>
+        <Header title="판매내역" showBack onBack={() => window.history.back()} />
+        <div className="flex flex-col items-center justify-center py-20 text-gray-400">
+          <Image
+            src={process.env.NEXT_PUBLIC_ICON_ISLAND || "/icons/island.png"}
+            alt="로그인 필요"
+            width={120}
+            height={120}
+            className="mb-4 opacity-50"
+          />
+          <p>로그인이 필요한 서비스입니다</p>
+          <Link
+            href="/login"
+            className="mt-4 px-6 py-2 bg-primary text-white rounded-full text-sm"
+          >
+            로그인하기
+          </Link>
+        </div>
+      </MobileLayout>
+    );
+  }
+
+  return (
+    <MobileLayout>
+      <Header title="판매내역" showBack onBack={() => window.history.back()} />
+
+      {/* 상태 필터 탭 */}
+      <div className="flex border-b border-gray-100 px-4">
+        {STATUS_FILTERS.map((filter) => (
+          <button
+            key={filter.value}
+            onClick={() => setStatusFilter(filter.value)}
+            className={`flex-1 py-3 text-sm font-medium transition-colors ${
+              statusFilter === filter.value
+                ? "text-primary border-b-2 border-primary"
+                : "text-gray-400"
+            }`}
+          >
+            {filter.label}
+          </button>
+        ))}
+      </div>
+
+      {/* 로딩 상태 */}
+      {loading && (
+        <div className="flex items-center justify-center py-20">
+          <div className="w-8 h-8 border-4 border-primary border-t-transparent rounded-full animate-spin" />
+        </div>
+      )}
+
+      {/* 에러 상태 */}
+      {error && (
+        <div className="flex flex-col items-center justify-center py-20 text-gray-400">
+          <p>{error}</p>
+        </div>
+      )}
+
+      {/* 게시글 목록 */}
+      {!loading && !error && filteredPosts.length > 0 && (
+        <div>
+          <div className="px-4 py-2 bg-gray-50 text-gray-500 text-sm">
+            총 {filteredPosts.length}개
+          </div>
+          {filteredPosts.map((post) => (
+            <SalesItem key={post.id} post={post} />
+          ))}
+        </div>
+      )}
+
+      {/* 빈 상태 */}
+      {!loading && !error && filteredPosts.length === 0 && (
+        <div className="flex flex-col items-center justify-center py-20 text-gray-400">
+          <Image
+            src={process.env.NEXT_PUBLIC_ICON_ISLAND || "/icons/island.png"}
+            alt="빈 판매내역"
+            width={120}
+            height={120}
+            className="mb-4 opacity-50"
+          />
+          <p className="text-lg">아직 판매 게시글이 없어요</p>
+          <p className="text-sm mt-1">물품을 등록해보세요!</p>
+          <Link
+            href="/post/new"
+            className="mt-4 px-6 py-2 bg-primary text-white rounded-full text-sm"
+          >
+            글쓰기
+          </Link>
+        </div>
+      )}
+    </MobileLayout>
+  );
+}

--- a/apps/web/src/lib/postApi.ts
+++ b/apps/web/src/lib/postApi.ts
@@ -710,7 +710,7 @@ export function formatPrice(price: number | null, currencyType: string | null): 
 
   switch (currencyType) {
     case 'BELL':
-      return `${formattedPrice}벨`;
+      return `${formattedPrice}덩`;
     case 'MILE_TICKET':
       return `${formattedPrice}마일`;
     default:

--- a/apps/web/src/lib/postApi.ts
+++ b/apps/web/src/lib/postApi.ts
@@ -693,6 +693,19 @@ export function extractImageUrls(description: string | null | undefined): string
 }
 
 /**
+ * 이미지 URL이 안전한 프로토콜(http/https)인지 검증
+ * javascript:, data: 등 위험한 프로토콜 차단
+ */
+export function isSafeImageUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return ["https:", "http:"].includes(parsed.protocol);
+  } catch {
+    return false;
+  }
+}
+
+/**
  * description에서 [images:...] 패턴을 제거한 텍스트 반환
  */
 export function stripImagePattern(description: string | null | undefined): string {


### PR DESCRIPTION
## Summary
- CodeRabbit 리뷰 반영: 이미지 URL 새니타이제이션, WebSocket onDisconnect 중복 호출 방지, hasDisconnected 재연결 리셋, mannerScore NaN 가드
- 가격 단위 "벨" → "덩"으로 변경 (formatPrice 중앙 함수 및 각 입력 폼)
- 판매내역/구매내역 페이지 신규 생성 (/profile/sales, /profile/purchases)
- 기타 기존 커밋: SockJS→네이티브 WebSocket 전환, 프로필 isProfileComplete 갱신, 닉네임 민트색, 무 점수 색상 로직 등

## Test plan
- [ ] 게시글 상세 이미지 캐러셀 정상 표시 확인
- [ ] 채팅 WebSocket 연결/재연결/끊김 동작 확인
- [ ] /profile/sales 접속 시 내 판매 게시글 목록 표시 확인
- [ ] /profile/purchases 접속 시 내 구매 게시글 목록 표시 확인
- [ ] 가격 표시 단위가 "덩"으로 통일 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사용자 판매 내역 페이지 추가
  * 사용자 구매 내역 페이지 추가
  * 판매/구매 목록에 상태 필터 추가(전체, 이용 가능, 예약됨, 완료)

* **스타일**
  * 앱 전반의 BELL 화폐 단위 표기를 "벨"에서 "덩"으로 변경
<!-- end of auto-generated comment: release notes by coderabbit.ai -->