### PR TITLE
feat: 채팅 거래 버튼, 무 점수 리뷰 연동, 게시글 수정/삭제

### DIFF
--- a/apps/api/src/main/java/com/acnh/api/ApiApplication.java
+++ b/apps/api/src/main/java/com/acnh/api/ApiApplication.java
@@ -2,8 +2,10 @@ package com.acnh.api;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class ApiApplication {
 
 	public static void main(String[] args) {

--- a/apps/api/src/main/java/com/acnh/api/chat/dto/ChatRoomResponse.java
+++ b/apps/api/src/main/java/com/acnh/api/chat/dto/ChatRoomResponse.java
@@ -18,6 +18,7 @@ public class ChatRoomResponse {
     private String postItemName;
     private String postImageUrl;
     private Integer postPrice;
+    private String postCurrencyType;
     private String postStatus;
 
     private Long otherUserId;
@@ -36,7 +37,7 @@ public class ChatRoomResponse {
      * Entity -> DTO 변환
      */
     public static ChatRoomResponse from(ChatRoom chatRoom, Long currentUserId,
-                                         String postItemName, String postImageUrl, Integer postPrice, String postStatus,
+                                         String postItemName, String postImageUrl, Integer postPrice, String postCurrencyType, String postStatus,
                                          String otherUserNickname, String otherUserIslandName,
                                          String lastMessage, LocalDateTime lastMessageAt,
                                          Integer unreadCount) {
@@ -51,6 +52,7 @@ public class ChatRoomResponse {
                 .postItemName(postItemName)
                 .postImageUrl(postImageUrl)
                 .postPrice(postPrice)
+                .postCurrencyType(postCurrencyType)
                 .postStatus(postStatus)
                 .otherUserId(otherUserId)
                 .otherUserNickname(otherUserNickname)

--- a/apps/api/src/main/java/com/acnh/api/chat/service/ChatService.java
+++ b/apps/api/src/main/java/com/acnh/api/chat/service/ChatService.java
@@ -484,6 +484,7 @@ public class ChatService {
         // TODO: Post에 이미지 필드 추가 시 연동 필요
         String postImageUrl = null;
         Integer postPrice = post != null ? post.getPrice() : null;
+        String postCurrencyType = post != null ? post.getCurrencyType() : null;
         String postStatus = post != null ? post.getStatus() : null;
 
         // 상대방 정보
@@ -509,7 +510,7 @@ public class ChatService {
         int unreadCount = (int) chatMessageRepository
                 .countByChatRoomIdAndSenderIdNotAndIsReadFalseAndDeletedAtIsNull(chatRoom.getId(), currentUserId);
 
-        return ChatRoomResponse.from(chatRoom, currentUserId, postItemName, postImageUrl, postPrice, postStatus,
+        return ChatRoomResponse.from(chatRoom, currentUserId, postItemName, postImageUrl, postPrice, postCurrencyType, postStatus,
                 otherNickname, otherIslandName, lastMessage, lastMessageAt, unreadCount);
     }
 
@@ -530,6 +531,7 @@ public class ChatService {
         // TODO: Post에 이미지 필드 추가 시 연동 필요
         String postImageUrl = null;
         Integer postPrice = post != null ? post.getPrice() : null;
+        String postCurrencyType = post != null ? post.getCurrencyType() : null;
         String postStatus = post != null ? post.getStatus() : null;
 
         // 상대방 정보
@@ -552,7 +554,7 @@ public class ChatService {
         // 읽지 않은 메시지 수
         int unreadCount = unreadCountMap.getOrDefault(chatRoom.getId(), 0L).intValue();
 
-        return ChatRoomResponse.from(chatRoom, currentUserId, postItemName, postImageUrl, postPrice, postStatus,
+        return ChatRoomResponse.from(chatRoom, currentUserId, postItemName, postImageUrl, postPrice, postCurrencyType, postStatus,
                 otherNickname, otherIslandName, lastMessage, lastMessageAt, unreadCount);
     }
 }

--- a/apps/api/src/main/java/com/acnh/api/member/entity/MannerScorePending.java
+++ b/apps/api/src/main/java/com/acnh/api/member/entity/MannerScorePending.java
@@ -1,0 +1,63 @@
+package com.acnh.api.member.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 무 점수 지연 적용 Entity
+ * - 리뷰 수신 시 점수 변동을 3일 후 적용하기 위한 대기 테이블
+ * - 상대방이 준 점수를 유추하지 못하도록 지연 적용
+ */
+@Entity
+@Table(name = "manner_score_pending")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MannerScorePending {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Column(name = "review_id", nullable = false)
+    private Long reviewId;
+
+    // 적용할 점수 변동량 (양수: 증가, 음수: 감소)
+    @Column(name = "score_delta", nullable = false)
+    private Integer scoreDelta;
+
+    // 이 시점 이후에 적용
+    @Column(name = "apply_at", nullable = false)
+    private LocalDateTime applyAt;
+
+    // 적용 완료 여부
+    @Column(name = "applied", nullable = false)
+    private Boolean applied;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public MannerScorePending(Long memberId, Long reviewId, Integer scoreDelta, LocalDateTime applyAt) {
+        this.memberId = memberId;
+        this.reviewId = reviewId;
+        this.scoreDelta = scoreDelta;
+        this.applyAt = applyAt;
+        this.applied = false;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    /**
+     * 적용 완료 처리
+     */
+    public void markApplied() {
+        this.applied = true;
+    }
+}

--- a/apps/api/src/main/java/com/acnh/api/member/repository/MannerScorePendingRepository.java
+++ b/apps/api/src/main/java/com/acnh/api/member/repository/MannerScorePendingRepository.java
@@ -1,0 +1,18 @@
+package com.acnh.api.member.repository;
+
+import com.acnh.api.member.entity.MannerScorePending;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 무 점수 지연 적용 Repository
+ */
+public interface MannerScorePendingRepository extends JpaRepository<MannerScorePending, Long> {
+
+    /**
+     * 적용 대상 조회: 적용 시점이 지났고 아직 미적용인 레코드
+     */
+    List<MannerScorePending> findByAppliedFalseAndApplyAtBefore(LocalDateTime now);
+}

--- a/apps/api/src/main/java/com/acnh/api/member/scheduler/MannerScoreScheduler.java
+++ b/apps/api/src/main/java/com/acnh/api/member/scheduler/MannerScoreScheduler.java
@@ -1,6 +1,7 @@
 package com.acnh.api.member.scheduler;
 
 import com.acnh.api.member.entity.MannerScorePending;
+import com.acnh.api.member.entity.Member;
 import com.acnh.api.member.repository.MannerScorePendingRepository;
 import com.acnh.api.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * 무 점수 지연 적용 스케줄러
@@ -26,9 +28,10 @@ public class MannerScoreScheduler {
     private final MemberRepository memberRepository;
 
     /**
-     * 1시간마다 대기 중인 무 점수 변동 적용
+     * 주기적으로 대기 중인 무 점수 변동 적용
+     * - fixedRateString: 환경변수로 주기 설정 가능 (기본값 3600000ms = 1시간)
      */
-    @Scheduled(fixedRate = 3600000)
+    @Scheduled(fixedRateString = "${manner-score.scheduler.fixed-rate:3600000}")
     @Transactional
     public void applyPendingMannerScores() {
         List<MannerScorePending> pendingList =
@@ -42,13 +45,20 @@ public class MannerScoreScheduler {
 
         int appliedCount = 0;
         for (MannerScorePending pending : pendingList) {
-            memberRepository.findById(pending.getMemberId()).ifPresent(member -> {
+            // Before: member 미발견 시 점수 적용 누락되지만 markApplied()로 무시됨 (점수 유실)
+            // After: member 미발견 시 경고 로그 출력, markApplied()는 여전히 호출 (재시도 불필요하므로)
+            Optional<Member> memberOpt = memberRepository.findById(pending.getMemberId());
+            if (memberOpt.isPresent()) {
+                Member member = memberOpt.get();
                 if (pending.getScoreDelta() >= 0) {
                     member.increaseMannerScore(pending.getScoreDelta());
                 } else {
                     member.decreaseMannerScore(Math.abs(pending.getScoreDelta()));
                 }
-            });
+            } else {
+                log.warn("무 점수 적용 대상 회원 미발견 - pendingId: {}, memberId: {}, scoreDelta: {}",
+                        pending.getId(), pending.getMemberId(), pending.getScoreDelta());
+            }
             pending.markApplied();
             appliedCount++;
         }

--- a/apps/api/src/main/java/com/acnh/api/member/scheduler/MannerScoreScheduler.java
+++ b/apps/api/src/main/java/com/acnh/api/member/scheduler/MannerScoreScheduler.java
@@ -1,0 +1,58 @@
+package com.acnh.api.member.scheduler;
+
+import com.acnh.api.member.entity.MannerScorePending;
+import com.acnh.api.member.repository.MannerScorePendingRepository;
+import com.acnh.api.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 무 점수 지연 적용 스케줄러
+ * - 리뷰 수신 시 예약된 점수 변동을 3일 후 실제 적용
+ * - 상대방이 준 점수를 유추하지 못하도록 지연 적용
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MannerScoreScheduler {
+
+    private final MannerScorePendingRepository mannerScorePendingRepository;
+    private final MemberRepository memberRepository;
+
+    /**
+     * 1시간마다 대기 중인 무 점수 변동 적용
+     */
+    @Scheduled(fixedRate = 3600000)
+    @Transactional
+    public void applyPendingMannerScores() {
+        List<MannerScorePending> pendingList =
+                mannerScorePendingRepository.findByAppliedFalseAndApplyAtBefore(LocalDateTime.now());
+
+        if (pendingList.isEmpty()) {
+            return;
+        }
+
+        log.info("무 점수 지연 적용 시작 - 대상: {}건", pendingList.size());
+
+        int appliedCount = 0;
+        for (MannerScorePending pending : pendingList) {
+            memberRepository.findById(pending.getMemberId()).ifPresent(member -> {
+                if (pending.getScoreDelta() >= 0) {
+                    member.increaseMannerScore(pending.getScoreDelta());
+                } else {
+                    member.decreaseMannerScore(Math.abs(pending.getScoreDelta()));
+                }
+            });
+            pending.markApplied();
+            appliedCount++;
+        }
+
+        log.info("무 점수 지연 적용 완료 - 적용: {}건", appliedCount);
+    }
+}

--- a/apps/api/src/main/java/com/acnh/api/review/service/ReviewService.java
+++ b/apps/api/src/main/java/com/acnh/api/review/service/ReviewService.java
@@ -50,6 +50,9 @@ public class ReviewService {
     // 무 점수 지연 적용 일수
     private static final int MANNER_SCORE_DELAY_DAYS = 3;
 
+    // 리뷰 작성 시 작성자에게 즉시 부여되는 무 점수 보너스
+    private static final int MANNER_SCORE_WRITE_BONUS = 2;
+
     /**
      * 리뷰 작성
      * - 해당 게시글에 채팅 기록이 있는 경우만 평가 가능
@@ -101,9 +104,9 @@ public class ReviewService {
         log.info("리뷰 작성 완료 - reviewId: {}, postId: {}, reviewerId: {}, revieweeId: {}",
                 savedReview.getId(), post.getId(), reviewer.getId(), reviewee.getId());
 
-        // 무 점수: 리뷰 작성자 즉시 +2
-        reviewer.increaseMannerScore(2);
-        log.info("무 점수 즉시 적용 - reviewerId: {}, +2 (리뷰 작성 보상)", reviewer.getId());
+        // 무 점수: 리뷰 작성자 즉시 보너스 적용
+        reviewer.increaseMannerScore(MANNER_SCORE_WRITE_BONUS);
+        log.info("무 점수 즉시 적용 - reviewerId: {}, +{} (리뷰 작성 보상)", reviewer.getId(), MANNER_SCORE_WRITE_BONUS);
 
         // 무 점수: 리뷰 수신자 3일 후 지연 적용
         int rating = request.getRating();

--- a/apps/api/src/main/java/com/acnh/api/review/service/ReviewService.java
+++ b/apps/api/src/main/java/com/acnh/api/review/service/ReviewService.java
@@ -4,7 +4,9 @@ import com.acnh.api.chat.repository.ChatRoomRepository;
 import com.acnh.api.common.exception.InvalidRequestException;
 import com.acnh.api.common.exception.NotFoundException;
 import com.acnh.api.filter.ProfanityFilter;
+import com.acnh.api.member.entity.MannerScorePending;
 import com.acnh.api.member.entity.Member;
+import com.acnh.api.member.repository.MannerScorePendingRepository;
 import com.acnh.api.member.repository.MemberRepository;
 import com.acnh.api.post.entity.Post;
 import com.acnh.api.post.repository.PostRepository;
@@ -21,6 +23,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -41,7 +44,11 @@ public class ReviewService {
     private final MemberRepository memberRepository;
     private final PostRepository postRepository;
     private final ChatRoomRepository chatRoomRepository;
+    private final MannerScorePendingRepository mannerScorePendingRepository;
     private final ProfanityFilter profanityFilter;
+
+    // 무 점수 지연 적용 일수
+    private static final int MANNER_SCORE_DELAY_DAYS = 3;
 
     /**
      * 리뷰 작성
@@ -93,6 +100,25 @@ public class ReviewService {
 
         log.info("리뷰 작성 완료 - reviewId: {}, postId: {}, reviewerId: {}, revieweeId: {}",
                 savedReview.getId(), post.getId(), reviewer.getId(), reviewee.getId());
+
+        // 무 점수: 리뷰 작성자 즉시 +2
+        reviewer.increaseMannerScore(2);
+        log.info("무 점수 즉시 적용 - reviewerId: {}, +2 (리뷰 작성 보상)", reviewer.getId());
+
+        // 무 점수: 리뷰 수신자 3일 후 지연 적용
+        int rating = request.getRating();
+        int scoreDelta = rating >= 3 ? rating * 2 : rating * -2;
+        if (scoreDelta != 0) {
+            MannerScorePending pending = MannerScorePending.builder()
+                    .memberId(reviewee.getId())
+                    .reviewId(savedReview.getId())
+                    .scoreDelta(scoreDelta)
+                    .applyAt(LocalDateTime.now().plusDays(MANNER_SCORE_DELAY_DAYS))
+                    .build();
+            mannerScorePendingRepository.save(pending);
+            log.info("무 점수 지연 적용 예약 - revieweeId: {}, delta: {}, applyAt: {}",
+                    reviewee.getId(), scoreDelta, pending.getApplyAt());
+        }
 
         return toReviewResponse(savedReview);
     }

--- a/apps/web/src/app/chat/[id]/page.tsx
+++ b/apps/web/src/app/chat/[id]/page.tsx
@@ -698,11 +698,17 @@ export default function ChatRoomPage() {
                 <span className="text-xs text-white font-medium">카메라</span>
               </button>
 
-              {/* 약속 */}
+              {/* 약속 - AVAILABLE 상태에서만 모달 열기 */}
               <button
                 onClick={() => {
                   setIsBottomTabOpen(false);
-                  setShowAppointmentModal(true);
+                  if (chatRoom?.postStatus === "AVAILABLE") {
+                    setShowAppointmentModal(true);
+                  } else if (chatRoom?.postStatus === "RESERVED") {
+                    alert("이미 약속이 잡혀있습니다.");
+                  } else {
+                    alert("거래가 완료된 상품입니다.");
+                  }
                 }}
                 className="flex flex-col items-center gap-1 p-3 rounded-xl hover:bg-white/20 transition-colors"
               >

--- a/apps/web/src/app/chat/[id]/page.tsx
+++ b/apps/web/src/app/chat/[id]/page.tsx
@@ -8,7 +8,7 @@ import { ChevronLeftIcon, CameraIcon, MoreVerticalIcon, FlagIcon, BlockIcon, Exi
 import { useAuth } from "@/context/AuthContext";
 import { webSocketClient, ChatMessage } from "@/lib/websocket";
 import { getChatRoom, getChatMessages, formatMessageTime, ChatRoom } from "@/lib/chatApi";
-import { blockUser, leaveChatRoom, createReport, ReportReasonCode, reserveChatRoom, unreserveChatRoom, completeChatRoom } from "@/lib/postApi";
+import { blockUser, leaveChatRoom, createReport, ReportReasonCode, reserveChatRoom, unreserveChatRoom, completeChatRoom, formatPrice } from "@/lib/postApi";
 import AppointmentModal from "@/components/chat/AppointmentModal";
 
 // 거래 상태 타입
@@ -501,7 +501,7 @@ export default function ChatRoomPage() {
                   </div>
                   {chatRoom.postPrice != null && (
                     <p className="text-sm font-semibold text-gray-900 mt-0.5">
-                      {chatRoom.postPrice.toLocaleString()}벨
+                      {formatPrice(chatRoom.postPrice, chatRoom.postCurrencyType)}
                     </p>
                   )}
                 </div>

--- a/apps/web/src/app/chat/[id]/page.tsx
+++ b/apps/web/src/app/chat/[id]/page.tsx
@@ -8,7 +8,8 @@ import { ChevronLeftIcon, CameraIcon, MoreVerticalIcon, FlagIcon, BlockIcon, Exi
 import { useAuth } from "@/context/AuthContext";
 import { webSocketClient, ChatMessage } from "@/lib/websocket";
 import { getChatRoom, getChatMessages, formatMessageTime, ChatRoom } from "@/lib/chatApi";
-import { blockUser, leaveChatRoom, createReport, ReportReasonCode } from "@/lib/postApi";
+import { blockUser, leaveChatRoom, createReport, ReportReasonCode, reserveChatRoom, unreserveChatRoom, completeChatRoom } from "@/lib/postApi";
+import AppointmentModal from "@/components/chat/AppointmentModal";
 
 // 거래 상태 타입
 type TradeStatus = "AVAILABLE" | "RESERVED" | "COMPLETED";
@@ -135,6 +136,11 @@ export default function ChatRoomPage() {
   const [reportError, setReportError] = useState<string | null>(null);
   const [isBlocking, setIsBlocking] = useState(false);
   const [isLeaving, setIsLeaving] = useState(false);
+
+  // 거래 상태 변경 관련 상태
+  const [showAppointmentModal, setShowAppointmentModal] = useState(false);
+  const [showCompleteConfirm, setShowCompleteConfirm] = useState(false);
+  const [isStatusChanging, setIsStatusChanging] = useState(false);
 
   // 신고 사유 옵션
   const REPORT_REASONS: { code: ReportReasonCode; label: string }[] = [
@@ -319,6 +325,69 @@ export default function ChatRoomPage() {
     }
   };
 
+  // 약속 잡기 (예약) 핸들러
+  const handleReserve = async (scheduledTradeAt: string) => {
+    setIsStatusChanging(true);
+    try {
+      await reserveChatRoom(roomId, scheduledTradeAt);
+      // 채팅방 정보 다시 조회하여 상태 반영
+      const updatedRoom = await getChatRoom(roomId);
+      setChatRoom(updatedRoom);
+      setShowAppointmentModal(false);
+    } catch (err) {
+      console.error("약속 잡기 실패:", err);
+      alert(err instanceof Error ? err.message : "약속 잡기에 실패했습니다");
+    } finally {
+      setIsStatusChanging(false);
+    }
+  };
+
+  // 예약 취소 핸들러
+  const handleUnreserve = async () => {
+    if (!confirm("약속을 취소하시겠습니까?")) return;
+
+    setIsStatusChanging(true);
+    try {
+      await unreserveChatRoom(roomId);
+      const updatedRoom = await getChatRoom(roomId);
+      setChatRoom(updatedRoom);
+    } catch (err) {
+      console.error("예약 취소 실패:", err);
+      alert(err instanceof Error ? err.message : "예약 취소에 실패했습니다");
+    } finally {
+      setIsStatusChanging(false);
+    }
+  };
+
+  // 거래 완료 핸들러
+  const handleComplete = async () => {
+    setIsStatusChanging(true);
+    try {
+      await completeChatRoom(roomId);
+      const updatedRoom = await getChatRoom(roomId);
+      setChatRoom(updatedRoom);
+      setShowCompleteConfirm(false);
+    } catch (err) {
+      console.error("거래 완료 실패:", err);
+      alert(err instanceof Error ? err.message : "거래 완료 처리에 실패했습니다");
+    } finally {
+      setIsStatusChanging(false);
+    }
+  };
+
+  // 약속 일시 포맷팅
+  const formatScheduledTime = (dateStr: string | null) => {
+    if (!dateStr) return "";
+    const date = new Date(dateStr);
+    const month = date.getMonth() + 1;
+    const day = date.getDate();
+    const hours = date.getHours();
+    const minutes = date.getMinutes();
+    const ampm = hours >= 12 ? "오후" : "오전";
+    const h12 = hours === 0 ? 12 : hours > 12 ? hours - 12 : hours;
+    return `${month}/${day} ${ampm} ${h12}:${String(minutes).padStart(2, "0")}`;
+  };
+
   // 신고 제출 핸들러
   const handleReportSubmit = async () => {
     if (!chatRoom || !selectedReportReason) return;
@@ -393,48 +462,113 @@ export default function ChatRoomPage() {
           </div>
         </header>
 
-        {/* 상품 정보 바 */}
+        {/* 상품 정보 바 + 거래 액션 버튼 */}
         {chatRoom && (
-          <div className="relative z-10 flex items-center gap-3 px-4 py-3 border-b border-gray-100 bg-white">
-            <Link
-              href={`/post/${chatRoom.postId}`}
-              className="flex items-center gap-3 flex-1 min-w-0 hover:opacity-80"
-            >
-              <div className="w-12 h-12 bg-gray-200 rounded-lg flex-shrink-0 overflow-hidden">
-                {chatRoom.postImageUrl ? (
-                  <Image
-                    src={chatRoom.postImageUrl}
-                    alt={chatRoom.postItemName}
-                    width={48}
-                    height={48}
-                    className="w-full h-full object-cover"
-                  />
-                ) : (
-                  <div className="w-full h-full flex items-center justify-center text-2xl">
-                    📦
-                  </div>
-                )}
-              </div>
-              <div className="flex-1 min-w-0">
-                <div className="flex items-center gap-2">
-                  <span className={`text-xs px-2 py-0.5 rounded font-medium ${
-                    chatRoom.postStatus === "AVAILABLE"
-                      ? "bg-[#5BBFB3] text-white"
-                      : chatRoom.postStatus === "RESERVED"
-                      ? "bg-yellow-500 text-white"
-                      : "bg-gray-500 text-white"
-                  }`}>
-                    {getTradeStatusLabel(chatRoom.postStatus as TradeStatus)}
-                  </span>
-                  <span className="text-sm text-gray-900 truncate">{chatRoom.postItemName}</span>
+          <div className="relative z-10 border-b border-gray-100 bg-white">
+            {/* 상품 정보 */}
+            <div className="flex items-center gap-3 px-4 py-3">
+              <Link
+                href={`/post/${chatRoom.postId}`}
+                className="flex items-center gap-3 flex-1 min-w-0 hover:opacity-80"
+              >
+                <div className="w-12 h-12 bg-gray-200 rounded-lg flex-shrink-0 overflow-hidden">
+                  {chatRoom.postImageUrl ? (
+                    <Image
+                      src={chatRoom.postImageUrl}
+                      alt={chatRoom.postItemName}
+                      width={48}
+                      height={48}
+                      className="w-full h-full object-cover"
+                    />
+                  ) : (
+                    <div className="w-full h-full flex items-center justify-center text-2xl">
+                      📦
+                    </div>
+                  )}
                 </div>
-                {chatRoom.postPrice && (
-                  <p className="text-sm font-semibold text-gray-900 mt-0.5">
-                    {chatRoom.postPrice.toLocaleString()}벨
-                  </p>
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className={`text-xs px-2 py-0.5 rounded font-medium ${
+                      chatRoom.postStatus === "AVAILABLE"
+                        ? "bg-[#5BBFB3] text-white"
+                        : chatRoom.postStatus === "RESERVED"
+                        ? "bg-yellow-500 text-white"
+                        : "bg-gray-500 text-white"
+                    }`}>
+                      {getTradeStatusLabel(chatRoom.postStatus as TradeStatus)}
+                    </span>
+                    <span className="text-sm text-gray-900 truncate">{chatRoom.postItemName}</span>
+                  </div>
+                  {chatRoom.postPrice != null && (
+                    <p className="text-sm font-semibold text-gray-900 mt-0.5">
+                      {chatRoom.postPrice.toLocaleString()}벨
+                    </p>
+                  )}
+                </div>
+              </Link>
+            </div>
+
+            {/* 거래 액션 버튼 (상태별) */}
+            {chatRoom.postStatus !== "COMPLETED" && (
+              <div className="flex items-center gap-2 px-4 pb-3">
+                {/* 판매중 → 약속 잡기 */}
+                {chatRoom.postStatus === "AVAILABLE" && (
+                  <button
+                    onClick={() => setShowAppointmentModal(true)}
+                    disabled={isStatusChanging}
+                    className="flex items-center gap-1.5 px-4 py-2 border border-gray-300 rounded-full text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors disabled:opacity-50"
+                  >
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                      <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+                      <line x1="16" y1="2" x2="16" y2="6" />
+                      <line x1="8" y1="2" x2="8" y2="6" />
+                      <line x1="3" y1="10" x2="21" y2="10" />
+                    </svg>
+                    약속잡기
+                  </button>
+                )}
+
+                {/* 예약중 → 거래 완료 + 예약 취소 */}
+                {chatRoom.postStatus === "RESERVED" && (
+                  <>
+                    <button
+                      onClick={() => setShowCompleteConfirm(true)}
+                      disabled={isStatusChanging}
+                      className="flex items-center gap-1.5 px-4 py-2 bg-[#5BBFB3] text-white rounded-full text-sm font-medium hover:bg-[#4DAE9F] transition-colors disabled:opacity-50"
+                    >
+                      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                        <polyline points="20 6 9 17 4 12" />
+                      </svg>
+                      거래 완료
+                    </button>
+                    <button
+                      onClick={handleUnreserve}
+                      disabled={isStatusChanging}
+                      className="flex items-center gap-1.5 px-4 py-2 border border-gray-300 rounded-full text-sm font-medium text-gray-500 hover:bg-gray-50 transition-colors disabled:opacity-50"
+                    >
+                      예약 취소
+                    </button>
+                    {chatRoom.scheduledTradeAt && (
+                      <span className="text-xs text-gray-400 ml-auto">
+                        {formatScheduledTime(chatRoom.scheduledTradeAt)}
+                      </span>
+                    )}
+                  </>
                 )}
               </div>
-            </Link>
+            )}
+
+            {/* 거래 완료 상태 표시 */}
+            {chatRoom.postStatus === "COMPLETED" && (
+              <div className="flex items-center gap-2 px-4 pb-3">
+                <span className="flex items-center gap-1.5 px-4 py-2 bg-gray-100 rounded-full text-sm font-medium text-gray-500">
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <polyline points="20 6 9 17 4 12" />
+                  </svg>
+                  거래 완료됨
+                </span>
+              </div>
+            )}
           </div>
         )}
 
@@ -565,7 +699,13 @@ export default function ChatRoomPage() {
               </button>
 
               {/* 약속 */}
-              <button className="flex flex-col items-center gap-1 p-3 rounded-xl hover:bg-white/20 transition-colors">
+              <button
+                onClick={() => {
+                  setIsBottomTabOpen(false);
+                  setShowAppointmentModal(true);
+                }}
+                className="flex flex-col items-center gap-1 p-3 rounded-xl hover:bg-white/20 transition-colors"
+              >
                 <div className="w-12 h-12 bg-white/30 rounded-full flex items-center justify-center">
                   <svg
                     width="24"
@@ -762,6 +902,54 @@ export default function ChatRoomPage() {
                   className="w-full py-4 bg-[#5BBFB3] text-white font-semibold rounded-xl hover:bg-[#4DAE9F] transition-colors disabled:bg-gray-300 disabled:cursor-not-allowed"
                 >
                   {isSubmittingReport ? "신고 중..." : "신고하기"}
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* 약속 잡기 모달 */}
+        {showAppointmentModal && chatRoom && (
+          <AppointmentModal
+            otherUserNickname={chatRoom.otherUserNickname}
+            onConfirm={handleReserve}
+            onClose={() => setShowAppointmentModal(false)}
+            isSubmitting={isStatusChanging}
+          />
+        )}
+
+        {/* 거래 완료 확인 모달 */}
+        {showCompleteConfirm && (
+          <div
+            className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center px-8"
+            onClick={() => setShowCompleteConfirm(false)}
+          >
+            <div
+              className="w-full max-w-sm bg-white rounded-2xl overflow-hidden"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className="p-6 text-center">
+                <h3 className="text-lg font-semibold text-gray-900 mb-2">
+                  거래 완료
+                </h3>
+                <p className="text-sm text-gray-500">
+                  거래를 완료하시겠습니까?<br />
+                  완료 후에는 되돌릴 수 없습니다.
+                </p>
+              </div>
+              <div className="flex border-t border-gray-100">
+                <button
+                  onClick={() => setShowCompleteConfirm(false)}
+                  className="flex-1 py-4 text-gray-500 font-medium hover:bg-gray-50 transition-colors"
+                >
+                  취소
+                </button>
+                <button
+                  onClick={handleComplete}
+                  disabled={isStatusChanging}
+                  className="flex-1 py-4 text-[#5BBFB3] font-semibold hover:bg-gray-50 transition-colors border-l border-gray-100 disabled:opacity-50"
+                >
+                  {isStatusChanging ? "처리 중..." : "완료"}
                 </button>
               </div>
             </div>

--- a/apps/web/src/app/post/[id]/page.tsx
+++ b/apps/web/src/app/post/[id]/page.tsx
@@ -19,8 +19,10 @@ import {
   PriceOfferCreateRequest,
   blockUser,
   createReport,
+  deletePost,
   ReportReasonCode,
 } from "@/lib/postApi";
+import { useAuth } from "@/context/AuthContext";
 import { addRecentViewedPost } from "@/lib/recentPosts";
 import { getMannerScoreColor } from "@/lib/mannerScore";
 
@@ -39,6 +41,7 @@ const REPORT_REASONS: { code: ReportReasonCode; label: string }[] = [
 export default function PostDetailPage() {
   const params = useParams();
   const router = useRouter();
+  const { user } = useAuth();
   // params.id가 string[] 일 수 있으므로 안전하게 처리
   const postId = Array.isArray(params.id) ? params.id[0] : params.id;
 
@@ -67,6 +70,11 @@ export default function PostDetailPage() {
   const [reportError, setReportError] = useState<string | null>(null);
   // 차단하기 상태
   const [isBlocking, setIsBlocking] = useState(false);
+  // 삭제하기 상태
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  // 내 글 여부 판별
+  const isMyPost = !!(user && post && user.id === post.userUuid);
 
   // API에서 게시글 데이터 로드
   useEffect(() => {
@@ -169,6 +177,25 @@ export default function PostDetailPage() {
       alert(err instanceof Error ? err.message : "차단에 실패했습니다");
     } finally {
       setIsBlocking(false);
+    }
+  };
+
+  // 게시글 삭제 핸들러
+  const handleDeletePost = async () => {
+    if (!post) return;
+    if (!confirm("정말 삭제하시겠습니까? 삭제 후에는 되돌릴 수 없습니다.")) return;
+
+    setIsDeleting(true);
+    try {
+      await deletePost(post.id);
+      setShowMoreMenu(false);
+      alert("게시글이 삭제되었습니다.");
+      router.push("/");
+    } catch (err) {
+      console.error("삭제 실패:", err);
+      alert(err instanceof Error ? err.message : "삭제에 실패했습니다");
+    } finally {
+      setIsDeleting(false);
     }
   };
 
@@ -552,29 +579,62 @@ export default function PostDetailPage() {
               <div className="w-10 h-1 bg-gray-300 rounded-full" />
             </div>
 
-            {/* 메뉴 아이템들 */}
+            {/* 메뉴 아이템들 - 내 글/남의 글 분기 */}
             <div className="pb-6">
-              <button
-                onClick={() => {
-                  setShowMoreMenu(false);
-                  handleBlockUser();
-                }}
-                disabled={isBlocking}
-                className="flex items-center gap-3 w-full px-6 py-4 hover:bg-gray-50 transition-colors disabled:opacity-50"
-              >
-                <BlockIcon className="w-5 h-5 text-gray-600" />
-                <span className="text-gray-800">이 사용자의 글 보지 않기</span>
-              </button>
-              <button
-                onClick={() => {
-                  setShowMoreMenu(false);
-                  setShowReportModal(true);
-                }}
-                className="flex items-center gap-3 w-full px-6 py-4 hover:bg-gray-50 transition-colors"
-              >
-                <FlagIcon className="w-5 h-5 text-gray-600" />
-                <span className="text-gray-800">신고하기</span>
-              </button>
+              {isMyPost ? (
+                <>
+                  {/* 내 글: 수정하기, 삭제하기 */}
+                  <button
+                    onClick={() => {
+                      setShowMoreMenu(false);
+                      router.push(`/post/new?editId=${post.id}`);
+                    }}
+                    className="flex items-center gap-3 w-full px-6 py-4 hover:bg-gray-50 transition-colors"
+                  >
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-gray-600">
+                      <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+                      <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+                    </svg>
+                    <span className="text-gray-800">수정하기</span>
+                  </button>
+                  <button
+                    onClick={handleDeletePost}
+                    disabled={isDeleting}
+                    className="flex items-center gap-3 w-full px-6 py-4 hover:bg-gray-50 transition-colors disabled:opacity-50"
+                  >
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-red-500">
+                      <polyline points="3 6 5 6 21 6" />
+                      <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+                    </svg>
+                    <span className="text-red-500">{isDeleting ? "삭제 중..." : "삭제하기"}</span>
+                  </button>
+                </>
+              ) : (
+                <>
+                  {/* 남의 글: 차단, 신고 */}
+                  <button
+                    onClick={() => {
+                      setShowMoreMenu(false);
+                      handleBlockUser();
+                    }}
+                    disabled={isBlocking}
+                    className="flex items-center gap-3 w-full px-6 py-4 hover:bg-gray-50 transition-colors disabled:opacity-50"
+                  >
+                    <BlockIcon className="w-5 h-5 text-gray-600" />
+                    <span className="text-gray-800">이 사용자의 글 보지 않기</span>
+                  </button>
+                  <button
+                    onClick={() => {
+                      setShowMoreMenu(false);
+                      setShowReportModal(true);
+                    }}
+                    className="flex items-center gap-3 w-full px-6 py-4 hover:bg-gray-50 transition-colors"
+                  >
+                    <FlagIcon className="w-5 h-5 text-gray-600" />
+                    <span className="text-gray-800">신고하기</span>
+                  </button>
+                </>
+              )}
             </div>
 
             {/* 취소 버튼 */}

--- a/apps/web/src/app/post/new/page.tsx
+++ b/apps/web/src/app/post/new/page.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
-import { useRouter } from "next/navigation";
+import { Suspense, useState, useEffect, useRef } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { HomeOutlineIcon, PlusIcon } from "@/components/icons";
-import { createPost, getCategories, uploadPostImages, Category, PostCreateRequest } from "@/lib/postApi";
+import { createPost, getPost, updatePost, getCategories, uploadPostImages, extractImageUrls, stripImagePattern, Category, PostCreateRequest, PostUpdateRequest } from "@/lib/postApi";
 
 // 게시글 이미지 최대 업로드 수 (환경변수 또는 기본값 3)
 const MAX_POST_IMAGES = Number(process.env.NEXT_PUBLIC_MAX_POST_IMAGES) || 3;
@@ -15,9 +15,25 @@ interface ImagePreview {
   previewUrl: string;
 }
 
-// 상품 등록 페이지 - Figma 디자인 기반
+// Suspense boundary로 감싸는 래퍼 (useSearchParams 필요)
 export default function NewPostPage() {
+  return (
+    <Suspense fallback={
+      <div className="min-h-screen bg-white flex items-center justify-center">
+        <div className="animate-spin rounded-full h-8 w-8 border-2 border-primary border-t-transparent" />
+      </div>
+    }>
+      <NewPostContent />
+    </Suspense>
+  );
+}
+
+// 상품 등록/수정 페이지
+function NewPostContent() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const editId = searchParams.get("editId");
+  const isEditMode = !!editId;
 
   // 폼 상태
   const [postType, setPostType] = useState<"SELL" | "BUY">("SELL");
@@ -28,6 +44,7 @@ export default function NewPostPage() {
   const [currencyType, setCurrencyType] = useState<"BELL" | "MILE_TICKET">("BELL");
   const [priceNegotiable, setPriceNegotiable] = useState(false);
   const [images, setImages] = useState<ImagePreview[]>([]);
+  const [existingImageUrls, setExistingImageUrls] = useState<string[]>([]);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const imagesRef = useRef<ImagePreview[]>([]);
 
@@ -52,8 +69,8 @@ export default function NewPostPage() {
       try {
         const response = await getCategories();
         setCategories(response.categories);
-        // 첫 번째 카테고리를 기본 선택
-        if (response.categories.length > 0) {
+        // 수정 모드가 아닐 때만 첫 번째 카테고리 기본 선택
+        if (!isEditMode && response.categories.length > 0) {
           setCategoryId(response.categories[0].id);
         }
       } catch (err) {
@@ -61,11 +78,38 @@ export default function NewPostPage() {
       }
     }
     loadCategories();
-  }, []);
+  }, [isEditMode]);
+
+  // 수정 모드: 기존 게시글 데이터 로드
+  useEffect(() => {
+    if (!editId) return;
+    async function loadPostData() {
+      try {
+        const postData = await getPost(parseInt(editId!, 10));
+        setPostType(postData.postType);
+        setCategoryId(postData.categoryId);
+        setItemName(postData.itemName);
+        // description에서 이미지 패턴 제거하여 순수 텍스트만 표시
+        setDescription(stripImagePattern(postData.description));
+        if (postData.price != null) setPrice(String(postData.price));
+        if (postData.currencyType) setCurrencyType(postData.currencyType);
+        if (postData.priceNegotiable != null) setPriceNegotiable(postData.priceNegotiable);
+        // 기존 이미지 URL은 수정 시 유지 (새 이미지 업로드로 교체 가능)
+        const existingImageUrls = extractImageUrls(postData.description);
+        if (existingImageUrls.length > 0) {
+          setExistingImageUrls(existingImageUrls);
+        }
+      } catch (err) {
+        console.error("게시글 로드 실패:", err);
+        setError("게시글을 불러오는데 실패했습니다");
+      }
+    }
+    loadPostData();
+  }, [editId]);
 
   // 이미지 파일 선택 핸들러
   const handleImageAdd = () => {
-    if (images.length >= MAX_POST_IMAGES) return;
+    if ((existingImageUrls.length + images.length) >= MAX_POST_IMAGES) return;
     fileInputRef.current?.click();
   };
 
@@ -75,7 +119,7 @@ export default function NewPostPage() {
     if (!files) return;
 
     const newImages: ImagePreview[] = [];
-    const remainingSlots = MAX_POST_IMAGES - images.length;
+    const remainingSlots = MAX_POST_IMAGES - existingImageUrls.length - images.length;
 
     for (let i = 0; i < Math.min(files.length, remainingSlots); i++) {
       const file = files[i];
@@ -118,35 +162,51 @@ export default function NewPostPage() {
     setError(null);
 
     try {
-      // 1. 이미지가 있으면 먼저 업로드
-      let imageUrls: string[] = [];
+      // 1. 새 이미지가 있으면 업로드
+      let newImageUrls: string[] = [];
       if (images.length > 0) {
         const files = images.map((img) => img.file);
         const uploadResult = await uploadPostImages(files);
-        imageUrls = uploadResult.urls;
+        newImageUrls = uploadResult.urls;
       }
 
-      // 2. 게시글 생성 (이미지 URL을 설명에 포함)
-      // TODO: 백엔드 Post 엔티티에 imageUrls 필드 추가 후 별도 전달
-      const descriptionWithImages = imageUrls.length > 0
-        ? `${description.trim()}\n\n[images:${imageUrls.join(",")}]`
+      // 2. 최종 이미지 URL 목록 (기존 + 새로 업로드)
+      const allImageUrls = [...existingImageUrls, ...newImageUrls];
+
+      // 3. 이미지 URL을 설명에 포함
+      const descriptionWithImages = allImageUrls.length > 0
+        ? `${description.trim()}\n\n[images:${allImageUrls.join(",")}]`
         : description.trim();
 
-      const request: PostCreateRequest = {
-        postType,
-        categoryId,
-        itemName: itemName.trim(),
-        description: descriptionWithImages,
-        currencyType,
-        price: price ? parseInt(price, 10) : undefined,
-        priceNegotiable,
-      };
-
-      const newPost = await createPost(request);
-      router.push(`/post/${newPost.id}`);
+      if (isEditMode && editId) {
+        // 수정 모드
+        const request: PostUpdateRequest = {
+          categoryId: categoryId ?? undefined,
+          itemName: itemName.trim(),
+          description: descriptionWithImages,
+          currencyType,
+          price: price ? parseInt(price, 10) : undefined,
+          priceNegotiable,
+        };
+        await updatePost(parseInt(editId, 10), request);
+        router.push(`/post/${editId}`);
+      } else {
+        // 작성 모드
+        const request: PostCreateRequest = {
+          postType,
+          categoryId,
+          itemName: itemName.trim(),
+          description: descriptionWithImages,
+          currencyType,
+          price: price ? parseInt(price, 10) : undefined,
+          priceNegotiable,
+        };
+        const newPost = await createPost(request);
+        router.push(`/post/${newPost.id}`);
+      }
     } catch (err) {
-      console.error("게시글 작성 실패:", err);
-      setError(err instanceof Error ? err.message : "게시글 작성에 실패했습니다");
+      console.error(isEditMode ? "게시글 수정 실패:" : "게시글 작성 실패:", err);
+      setError(err instanceof Error ? err.message : isEditMode ? "게시글 수정에 실패했습니다" : "게시글 작성에 실패했습니다");
     } finally {
       setIsSubmitting(false);
     }
@@ -161,7 +221,7 @@ export default function NewPostPage() {
             <Link href="/" className="p-1 hover:bg-gray-100 rounded-full transition-colors">
               <HomeOutlineIcon className="w-6 h-6 text-gray-800" />
             </Link>
-            <h1 className="font-semibold text-lg">글쓰기</h1>
+            <h1 className="font-semibold text-lg">{isEditMode ? "글 수정" : "글쓰기"}</h1>
             <div className="w-8" />
           </div>
         </header>
@@ -331,17 +391,39 @@ export default function NewPostPage() {
               <button
                 type="button"
                 onClick={handleImageAdd}
-                disabled={images.length >= MAX_POST_IMAGES}
+                disabled={(existingImageUrls.length + images.length) >= MAX_POST_IMAGES}
                 className="w-16 h-16 flex-shrink-0 border-2 border-primary border-dashed rounded-lg flex flex-col items-center justify-center hover:bg-primary/5 transition-colors disabled:opacity-50"
               >
                 <PlusIcon className="w-6 h-6 text-primary" />
-                <span className="text-xs text-primary mt-0.5">{images.length}/{MAX_POST_IMAGES}</span>
+                <span className="text-xs text-primary mt-0.5">{existingImageUrls.length + images.length}/{MAX_POST_IMAGES}</span>
               </button>
 
-              {/* 선택된 이미지 미리보기 */}
+              {/* 기존 이미지 미리보기 (수정 모드) */}
+              {existingImageUrls.map((url, index) => (
+                <div
+                  key={`existing-${index}`}
+                  className="relative w-16 h-16 flex-shrink-0 bg-gray-200 rounded-lg overflow-hidden"
+                >
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
+                    src={url}
+                    alt={`기존 이미지 ${index + 1}`}
+                    className="w-full h-full object-cover"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setExistingImageUrls(existingImageUrls.filter((_, i) => i !== index))}
+                    className="absolute -top-1 -right-1 w-5 h-5 bg-gray-800 text-white rounded-full text-xs flex items-center justify-center"
+                  >
+                    ✕
+                  </button>
+                </div>
+              ))}
+
+              {/* 새로 선택된 이미지 미리보기 */}
               {images.map((image, index) => (
                 <div
-                  key={index}
+                  key={`new-${index}`}
                   className="relative w-16 h-16 flex-shrink-0 bg-gray-200 rounded-lg overflow-hidden"
                 >
                   {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -371,7 +453,7 @@ export default function NewPostPage() {
             disabled={!itemName.trim() || !description.trim() || !categoryId || isSubmitting}
             className="w-full py-4 bg-primary text-white font-semibold rounded-xl hover:bg-primary-dark transition-colors disabled:bg-gray-300 disabled:cursor-not-allowed"
           >
-            {isSubmitting ? "등록 중..." : "작성하기"}
+            {isSubmitting ? (isEditMode ? "수정 중..." : "등록 중...") : (isEditMode ? "수정하기" : "작성하기")}
           </button>
         </div>
       </div>

--- a/apps/web/src/app/post/new/page.tsx
+++ b/apps/web/src/app/post/new/page.tsx
@@ -235,29 +235,31 @@ function NewPostContent() {
             </div>
           )}
 
-          {/* 거래 유형 선택 (팔아요/구해요) */}
+          {/* 거래 유형 선택 (팔아요/구해요) - 수정 모드에서는 변경 불가 */}
           <div>
             <label className="block text-primary font-semibold mb-2">거래 유형</label>
             <div className="flex gap-2">
               <button
                 type="button"
-                onClick={() => setPostType("SELL")}
+                onClick={() => !isEditMode && setPostType("SELL")}
+                disabled={isEditMode}
                 className={`flex-1 py-3 rounded-lg text-sm font-medium border transition-colors ${
                   postType === "SELL"
                     ? "border-primary bg-primary text-white"
                     : "border-gray-300 text-gray-700 hover:border-gray-400"
-                }`}
+                } ${isEditMode ? "opacity-60 cursor-not-allowed" : ""}`}
               >
                 팔아요
               </button>
               <button
                 type="button"
-                onClick={() => setPostType("BUY")}
+                onClick={() => !isEditMode && setPostType("BUY")}
+                disabled={isEditMode}
                 className={`flex-1 py-3 rounded-lg text-sm font-medium border transition-colors ${
                   postType === "BUY"
                     ? "border-primary bg-primary text-white"
                     : "border-gray-300 text-gray-700 hover:border-gray-400"
-                }`}
+                } ${isEditMode ? "opacity-60 cursor-not-allowed" : ""}`}
               >
                 구해요
               </button>

--- a/apps/web/src/app/profile/reviews/page.tsx
+++ b/apps/web/src/app/profile/reviews/page.tsx
@@ -7,27 +7,6 @@ import { MobileLayout, Header } from "@/components/common";
 import { useAuth } from "@/context/AuthContext";
 import { getMyReviews, ReviewResponse, formatRelativeTime } from "@/lib/postApi";
 
-// 별점 표시 컴포넌트
-function StarRating({ rating }: { rating: number }) {
-  return (
-    <div className="flex gap-0.5">
-      {[1, 2, 3, 4, 5].map((star) => (
-        <svg
-          key={star}
-          width="16"
-          height="16"
-          viewBox="0 0 24 24"
-          fill={star <= rating ? "#FBBF24" : "none"}
-          stroke={star <= rating ? "#FBBF24" : "#D1D5DB"}
-          strokeWidth="2"
-        >
-          <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
-        </svg>
-      ))}
-    </div>
-  );
-}
-
 // 리뷰 아이템 컴포넌트
 function ReviewItem({ review }: { review: ReviewResponse }) {
   return (
@@ -51,9 +30,6 @@ function ReviewItem({ review }: { review: ReviewResponse }) {
         </div>
       </div>
 
-      {/* 별점 */}
-      <StarRating rating={review.rating} />
-
       {/* 리뷰 내용 */}
       {review.comment && (
         <p className="text-sm text-black mt-2">{review.comment}</p>
@@ -74,7 +50,6 @@ export default function ProfileReviewsPage() {
   const router = useRouter();
   const { isLoading: authLoading, isAuthenticated } = useAuth();
   const [reviews, setReviews] = useState<ReviewResponse[]>([]);
-  const [averageRating, setAverageRating] = useState<number | null>(null);
   const [reviewCount, setReviewCount] = useState<number>(0);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -92,7 +67,6 @@ export default function ProfileReviewsPage() {
         setError(null);
         const response = await getMyReviews(0, 20);
         setReviews(response.reviews);
-        setAverageRating(response.averageRating);
         setReviewCount(response.reviewCount ?? response.totalElements);
       } catch (err) {
         console.error("리뷰 로드 실패:", err);
@@ -127,16 +101,7 @@ export default function ProfileReviewsPage() {
       {!isLoading && !error && (
         <>
           <div className="p-4 bg-gray-50 border-b border-gray-100">
-            <div className="flex items-center justify-center gap-4">
-              <div className="text-center">
-                <p className="text-3xl font-bold text-primary">
-                  {averageRating != null && Number.isFinite(averageRating)
-                    ? averageRating.toFixed(1)
-                    : "-"}
-                </p>
-                <p className="text-xs text-gray-500 mt-1">평균 별점</p>
-              </div>
-              <div className="w-px h-10 bg-gray-200" />
+            <div className="flex items-center justify-center">
               <div className="text-center">
                 <p className="text-3xl font-bold text-gray-800">{reviewCount}</p>
                 <p className="text-xs text-gray-500 mt-1">받은 리뷰</p>

--- a/apps/web/src/components/chat/AppointmentModal.tsx
+++ b/apps/web/src/components/chat/AppointmentModal.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import { useState } from "react";
+
+interface AppointmentModalProps {
+  otherUserNickname: string;
+  onConfirm: (scheduledTradeAt: string) => void;
+  onClose: () => void;
+  isSubmitting: boolean;
+}
+
+// 약속 잡기 모달 (당근마켓 스타일)
+export default function AppointmentModal({
+  otherUserNickname,
+  onConfirm,
+  onClose,
+  isSubmitting,
+}: AppointmentModalProps) {
+  // 기본값: 내일, 현재 시간에서 30분 단위로 올림
+  const tomorrow = new Date();
+  tomorrow.setDate(tomorrow.getDate() + 1);
+
+  const [selectedDate, setSelectedDate] = useState(() => {
+    const y = tomorrow.getFullYear();
+    const m = String(tomorrow.getMonth() + 1).padStart(2, "0");
+    const d = String(tomorrow.getDate()).padStart(2, "0");
+    return `${y}-${m}-${d}`;
+  });
+
+  const [selectedHour, setSelectedHour] = useState(() => {
+    const now = new Date();
+    // 30분 단위로 올림
+    const minutes = now.getMinutes();
+    if (minutes > 30) {
+      const next = new Date(now.getTime());
+      next.setHours(next.getHours() + 1);
+      next.setMinutes(0);
+      return String(next.getHours()).padStart(2, "0");
+    }
+    return String(now.getHours()).padStart(2, "0");
+  });
+
+  const [selectedMinute, setSelectedMinute] = useState(() => {
+    const now = new Date();
+    const minutes = now.getMinutes();
+    if (minutes > 30) return "00";
+    if (minutes > 0) return "30";
+    return "00";
+  });
+
+  // 날짜 포맷 표시 (2월 10일 화요일)
+  const formatDisplayDate = (dateStr: string) => {
+    const date = new Date(dateStr + "T00:00:00");
+    const month = date.getMonth() + 1;
+    const day = date.getDate();
+    const dayNames = ["일요일", "월요일", "화요일", "수요일", "목요일", "금요일", "토요일"];
+    const dayName = dayNames[date.getDay()];
+    return `${month}월 ${day}일 ${dayName}`;
+  };
+
+  // 시간 포맷 표시 (오전 12:30)
+  const formatDisplayTime = (hour: string, minute: string) => {
+    const h = parseInt(hour);
+    const ampm = h >= 12 ? "오후" : "오전";
+    const h12 = h === 0 ? 12 : h > 12 ? h - 12 : h;
+    return `${ampm} ${h12}:${minute}`;
+  };
+
+  // 약속 확정
+  const handleConfirm = () => {
+    // ISO 8601 형식 (LocalDateTime 호환)
+    const scheduledTradeAt = `${selectedDate}T${selectedHour}:${selectedMinute}:00`;
+    onConfirm(scheduledTradeAt);
+  };
+
+  // 오늘 이후만 선택 가능
+  const today = new Date();
+  const minDate = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, "0")}-${String(today.getDate()).padStart(2, "0")}`;
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 z-50 flex items-end justify-center"
+      onClick={onClose}
+    >
+      <div
+        className="w-full bg-white rounded-t-2xl overflow-hidden animate-slide-up max-h-[90vh]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* 헤더 */}
+        <div className="flex items-center justify-between p-4">
+          <button
+            onClick={onClose}
+            className="p-1 hover:bg-gray-100 rounded-full"
+          >
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+          <div className="w-6" />
+        </div>
+
+        {/* 타이틀 */}
+        <div className="px-6 pb-6">
+          <h2 className="text-xl font-bold text-gray-900">
+            {otherUserNickname}님과 약속
+          </h2>
+        </div>
+
+        {/* 날짜 선택 */}
+        <div className="px-6 py-4 border-t border-gray-100">
+          <div className="flex items-center justify-between">
+            <span className="text-base font-semibold text-gray-900">날짜</span>
+            <label className="flex items-center gap-2 cursor-pointer text-gray-500 hover:text-gray-700">
+              <span>{formatDisplayDate(selectedDate)}</span>
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <polyline points="6 9 12 15 18 9" />
+              </svg>
+              <input
+                type="date"
+                value={selectedDate}
+                min={minDate}
+                onChange={(e) => setSelectedDate(e.target.value)}
+                className="absolute opacity-0 w-0 h-0"
+              />
+            </label>
+          </div>
+        </div>
+
+        {/* 시간 선택 */}
+        <div className="px-6 py-4 border-t border-gray-100">
+          <div className="flex items-center justify-between">
+            <span className="text-base font-semibold text-gray-900">시간</span>
+            <div className="flex items-center gap-2">
+              <span className="text-gray-500">
+                {formatDisplayTime(selectedHour, selectedMinute)}
+              </span>
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <polyline points="6 9 12 15 18 9" />
+              </svg>
+            </div>
+          </div>
+          {/* 시간 선택 드롭다운 */}
+          <div className="flex items-center gap-3 mt-3">
+            <select
+              value={selectedHour}
+              onChange={(e) => setSelectedHour(e.target.value)}
+              className="flex-1 px-3 py-2 border border-gray-300 rounded-lg text-gray-700 focus:outline-none focus:border-[#7ECEC5]"
+            >
+              {Array.from({ length: 24 }, (_, i) => {
+                const hour = String(i).padStart(2, "0");
+                const ampm = i >= 12 ? "오후" : "오전";
+                const h12 = i === 0 ? 12 : i > 12 ? i - 12 : i;
+                return (
+                  <option key={hour} value={hour}>
+                    {ampm} {h12}시
+                  </option>
+                );
+              })}
+            </select>
+            <select
+              value={selectedMinute}
+              onChange={(e) => setSelectedMinute(e.target.value)}
+              className="flex-1 px-3 py-2 border border-gray-300 rounded-lg text-gray-700 focus:outline-none focus:border-[#7ECEC5]"
+            >
+              {["00", "10", "20", "30", "40", "50"].map((m) => (
+                <option key={m} value={m}>
+                  {m}분
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        {/* 완료 버튼 */}
+        <div className="p-6 pb-8">
+          <button
+            onClick={handleConfirm}
+            disabled={isSubmitting}
+            className="w-full py-4 bg-[#5BBFB3] text-white font-semibold rounded-xl hover:bg-[#4DAE9F] transition-colors disabled:bg-gray-300 disabled:cursor-not-allowed text-lg"
+          >
+            {isSubmitting ? "처리 중..." : "완료"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/AppointmentModal.tsx
+++ b/apps/web/src/components/chat/AppointmentModal.tsx
@@ -74,6 +74,12 @@ export default function AppointmentModal({
   const handleConfirm = () => {
     // ISO 8601 형식 (LocalDateTime 호환)
     const scheduledTradeAt = `${selectedDate}T${selectedHour}:${selectedMinute}:00`;
+    // 선택한 일시가 현재보다 이후인지 검증
+    const selectedDateTime = new Date(scheduledTradeAt);
+    if (selectedDateTime <= new Date()) {
+      alert("현재 시각 이후의 시간을 선택해주세요.");
+      return;
+    }
     onConfirm(scheduledTradeAt);
   };
 

--- a/apps/web/src/components/chat/AppointmentModal.tsx
+++ b/apps/web/src/components/chat/AppointmentModal.tsx
@@ -31,7 +31,9 @@ export default function AppointmentModal({
     const now = new Date();
     // 30분 단위로 올림
     const minutes = now.getMinutes();
-    if (minutes > 30) {
+    // Before: minutes > 30 → 정확히 30분일 때 올림 안 됨
+    // After: minutes >= 30 → 30분 이상이면 다음 시간으로 올림
+    if (minutes >= 30) {
       const next = new Date(now.getTime());
       next.setHours(next.getHours() + 1);
       next.setMinutes(0);
@@ -43,7 +45,9 @@ export default function AppointmentModal({
   const [selectedMinute, setSelectedMinute] = useState(() => {
     const now = new Date();
     const minutes = now.getMinutes();
-    if (minutes > 30) return "00";
+    // Before: minutes > 30 → 30분일 때 "30" 반환 (올림 안 됨)
+    // After: minutes >= 30 → 30분 이상이면 "00" (다음 시간 올림과 일치)
+    if (minutes >= 30) return "00";
     if (minutes > 0) return "30";
     return "00";
   });

--- a/apps/web/src/lib/chatApi.ts
+++ b/apps/web/src/lib/chatApi.ts
@@ -9,6 +9,7 @@ export interface ChatRoom {
   postItemName: string;
   postImageUrl: string | null;
   postPrice: number | null;
+  postCurrencyType: string | null;
   postStatus: string | null;
   otherUserId: number;
   otherUserNickname: string;

--- a/apps/web/src/lib/postApi.ts
+++ b/apps/web/src/lib/postApi.ts
@@ -826,12 +826,14 @@ export async function leaveChatRoom(roomId: number): Promise<{ message: string }
 }
 
 /**
- * 거래 예약하기
+ * 거래 예약하기 (약속 잡기)
  * POST /api/chat/rooms/{roomId}/reserve
+ * @param scheduledTradeAt - 거래 예정 일시 (ISO 8601, 선택)
  */
-export async function reserveChatRoom(roomId: number): Promise<ChatRoom> {
+export async function reserveChatRoom(roomId: number, scheduledTradeAt?: string): Promise<ChatRoom> {
   return fetchWithAuth<ChatRoom>(`${API_URL}/api/chat/rooms/${roomId}/reserve`, {
     method: 'POST',
+    body: JSON.stringify(scheduledTradeAt ? { scheduledTradeAt } : {}),
   });
 }
 

--- a/apps/web/src/lib/postApi.ts
+++ b/apps/web/src/lib/postApi.ts
@@ -158,15 +158,19 @@ export interface ReviewListResponse {
 export interface ChatRoom {
   id: number;
   postId: number;
-  postItemName: string | null;
-  postStatus: 'AVAILABLE' | 'RESERVED' | 'COMPLETED';
-  sellerId: number;
-  sellerNickname: string | null;
-  buyerId: number;
-  buyerNickname: string | null;
+  postItemName: string;
+  postImageUrl: string | null;
+  postPrice: number | null;
+  postCurrencyType: string | null;
+  postStatus: string | null;
+  otherUserId: number;
+  otherUserNickname: string;
+  otherUserIslandName: string | null;
   lastMessage: string | null;
   lastMessageAt: string | null;
   unreadCount: number;
+  status: string;
+  scheduledTradeAt: string | null;
   createdAt: string;
 }
 


### PR DESCRIPTION
## Summary

### 1. 채팅방 거래 상태 변경 버튼 및 약속 잡기 모달
- 채팅방 상품 정보 바 하단에 거래 상태별 액션 버튼 추가
  - **판매중(AVAILABLE)**: "약속잡기" 버튼 → 날짜/시간 선택 모달 → 예약 API 호출
  - **예약중(RESERVED)**: "거래 완료" + "예약 취소" 버튼 + 약속 시간 표시
  - **거래완료(COMPLETED)**: "거래 완료됨" 배지 표시
- `AppointmentModal` 컴포넌트 생성 (당근마켓 스타일 바텀시트)
  - 날짜 선택 (오늘 이후), 시간 선택 (10분 단위)
  - 기본값: 내일, 현재 시간 30분 올림
- `reserveChatRoom` API에 `scheduledTradeAt` 파라미터 추가
- 거래 완료 확인 모달 (되돌릴 수 없음 안내)
- 하단 탭 "약속" 버튼과 약속잡기 모달 연동

### 2. 무 점수(매너 점수) 리뷰 연동
- **리뷰 작성 시**: 작성자 무 점수 즉시 **+2**
- **리뷰 수신 시 (rating >= 3)**: 수신자 무 점수 **+(rating × 2)**, 3일 후 적용
  - 예: 3점 → +6, 4점 → +8, 5점 → +10
- **리뷰 수신 시 (rating <= 2)**: 수신자 무 점수 **+(rating × -2)**, 3일 후 적용
  - 예: 1점 → -2, 2점 → -4 (0점은 변동 없음)
- **최소 점수**: 0 (음수 불가)
- 3일 지연 적용으로 상대방이 준 점수를 유추할 수 없게 함
- **새 파일:**
  - `MannerScorePending` 엔티티 (지연 적용 대기 테이블)
  - `MannerScorePendingRepository`
  - `MannerScoreScheduler` (1시간마다 대기 건 처리, `@EnableScheduling`)
- **받은 리뷰 페이지**: 별점 표시 제거, 평균 별점 제거 (받은 리뷰 수만 표시)

> **⚠️ DB 마이그레이션 필요**: 배포 전 Neon Console에서 아래 SQL 실행 필요
> ```sql
> CREATE TABLE manner_score_pending (
>     id BIGSERIAL PRIMARY KEY,
>     member_id BIGINT NOT NULL,
>     review_id BIGINT NOT NULL,
>     score_delta INTEGER NOT NULL,
>     apply_at TIMESTAMP NOT NULL,
>     applied BOOLEAN NOT NULL DEFAULT FALSE,
>     created_at TIMESTAMP NOT NULL DEFAULT NOW()
> );
> CREATE INDEX idx_manner_pending_apply ON manner_score_pending (applied, apply_at);
> ```

### 3. 게시글 더보기 메뉴 분기 + 수정/삭제 기능
- **내 글**: 수정하기, 삭제하기 메뉴 표시
  - 수정하기 → `/post/new?editId={id}` 이동 (기존 글쓰기 페이지 재활용)
  - 삭제하기 → confirm 후 `deletePost` API 호출 → 홈으로 이동
- **남의 글**: 기존 차단/신고 메뉴 유지
- 글쓰기 페이지 수정 모드:
  - `editId` 쿼리 파라미터로 수정 모드 진입
  - 기존 데이터 자동 로드 (제목, 내용, 카테고리, 가격, 이미지)
  - 기존 이미지 미리보기/개별 삭제 + 새 이미지 추가 가능
  - 헤더 "글 수정", 버튼 "수정하기"로 UI 변경
  - `useSearchParams` Suspense boundary 추가 (Next.js 14 필수)

## 변경 파일
| 파일 | 변경 |
|---|---|
| `apps/web/src/app/chat/[id]/page.tsx` | 거래 상태 버튼, 약속/완료 모달 추가 |
| `apps/web/src/components/chat/AppointmentModal.tsx` | 신규 - 약속 잡기 모달 |
| `apps/web/src/lib/postApi.ts` | `reserveChatRoom` scheduledTradeAt 파라미터 추가 |
| `apps/api/.../ReviewService.java` | 무 점수 로직 (즉시 +2, 3일 후 지연 적용) |
| `apps/api/.../MannerScorePending.java` | 신규 - 지연 적용 Entity |
| `apps/api/.../MannerScorePendingRepository.java` | 신규 - Repository |
| `apps/api/.../MannerScoreScheduler.java` | 신규 - 1시간 주기 스케줄러 |
| `apps/api/.../ApiApplication.java` | `@EnableScheduling` 추가 |
| `apps/web/src/app/profile/reviews/page.tsx` | 별점/평균 별점 제거 |
| `apps/web/src/app/post/[id]/page.tsx` | 더보기 메뉴 내 글/남의 글 분기, 삭제 기능 |
| `apps/web/src/app/post/new/page.tsx` | 수정 모드 추가 (editId), Suspense 래퍼 |

## Test plan
- [ ] 채팅방에서 약속잡기 버튼 클릭 → 날짜/시간 선택 → 예약 상태로 변경 확인
- [ ] 예약 상태에서 거래 완료 버튼 → 완료 상태 변경 확인
- [ ] 예약 상태에서 예약 취소 → 판매중으로 복귀 확인
- [ ] 리뷰 작성 → 작성자 무 점수 즉시 +2 확인
- [ ] 리뷰 수신 → `manner_score_pending` 테이블에 3일 후 적용 레코드 확인
- [ ] 받은 리뷰 페이지에서 별점 미표시 확인
- [ ] 내 게시글 상세 → 점 3개 메뉴 → 수정하기/삭제하기 표시 확인
- [ ] 남의 게시글 상세 → 점 3개 메뉴 → 차단/신고 표시 확인
- [ ] 수정하기 클릭 → 기존 데이터 로드 → 수정 후 저장 확인
- [ ] 삭제하기 클릭 → confirm → 삭제 후 홈으로 이동 확인
- [ ] Neon Console에서 `manner_score_pending` 테이블 생성 후 서버 재시작 정상 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 채팅 예약 및 거래 관리 추가: 약속 일정 설정, 예약 취소, 거래 완료 기능 및 약속 모달 도입
  * 게시물 작성/수정 개선: 기존 이미지 유지·편집, 이미지 업로드/미리보기 개선

* **Behavior**
  * 매너 점수 자동 조정: 리뷰에 따른 점수 변화가 예약되어 일정 후 자동 반영

* **UI Improvements**
  * 본인 게시물에 대한 편집·삭제 메뉴 분리
  * 리뷰 페이지에서 평균 점수 표시 제거, 받은 리뷰 수 표시 반영
<!-- end of auto-generated comment: release notes by coderabbit.ai -->