### PR TITLE
fix: 채팅 목록 UI 개선 + 시스템 메시지 + 약속 변경 기능

### DIFF
--- a/apps/api/src/main/java/com/acnh/api/chat/enums/MessageType.java
+++ b/apps/api/src/main/java/com/acnh/api/chat/enums/MessageType.java
@@ -4,8 +4,10 @@ package com.acnh.api.chat.enums;
  * 메시지 유형
  * - TEXT: 일반 텍스트 메시지
  * - IMAGE: 이미지 메시지
+ * - SYSTEM: 시스템 알림 메시지 (약속 잡기, 예약 취소, 거래 완료 등)
  */
 public enum MessageType {
     TEXT,
-    IMAGE
+    IMAGE,
+    SYSTEM
 }

--- a/apps/api/src/main/java/com/acnh/api/chat/service/ChatService.java
+++ b/apps/api/src/main/java/com/acnh/api/chat/service/ChatService.java
@@ -312,9 +312,18 @@ public class ChatService {
             throw new InvalidRequestException("게시글 작성자만 예약자를 지정할 수 있습니다");
         }
 
-        // 이미 예약된 경우
+        String formattedTime = formatScheduledTradeAt(scheduledTradeAt);
+
+        // Before: 이미 예약된 경우 에러 → 약속 시간 변경 불가
+        // After: 이미 예약된 경우 약속 시간만 업데이트
         if (chatRoom.getReservedUserId() != null) {
-            throw new InvalidRequestException("이미 예약된 채팅방입니다");
+            chatRoom.updateScheduledTradeAt(scheduledTradeAt);
+            log.info("약속 시간 변경 - roomId: {}, scheduledTradeAt: {}", roomId, scheduledTradeAt);
+
+            sendSystemMessage(roomId, member.getId(),
+                    "약속이 변경되었어요.\n날짜: " + formattedTime);
+
+            return toChatRoomResponse(chatRoom, member.getId());
         }
 
         // 채팅방의 신청자를 예약자로 지정
