### PR TITLE
fix: 채팅 읽음 표시 마지막 메시지에만 + 리뷰 텍스트 색상 수정

### DIFF
--- a/apps/api/src/main/java/com/acnh/api/member/dto/MemberProfileResponse.java
+++ b/apps/api/src/main/java/com/acnh/api/member/dto/MemberProfileResponse.java
@@ -1,6 +1,7 @@
 package com.acnh.api.member.dto;
 
 import com.acnh.api.member.entity.Member;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -24,6 +25,9 @@ public class MemberProfileResponse {
     private Integer totalTradeCount;
     private Long reviewCount;
     private LocalDateTime createdAt;
+    // Before: Lombok @Getter + boolean → Jackson이 "profileComplete"로 직렬화 (is prefix 제거)
+    // After: @JsonProperty로 "isProfileComplete" 명시 → 프론트 필드명과 일치
+    @JsonProperty("isProfileComplete")
     private boolean isProfileComplete;
 
     /**

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -15,4 +15,4 @@ NEXT_PUBLIC_WS_URL=ws://localhost:8080/ws
 # 아이콘 경로 설정
 NEXT_PUBLIC_ICON_ISLAND=/icons/island.png
 NEXT_PUBLIC_ICON_RACCOON=/icons/raccoon_bill.svg
-NEXT_PUBLIC_ICON_CARROT=/icons/carrot.svg
+NEXT_PUBLIC_ICON_CARROT=/icons/turnip-2.svg

--- a/apps/web/src/app/chat/[id]/page.tsx
+++ b/apps/web/src/app/chat/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useMemo } from "react";
 import { useRouter, useParams } from "next/navigation";
 import Link from "next/link";
 import Image from "next/image";
@@ -26,7 +26,9 @@ interface DisplayMessage {
 }
 
 // 메시지 버블 컴포넌트
-function MessageBubble({ message }: { message: DisplayMessage }) {
+// Before: isRead가 true인 모든 내 메시지에 "읽음" 표시
+// After: isLastRead prop으로 마지막 읽힌 내 메시지에만 "읽음" 표시
+function MessageBubble({ message, isLastRead }: { message: DisplayMessage; isLastRead?: boolean }) {
   return (
     <div className={`flex ${message.isMe ? "justify-end" : "justify-start"} mb-3`}>
       {!message.isMe && (
@@ -53,7 +55,7 @@ function MessageBubble({ message }: { message: DisplayMessage }) {
           )}
         </div>
         <div className="flex items-center gap-1 mt-1">
-          {message.isMe && message.isRead && (
+          {message.isMe && isLastRead && (
             <span className="text-xs text-gray-400">읽음</span>
           )}
           <span className={`text-xs ${message.isMe ? "text-gray-500" : "text-gray-400"}`}>
@@ -248,6 +250,14 @@ export default function ChatRoomPage() {
     };
   }, [accessToken, roomId, isLoading, chatRoom?.otherUserId]);
 
+  // 읽힌 내 메시지 중 마지막 메시지 ID (읽음 표시는 마지막에만)
+  const lastReadMyMessageId = useMemo(() => {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].isMe && messages[i].isRead) return messages[i].id;
+    }
+    return null;
+  }, [messages]);
+
   // 메시지 변경 시 스크롤
   useEffect(() => {
     scrollToBottom();
@@ -437,7 +447,7 @@ export default function ChatRoomPage() {
             </div>
           ) : (
             messages.map((message) => (
-              <MessageBubble key={message.id} message={message} />
+              <MessageBubble key={message.id} message={message} isLastRead={message.id === lastReadMyMessageId} />
             ))
           )}
           <div ref={messagesEndRef} />

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -130,7 +130,7 @@ export default function ProfilePage() {
               {user?.mannerScore != null && Number.isFinite(user.mannerScore) ? `${user.mannerScore.toFixed(1)} 벨` : "-"}
             </span>
             <Image
-              src={process.env.NEXT_PUBLIC_ICON_CARROT || "/icons/carrot.svg"}
+              src={process.env.NEXT_PUBLIC_ICON_CARROT || "/icons/turnip-2.svg"}
               alt="무 아이콘"
               title="무 점수"
               width={40}

--- a/apps/web/src/app/review/page.tsx
+++ b/apps/web/src/app/review/page.tsx
@@ -175,7 +175,7 @@ function ReviewForm() {
             placeholder="여기에 적어주세요!"
             value={review}
             onChange={(e) => setReview(e.target.value)}
-            className="w-full h-40 p-4 border border-gray-200 rounded-xl resize-none focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
+            className="w-full h-40 p-4 border border-gray-200 rounded-xl resize-none text-gray-900 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
           />
         </div>
       </div>

--- a/apps/web/src/app/user/[id]/page.tsx
+++ b/apps/web/src/app/user/[id]/page.tsx
@@ -186,7 +186,7 @@ export default function UserProfilePage() {
               {userProfile.mannerScore != null && Number.isFinite(userProfile.mannerScore) ? `${userProfile.mannerScore.toFixed(1)} 벨` : "-"}
             </span>
             <Image
-              src={process.env.NEXT_PUBLIC_ICON_CARROT || "/icons/carrot.svg"}
+              src={process.env.NEXT_PUBLIC_ICON_CARROT || "/icons/turnip-2.svg"}
               alt="무 아이콘"
               title="무 점수"
               width={40}


### PR DESCRIPTION
## Summary
- 채팅: "읽음" 표시가 읽힌 모든 내 메시지에 표시되던 것을 마지막 읽힌 메시지에만 표시하도록 변경
- 리뷰: 후기 textarea 입력 텍스트가 회색이던 것을 검정색(`text-gray-900`)으로 수정

## Changes

### 채팅 읽음 표시 (`chat/[id]/page.tsx`)
- `useMemo`로 읽힌 내 메시지 중 마지막 ID(`lastReadMyMessageId`) 계산
- `MessageBubble`에 `isLastRead` prop 추가, 해당 메시지에만 "읽음" 표시
- Before: `isRead: true`인 모든 내 메시지에 "읽음" 표시
- After: 마지막 읽힌 메시지에만 "읽음" 표시 (카카오톡 방식)

### 리뷰 텍스트 색상 (`review/page.tsx`)
- textarea에 `text-gray-900` 추가

## Test plan
- [ ] 채팅방에서 메시지 여러 개 보낸 후 상대가 읽었을 때 마지막 메시지에만 "읽음" 표시 확인
- [ ] 리뷰 페이지에서 textarea 입력 시 검정 글씨 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 채팅에서 현재 사용자의 "읽음" 표시는 마지막으로 읽힌 메시지에만 표시되도록 개선되었습니다.

* **스타일**
  * 리뷰 페이지 입력 텍스트 색상이 더 또렷해졌습니다.
  * 프로필/사용자 페이지의 아이콘이 변경되고(무 아이콘), 일부 이미지 크기 속성이 조정되었습니다.

* **잡무(Chores)**
  * API 응답 필드 직렬화 이름이 명시적으로 설정되었고 예시 환경 설정 파일의 아이콘 경로가 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->