@@ -324,7 +333,6 @@ public class ChatService {
         log.info("예약자 지정 - roomId: {}, reservedUserId: {}", roomId, chatRoom.getApplicantId());
 
         // 시스템 메시지: 약속 잡기 알림
-        String formattedTime = formatScheduledTradeAt(scheduledTradeAt);
         sendSystemMessage(roomId, member.getId(),
                 "약속이 잡혔어요.\n날짜: " + formattedTime);
 

--- a/apps/api/src/main/java/com/acnh/api/chat/service/ChatService.java
+++ b/apps/api/src/main/java/com/acnh/api/chat/service/ChatService.java
@@ -19,6 +19,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -463,8 +465,16 @@ public class ChatService {
 
         ChatMessageResponse response = ChatMessageResponse.from(saved, "시스템");
 
-        // WebSocket 브로드캐스트 (실시간 반영)
-        messagingTemplate.convertAndSend("/topic/chat." + chatRoomId, response);
+        // Before: 트랜잭션 커밋 전 브로드캐스트 → 롤백 시 유령 메시지 전송 위험
+        // After: 트랜잭션 커밋 후 브로드캐스트 → 롤백 시 메시지 미전송
+        TransactionSynchronizationManager.registerSynchronization(
+                new TransactionSynchronization() {
+                    @Override
+                    public void afterCommit() {
+                        messagingTemplate.convertAndSend("/topic/chat." + chatRoomId, response);
+                    }
+                }
+        );
 
         log.info("시스템 메시지 전송 - roomId: {}, content: {}", chatRoomId, content);
     }

--- a/apps/api/src/main/java/com/acnh/api/chat/service/ChatService.java
+++ b/apps/api/src/main/java/com/acnh/api/chat/service/ChatService.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -40,6 +41,7 @@ public class ChatService {
     private final MemberRepository memberRepository;
     private final PostRepository postRepository;
     private final ProfanityFilter profanityFilter;
+    private final SimpMessagingTemplate messagingTemplate;
 
     /**
      * 채팅방 생성 또는 기존 채팅방 반환
@@ -321,6 +323,11 @@ public class ChatService {
 
         log.info("예약자 지정 - roomId: {}, reservedUserId: {}", roomId, chatRoom.getApplicantId());
 
+        // 시스템 메시지: 약속 잡기 알림
+        String formattedTime = formatScheduledTradeAt(scheduledTradeAt);
+        sendSystemMessage(roomId, member.getId(),
+                "약속이 잡혔어요.\n날짜: " + formattedTime);
+
         return toChatRoomResponse(chatRoom, member.getId());
     }
 
@@ -347,6 +354,9 @@ public class ChatService {
         chatRoom.updateStatus("ACTIVE");
 
         log.info("예약 해제 - roomId: {}", roomId);
+
+        // 시스템 메시지: 약속 취소 알림
+        sendSystemMessage(roomId, member.getId(), "약속이 취소되었어요.");
 
         return toChatRoomResponse(chatRoom, member.getId());
     }
@@ -378,6 +388,9 @@ public class ChatService {
         post.updateStatus("COMPLETED");
 
         log.info("거래 완료 - roomId: {}, postId: {}", roomId, chatRoom.getPostId());
+
+        // 시스템 메시지: 거래 완료 알림
+        sendSystemMessage(roomId, member.getId(), "거래가 완료되었어요.");
 
         return toChatRoomResponse(chatRoom, member.getId());
     }
@@ -418,6 +431,53 @@ public class ChatService {
         return chatRooms.stream()
                 .map(room -> toChatRoomResponse(room, member.getId()))
                 .toList();
+    }
+
+    // ========== 시스템 메시지 ==========
+
+    /**
+     * 시스템 메시지 생성, 저장, WebSocket 브로드캐스트
+     * - 약속 잡기, 예약 취소, 거래 완료 등 상태 변경 시 채팅방에 알림 표시
+     */
+    private void sendSystemMessage(Long chatRoomId, Long senderId, String content) {
+        ChatMessage systemMessage = ChatMessage.builder()
+                .chatRoomId(chatRoomId)
+                .senderId(senderId)
+                .messageType("SYSTEM")
+                .content(content)
+                .build();
+
+        ChatMessage saved = chatMessageRepository.save(systemMessage);
+
+        // 채팅방 updatedAt 갱신 (목록 정렬용)
+        ChatRoom chatRoom = findChatRoomById(chatRoomId);
+        chatRoom.touch();
+
+        ChatMessageResponse response = ChatMessageResponse.from(saved, "시스템");
+
+        // WebSocket 브로드캐스트 (실시간 반영)
+        messagingTemplate.convertAndSend("/topic/chat." + chatRoomId, response);
+
+        log.info("시스템 메시지 전송 - roomId: {}, content: {}", chatRoomId, content);
+    }
+
+    /**
+     * 약속 일시를 한국어 포맷으로 변환
+     * 예: "2월 15일 토요일 오후 2:30"
+     */
+    private String formatScheduledTradeAt(LocalDateTime dateTime) {
+        if (dateTime == null) return "";
+
+        String[] dayNames = {"일요일", "월요일", "화요일", "수요일", "목요일", "금요일", "토요일"};
+        String dayName = dayNames[dateTime.getDayOfWeek().getValue() % 7];
+
+        int hour = dateTime.getHour();
+        String ampm = hour >= 12 ? "오후" : "오전";
+        int h12 = hour == 0 ? 12 : hour > 12 ? hour - 12 : hour;
+        String minute = String.format("%02d", dateTime.getMinute());
+
+        return String.format("%d월 %d일 %s %s %d:%s",
+                dateTime.getMonthValue(), dateTime.getDayOfMonth(), dayName, ampm, h12, minute);
     }
 
     // ========== Private Helper Methods ==========

--- a/apps/api/src/main/java/com/acnh/api/post/repository/PostRepository.java
+++ b/apps/api/src/main/java/com/acnh/api/post/repository/PostRepository.java
@@ -75,7 +75,9 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     @Query(value = "SELECT * FROM posts p WHERE p.deleted_at IS NULL " +
             "AND (:hasCategoryFilter = false OR p.category_id IN (:categoryIds)) " +
             "AND (:hasPostTypeFilter = false OR p.post_type IN (:postTypes)) " +
-            "AND (:status IS NULL OR p.status = :status) " +
+            // Before: 상태 필터 없으면 COMPLETED 포함 → 홈화면에 거래 완료 게시글 노출
+            // After: 상태 필터 없으면 COMPLETED 제외, 명시적 필터 시 해당 상태만 조회
+            "AND ((:status IS NULL AND p.status != 'COMPLETED') OR p.status = :status) " +
             "AND (:hasCurrencyTypeFilter = false OR p.currency_type IN (:currencyTypes)) " +
             "AND (:minPrice IS NULL OR p.price >= :minPrice) " +
             "AND (:maxPrice IS NULL OR p.price <= :maxPrice) " +
@@ -83,7 +85,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
             countQuery = "SELECT COUNT(*) FROM posts p WHERE p.deleted_at IS NULL " +
             "AND (:hasCategoryFilter = false OR p.category_id IN (:categoryIds)) " +
             "AND (:hasPostTypeFilter = false OR p.post_type IN (:postTypes)) " +
-            "AND (:status IS NULL OR p.status = :status) " +
+            "AND ((:status IS NULL AND p.status != 'COMPLETED') OR p.status = :status) " +
             "AND (:hasCurrencyTypeFilter = false OR p.currency_type IN (:currencyTypes)) " +
             "AND (:minPrice IS NULL OR p.price >= :minPrice) " +
             "AND (:maxPrice IS NULL OR p.price <= :maxPrice)",
@@ -113,7 +115,9 @@ public interface PostRepository extends JpaRepository<Post, Long> {
             "  OR LOWER(REPLACE(COALESCE(p.description, ''), ' ', '')) LIKE LOWER(CONCAT('%', REPLACE(:keyword, ' ', ''), '%'))) " +
             "AND (:hasCategoryFilter = false OR p.category_id IN (:categoryIds)) " +
             "AND (:hasPostTypeFilter = false OR p.post_type IN (:postTypes)) " +
-            "AND (:status IS NULL OR p.status = :status) " +
+            // Before: 상태 필터 없으면 COMPLETED 포함 → 검색 결과에 거래 완료 게시글 노출
+            // After: 상태 필터 없으면 COMPLETED 제외, 명시적 필터 시 해당 상태만 조회
+            "AND ((:status IS NULL AND p.status != 'COMPLETED') OR p.status = :status) " +
             "AND (:hasCurrencyTypeFilter = false OR p.currency_type IN (:currencyTypes)) " +
             "AND (:minPrice IS NULL OR p.price >= :minPrice) " +
             "AND (:maxPrice IS NULL OR p.price <= :maxPrice) " +
@@ -123,7 +127,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
             "  OR LOWER(REPLACE(COALESCE(p.description, ''), ' ', '')) LIKE LOWER(CONCAT('%', REPLACE(:keyword, ' ', ''), '%'))) " +
             "AND (:hasCategoryFilter = false OR p.category_id IN (:categoryIds)) " +
             "AND (:hasPostTypeFilter = false OR p.post_type IN (:postTypes)) " +
-            "AND (:status IS NULL OR p.status = :status) " +
+            "AND ((:status IS NULL AND p.status != 'COMPLETED') OR p.status = :status) " +
             "AND (:hasCurrencyTypeFilter = false OR p.currency_type IN (:currencyTypes)) " +
             "AND (:minPrice IS NULL OR p.price >= :minPrice) " +
             "AND (:maxPrice IS NULL OR p.price <= :maxPrice)",

--- a/apps/web/src/app/chat/[id]/page.tsx
+++ b/apps/web/src/app/chat/[id]/page.tsx
@@ -719,14 +719,12 @@ export default function ChatRoomPage() {
                 <span className="text-xs text-white font-medium">카메라</span>
               </button>
 
-              {/* 약속 - AVAILABLE 상태에서만 모달 열기 */}
+              {/* 약속 - AVAILABLE/RESERVED 상태에서 모달 열기 (RESERVED면 시간 변경) */}
               <button
                 onClick={() => {
                   setIsBottomTabOpen(false);
-                  if (chatRoom?.postStatus === "AVAILABLE") {
+                  if (chatRoom?.postStatus === "AVAILABLE" || chatRoom?.postStatus === "RESERVED") {
                     setShowAppointmentModal(true);
-                  } else if (chatRoom?.postStatus === "RESERVED") {
-                    alert("이미 약속이 잡혀있습니다.");
                   } else {
                     alert("거래가 완료된 상품입니다.");
                   }
@@ -942,6 +940,7 @@ export default function ChatRoomPage() {
             onConfirm={handleReserve}
             onClose={() => setShowAppointmentModal(false)}
             isSubmitting={isStatusChanging}
+            initialScheduledAt={chatRoom.scheduledTradeAt}
           />
         )}
 

--- a/apps/web/src/app/chat/[id]/page.tsx
+++ b/apps/web/src/app/chat/[id]/page.tsx
@@ -19,6 +19,7 @@ interface DisplayMessage {
   id: number;
   senderId: number;
   senderNickname: string;
+  messageType: 'TEXT' | 'IMAGE' | 'SYSTEM';
   content: string | null;
   imageUrl: string | null;
   isMe: boolean;
@@ -26,10 +27,29 @@ interface DisplayMessage {
   isRead: boolean;
 }
 
+// 시스템 메시지 컴포넌트 (약속 잡기, 예약 취소, 거래 완료 알림)
+function SystemMessageCard({ message }: { message: DisplayMessage }) {
+  return (
+    <div className="flex justify-center mb-4 px-4">
+      <div className="bg-gray-100 rounded-2xl px-5 py-4 max-w-[280px] w-full shadow-sm">
+        <p className="text-sm text-gray-800 font-semibold whitespace-pre-line text-center">
+          {message.content}
+        </p>
+        <p className="text-xs text-gray-400 text-center mt-2">{message.time}</p>
+      </div>
+    </div>
+  );
+}
+
 // 메시지 버블 컴포넌트
 // Before: isRead가 true인 모든 내 메시지에 "읽음" 표시
 // After: isLastRead prop으로 마지막 읽힌 내 메시지에만 "읽음" 표시
 function MessageBubble({ message, isLastRead }: { message: DisplayMessage; isLastRead?: boolean }) {
+  // 시스템 메시지는 카드형으로 렌더링
+  if (message.messageType === "SYSTEM") {
+    return <SystemMessageCard message={message} />;
+  }
+
   return (
     <div className={`flex ${message.isMe ? "justify-end" : "justify-start"} mb-3`}>
       {!message.isMe && (
@@ -162,9 +182,10 @@ export default function ChatRoomPage() {
     id: msg.id,
     senderId: msg.senderId,
     senderNickname: msg.senderNickname,
+    messageType: msg.messageType,
     content: msg.content,
     imageUrl: msg.imageUrl,
-    isMe: otherUserId !== undefined && msg.senderId !== otherUserId,
+    isMe: msg.messageType === 'SYSTEM' ? false : (otherUserId !== undefined && msg.senderId !== otherUserId),
     time: formatMessageTime(msg.createdAt),
     isRead: msg.isRead,
   });

--- a/apps/web/src/app/chat/page.tsx
+++ b/apps/web/src/app/chat/page.tsx
@@ -45,13 +45,18 @@ function ChatItem({ chat }: { chat: ChatRoom }) {
           {chat.postItemName}
         </span>
         {chat.postStatus && (
-          <span className={`text-xs px-1.5 py-0.5 rounded ${
+          <span className={`text-xs px-1.5 py-0.5 rounded font-medium ${
             chat.postStatus === 'AVAILABLE' ? 'bg-green-100 text-green-700' :
-            chat.postStatus === 'RESERVED' ? 'bg-yellow-100 text-yellow-700' :
-            'bg-gray-100 text-gray-700'
-          }`}>
+            chat.postStatus === 'RESERVED' ? 'text-yellow-700' :
+            'text-white'
+          }`}
+          style={
+            chat.postStatus === 'RESERVED' ? { backgroundColor: '#FFFFF0', border: '1px solid #e5e0c8' } :
+            chat.postStatus === 'COMPLETED' ? { backgroundColor: '#adb5bd' } :
+            undefined
+          }>
             {chat.postStatus === 'AVAILABLE' ? '판매중' :
-             chat.postStatus === 'RESERVED' ? '예약중' : '완료'}
+             chat.postStatus === 'RESERVED' ? '예약중' : '거래완료'}
           </span>
         )}
       </div>

--- a/apps/web/src/app/chat/page.tsx
+++ b/apps/web/src/app/chat/page.tsx
@@ -27,12 +27,12 @@ function ChatItem({ chat }: { chat: ChatRoom }) {
 
       {/* 채팅 정보 */}
       <div className="flex-1 min-w-0">
-        <div className="flex items-center gap-2">
-          <span className="font-medium text-black">{chat.otherUserNickname}</span>
+        <div className="flex items-center gap-2 min-w-0">
+          <span className="font-medium text-black truncate max-w-[80px] flex-shrink-0">{chat.otherUserNickname}</span>
           {chat.otherUserIslandName && (
-            <span className="text-xs text-black">{chat.otherUserIslandName}</span>
+            <span className="text-xs text-black truncate max-w-[60px] flex-shrink-0">{chat.otherUserIslandName}</span>
           )}
-          <span className="text-xs text-black">· {formatChatTime(chat.lastMessageAt)}</span>
+          <span className="text-xs text-black whitespace-nowrap flex-shrink-0">· {formatChatTime(chat.lastMessageAt)}</span>
         </div>
         <p className="text-sm text-black truncate mt-0.5">
           {chat.lastMessage || "채팅을 시작해보세요!"}

--- a/apps/web/src/components/chat/AppointmentModal.tsx
+++ b/apps/web/src/components/chat/AppointmentModal.tsx
@@ -46,7 +46,12 @@ export default function AppointmentModal({
 
   const [selectedHour, setSelectedHour] = useState(() => {
     if (initialDate) {
-      return String(initialDate.getHours()).padStart(2, "0");
+      // Before: 분 반올림이 60이면 시간 미조정 (예: 14:55 → 14:00)
+      // After: 분 반올림 60 시 시간 +1 (예: 14:55 → 15:00)
+      const m = initialDate.getMinutes();
+      const rounded = Math.round(m / 10) * 10;
+      const h = rounded >= 60 ? (initialDate.getHours() + 1) % 24 : initialDate.getHours();
+      return String(h).padStart(2, "0");
     }
     const now = new Date();
     const minutes = now.getMinutes();

--- a/apps/web/src/components/chat/AppointmentModal.tsx
+++ b/apps/web/src/components/chat/AppointmentModal.tsx
@@ -7,6 +7,7 @@ interface AppointmentModalProps {
   onConfirm: (scheduledTradeAt: string) => void;
   onClose: () => void;
   isSubmitting: boolean;
+  initialScheduledAt?: string | null;
 }
 
 // 약속 잡기 모달 (당근마켓 스타일)
@@ -15,21 +16,39 @@ export default function AppointmentModal({
   onConfirm,
   onClose,
   isSubmitting,
+  initialScheduledAt,
 }: AppointmentModalProps) {
-  // 기본값: 내일, 현재 시간에서 30분 단위로 올림
+  // 기존 약속이 있으면 해당 시간으로 초기화, 없으면 내일 + 30분 올림
+  const getInitialDate = (): Date | null => {
+    if (initialScheduledAt) {
+      // 백엔드 UTC → 로컬 변환
+      const dateStr = initialScheduledAt.endsWith('Z') || initialScheduledAt.includes('+')
+        ? initialScheduledAt
+        : initialScheduledAt + 'Z';
+      const d = new Date(dateStr);
+      if (!isNaN(d.getTime())) return d;
+    }
+    return null;
+  };
+
+  const initialDate = getInitialDate();
+
   const tomorrow = new Date();
   tomorrow.setDate(tomorrow.getDate() + 1);
 
   const [selectedDate, setSelectedDate] = useState(() => {
-    const y = tomorrow.getFullYear();
-    const m = String(tomorrow.getMonth() + 1).padStart(2, "0");
-    const d = String(tomorrow.getDate()).padStart(2, "0");
+    const base = initialDate || tomorrow;
+    const y = base.getFullYear();
+    const m = String(base.getMonth() + 1).padStart(2, "0");
+    const d = String(base.getDate()).padStart(2, "0");
     return `${y}-${m}-${d}`;
   });
 
   const [selectedHour, setSelectedHour] = useState(() => {
+    if (initialDate) {
+      return String(initialDate.getHours()).padStart(2, "0");
+    }
     const now = new Date();
-    // 30분 단위로 올림
     const minutes = now.getMinutes();
     // Before: minutes > 30 → 정확히 30분일 때 올림 안 됨
     // After: minutes >= 30 → 30분 이상이면 다음 시간으로 올림
@@ -43,6 +62,12 @@ export default function AppointmentModal({
   });
 
   const [selectedMinute, setSelectedMinute] = useState(() => {
+    if (initialDate) {
+      // 10분 단위에 맞추기
+      const m = initialDate.getMinutes();
+      const rounded = Math.round(m / 10) * 10;
+      return String(rounded >= 60 ? 0 : rounded).padStart(2, "0");
+    }
     const now = new Date();
     const minutes = now.getMinutes();
     // Before: minutes > 30 → 30분일 때 "30" 반환 (올림 안 됨)
@@ -113,7 +138,7 @@ export default function AppointmentModal({
         {/* 타이틀 */}
         <div className="px-6 pb-6">
           <h2 className="text-xl font-bold text-gray-900">
-            {otherUserNickname}님과 약속
+            {initialScheduledAt ? "약속 시간 변경" : `${otherUserNickname}님과 약속`}
           </h2>
         </div>
 

--- a/apps/web/src/lib/chatApi.ts
+++ b/apps/web/src/lib/chatApi.ts
@@ -106,11 +106,21 @@ export async function getChatMessages(roomId: number): Promise<ChatMessage[]> {
   return fetchWithAuth<ChatMessage[]>(`${API_URL}/api/chat/rooms/${roomId}/messages`);
 }
 
+// 백엔드 LocalDateTime(UTC 기준)을 로컬 시간으로 변환
+// Before: new Date(dateString) → timezone 정보 없어 로컬로 해석, 9시간 오차
+// After: 'Z' suffix 추가하여 UTC로 파싱 → 브라우저가 자동으로 로컬 시간 변환
+function parseServerDate(dateString: string): Date {
+  if (!dateString.endsWith('Z') && !dateString.includes('+')) {
+    return new Date(dateString + 'Z');
+  }
+  return new Date(dateString);
+}
+
 // 시간 포맷팅 (채팅 목록용)
 export function formatChatTime(dateString: string | null): string {
   if (!dateString) return '';
 
-  const date = new Date(dateString);
+  const date = parseServerDate(dateString);
   const now = new Date();
   const diff = now.getTime() - date.getTime();
 
@@ -129,7 +139,7 @@ export function formatChatTime(dateString: string | null): string {
 
 // 시간 포맷팅 (채팅방 내부용)
 export function formatMessageTime(dateString: string): string {
-  const date = new Date(dateString);
+  const date = parseServerDate(dateString);
   const hours = date.getHours();
   const minutes = date.getMinutes();
   const ampm = hours >= 12 ? '오후' : '오전';

--- a/apps/web/src/lib/websocket.ts
+++ b/apps/web/src/lib/websocket.ts
@@ -8,7 +8,7 @@ export interface ChatMessage {
   chatRoomId: number;
   senderId: number;
   senderNickname: string;
-  messageType: 'TEXT' | 'IMAGE';
+  messageType: 'TEXT' | 'IMAGE' | 'SYSTEM';
   content: string | null;
   imageUrl: string | null;
   isRead: boolean;


### PR DESCRIPTION
## Summary
- 채팅 목록 유저 이름/섬 이름이 길면 `...`으로 truncation 처리
- 채팅 시간 UTC 9시간 오차 수정 (서버 UTC → 로컬 시간 변환)
- 채팅 목록 상태 배지 색상 변경 (예약중: `#FFFFF0`, 거래완료: `#adb5bd`)
- 약속/예약취소/거래완료 시 당근마켓 스타일 카드형 시스템 메시지 표시
- 이미 예약 중인 채팅방에서 약속 시간 변경 기능

## Changes
### 채팅 목록 UI
- 닉네임/섬이름에 `truncate max-w` 적용하여 줄바꿈 방지
- `parseServerDate()` 헬퍼로 UTC 시간 보정
- 상태 배지 RESERVED/COMPLETED 색상 디자인 반영

### 시스템 메시지 (백엔드 + 프론트엔드)
- `MessageType.SYSTEM` enum 추가
- `ChatService`에 `SimpMessagingTemplate` 주입, 예약/취소/완료 시 시스템 메시지 DB 저장 + WebSocket 브로드캐스트
- `SystemMessageCard` 컴포넌트로 중앙 카드형 렌더링

### 약속 시간 변경
- 이미 예약된 채팅방에서 약속 버튼 클릭 시 기존 시간으로 pre-fill된 모달 표시
- 백엔드에서 기존 예약 시 에러 대신 시간만 업데이트 + "약속이 변경되었어요." 시스템 메시지

## Test plan
- [ ] 채팅 목록에서 긴 닉네임/섬이름이 `...`으로 잘리는지 확인
- [ ] 채팅 목록/채팅방 시간이 로컬 시간(KST)으로 정확히 표시되는지 확인
- [ ] 예약중/거래완료 배지 색상이 디자인과 일치하는지 확인
- [ ] 약속 잡기 시 채팅방에 카드형 시스템 메시지가 표시되는지 확인
- [ ] 예약 취소/거래 완료 시에도 시스템 메시지가 표시되는지 확인
- [ ] 이미 예약된 채팅방에서 약속 버튼 클릭 시 기존 시간이 pre-fill되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 채팅에서 약속 예약, 취소, 거래 완료 시 시스템 알림 추가
  * 채팅 내 약속 시간 재설정 기능 추가

* **버그 수정**
  * 약속 시간 날짜 처리 개선
  * 완료된 게시물 필터링 로직 수정

* **스타일**
  * 채팅 목록 텍스트 오버플로우 처리 개선
  * 상태 표시 한글화: "판매중", "예약중", "거래완료"

<!-- end of auto-generated comment: release notes by coderabbit.ai -->