### PR TITLE
fix: 채팅 거래 상태 버그 수정 및 권한 처리

### DIFF
--- a/apps/api/src/main/java/com/acnh/api/chat/dto/ChatRoomResponse.java
+++ b/apps/api/src/main/java/com/acnh/api/chat/dto/ChatRoomResponse.java
@@ -33,6 +33,9 @@ public class ChatRoomResponse {
     private LocalDateTime scheduledTradeAt;
     private LocalDateTime createdAt;
 
+    // 현재 사용자가 게시글 작성자인지 여부 (거래 액션 버튼 표시용)
+    private boolean isPostOwner;
+
     /**
      * Entity -> DTO 변환
      */
@@ -45,6 +48,9 @@ public class ChatRoomResponse {
         Long otherUserId = chatRoom.getPostOwnerId().equals(currentUserId)
                 ? chatRoom.getApplicantId()
                 : chatRoom.getPostOwnerId();
+
+        // 현재 사용자가 게시글 작성자인지 판별
+        boolean isPostOwner = chatRoom.getPostOwnerId().equals(currentUserId);
 
         return ChatRoomResponse.builder()
                 .id(chatRoom.getId())
@@ -63,6 +69,7 @@ public class ChatRoomResponse {
                 .status(chatRoom.getStatus())
                 .scheduledTradeAt(chatRoom.getScheduledTradeAt())
                 .createdAt(chatRoom.getCreatedAt())
+                .isPostOwner(isPostOwner)
                 .build();
     }
 }

--- a/apps/api/src/main/java/com/acnh/api/chat/dto/ChatRoomResponse.java
+++ b/apps/api/src/main/java/com/acnh/api/chat/dto/ChatRoomResponse.java
@@ -1,6 +1,7 @@
 package com.acnh.api.chat.dto;
 
 import com.acnh.api.chat.entity.ChatRoom;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -33,7 +34,9 @@ public class ChatRoomResponse {
     private LocalDateTime scheduledTradeAt;
     private LocalDateTime createdAt;
 
-    // 현재 사용자가 게시글 작성자인지 여부 (거래 액션 버튼 표시용)
+    // Before: Lombok @Getter + boolean isPostOwner → Jackson이 "postOwner"로 직렬화 (is 접두사 제거)
+    // After: @JsonProperty로 명시적 키 지정 → 프론트엔드 기대값 "isPostOwner"와 일치
+    @JsonProperty("isPostOwner")
     private boolean isPostOwner;
 
     /**
@@ -44,13 +47,12 @@ public class ChatRoomResponse {
                                          String otherUserNickname, String otherUserIslandName,
                                          String lastMessage, LocalDateTime lastMessageAt,
                                          Integer unreadCount) {
-        // 상대방 ID 결정 (내가 postOwner면 상대방은 applicant, 반대면 postOwner)
-        Long otherUserId = chatRoom.getPostOwnerId().equals(currentUserId)
+        // Before: getPostOwnerId().equals(currentUserId) 중복 호출
+        // After: isPostOwner 먼저 판별하여 otherUserId 결정에 재사용
+        boolean isPostOwner = chatRoom.getPostOwnerId().equals(currentUserId);
+        Long otherUserId = isPostOwner
                 ? chatRoom.getApplicantId()
                 : chatRoom.getPostOwnerId();
-
-        // 현재 사용자가 게시글 작성자인지 판별
-        boolean isPostOwner = chatRoom.getPostOwnerId().equals(currentUserId);
 
         return ChatRoomResponse.builder()
                 .id(chatRoom.getId())

--- a/apps/api/src/main/java/com/acnh/api/chat/service/ChatService.java
+++ b/apps/api/src/main/java/com/acnh/api/chat/service/ChatService.java
@@ -368,10 +368,15 @@ public class ChatService {
         chatRoom.cancelReservation();
         chatRoom.updateStatus("ACTIVE");
 
-        // Before: 게시글 상태 미변경 → 채팅 목록에서 "예약중" 유지
-        // After: 게시글 상태도 AVAILABLE로 복구
+        // Before: 무조건 게시글 상태 AVAILABLE로 복구 → 다른 채팅방이 예약 중이면 상태 불일치
+        // After: 같은 게시글의 다른 예약된 채팅방이 없을 때만 AVAILABLE로 복구
         Post post = findPostById(chatRoom.getPostId());
-        post.updateStatus("AVAILABLE");
+        boolean hasOtherReserved = chatRoomRepository.findByPostIdAndDeletedAtIsNull(chatRoom.getPostId())
+                .stream()
+                .anyMatch(r -> !r.getId().equals(chatRoom.getId()) && r.getReservedUserId() != null);
+        if (!hasOtherReserved) {
+            post.updateStatus("AVAILABLE");
+        }
 
         log.info("예약 해제 - roomId: {}", roomId);
 

--- a/apps/api/src/main/java/com/acnh/api/chat/service/ChatService.java
+++ b/apps/api/src/main/java/com/acnh/api/chat/service/ChatService.java
@@ -332,6 +332,11 @@ public class ChatService {
         chatRoom.reserve(chatRoom.getApplicantId(), scheduledTradeAt);
         chatRoom.updateStatus("RESERVED");
 
+        // Before: 게시글 상태 미변경 → 채팅 목록에서 "판매중" 유지
+        // After: 게시글 상태도 RESERVED로 변경
+        Post post = findPostById(chatRoom.getPostId());
+        post.updateStatus("RESERVED");
+
         log.info("예약자 지정 - roomId: {}, reservedUserId: {}", roomId, chatRoom.getApplicantId());
 
         // 시스템 메시지: 약속 잡기 알림
@@ -362,6 +367,11 @@ public class ChatService {
 
         chatRoom.cancelReservation();
         chatRoom.updateStatus("ACTIVE");
+
+        // Before: 게시글 상태 미변경 → 채팅 목록에서 "예약중" 유지
+        // After: 게시글 상태도 AVAILABLE로 복구
+        Post post = findPostById(chatRoom.getPostId());
+        post.updateStatus("AVAILABLE");
 
         log.info("예약 해제 - roomId: {}", roomId);
 

--- a/apps/web/src/app/chat/[id]/page.tsx
+++ b/apps/web/src/app/chat/[id]/page.tsx
@@ -549,7 +549,7 @@ export default function ChatRoomPage() {
                   </button>
                 )}
 
-                {/* 예약중 → 거래 완료 + 예약 취소 */}
+                {/* 예약중 → 거래 완료 + 약속 변경 + 예약 취소 */}
                 {chatRoom.postStatus === "RESERVED" && (
                   <>
                     <button
@@ -561,6 +561,13 @@ export default function ChatRoomPage() {
                         <polyline points="20 6 9 17 4 12" />
                       </svg>
                       거래 완료
+                    </button>
+                    <button
+                      onClick={() => setShowAppointmentModal(true)}
+                      disabled={isStatusChanging}
+                      className="flex items-center gap-1.5 px-4 py-2 border border-gray-300 rounded-full text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors disabled:opacity-50"
+                    >
+                      약속 변경
                     </button>
                     <button
                       onClick={handleUnreserve}

--- a/apps/web/src/app/chat/[id]/page.tsx
+++ b/apps/web/src/app/chat/[id]/page.tsx
@@ -529,8 +529,8 @@ export default function ChatRoomPage() {
               </Link>
             </div>
 
-            {/* 거래 액션 버튼 (상태별) */}
-            {chatRoom.postStatus !== "COMPLETED" && (
+            {/* 거래 액션 버튼 (게시글 작성자만 표시) */}
+            {chatRoom.isPostOwner && chatRoom.postStatus !== "COMPLETED" && (
               <div className="flex items-center gap-2 px-4 pb-3">
                 {/* 판매중 → 약속 잡기 */}
                 {chatRoom.postStatus === "AVAILABLE" && (
@@ -726,7 +726,8 @@ export default function ChatRoomPage() {
                 <span className="text-xs text-white font-medium">카메라</span>
               </button>
 
-              {/* 약속 - AVAILABLE/RESERVED 상태에서 모달 열기 (RESERVED면 시간 변경) */}
+              {/* 약속 - 게시글 작성자만 표시, AVAILABLE/RESERVED 상태에서 모달 열기 */}
+              {chatRoom?.isPostOwner && (
               <button
                 onClick={() => {
                   setIsBottomTabOpen(false);
@@ -757,6 +758,7 @@ export default function ChatRoomPage() {
                 </div>
                 <span className="text-xs text-white font-medium">약속</span>
               </button>
+              )}
             </div>
           </div>
         </div>

--- a/apps/web/src/app/post/new/page.tsx
+++ b/apps/web/src/app/post/new/page.tsx
@@ -181,6 +181,7 @@ function NewPostContent() {
       if (isEditMode && editId) {
         // 수정 모드
         const request: PostUpdateRequest = {
+          postType,
           categoryId: categoryId ?? undefined,
           itemName: itemName.trim(),
           description: descriptionWithImages,

--- a/apps/web/src/app/profile/favorites/page.tsx
+++ b/apps/web/src/app/profile/favorites/page.tsx
@@ -17,8 +17,11 @@ function FavoriteItem({
   onUnlike: (postId: number) => void;
 }) {
   // 가격 포맷팅
+  // Before: price === 0 → "0 덩" (나눔인데 가격처럼 표시)
+  // After: price === 0 → "나눔"
   const formatPrice = (price: number | null, currencyType: string | null) => {
     if (price === null) return "가격 미정";
+    if (price === 0) return "나눔";
     if (currencyType === "MILE_TICKET") return `마일 티켓 ${price}장`;
     return `${price.toLocaleString()} 덩`;
   };

--- a/apps/web/src/app/profile/favorites/page.tsx
+++ b/apps/web/src/app/profile/favorites/page.tsx
@@ -6,7 +6,7 @@ import Image from "next/image";
 import { MobileLayout, Header } from "@/components/common";
 import { HeartIcon } from "@/components/icons";
 import { useAuth } from "@/context/AuthContext";
-import { getMyLikes, extractImageUrls, isSafeImageUrl, Post, togglePostLike } from "@/lib/postApi";
+import { getMyLikes, extractImageUrls, isSafeImageUrl, Post, togglePostLike, formatPrice } from "@/lib/postApi";
 
 // 관심 상품 아이템 컴포넌트
 function FavoriteItem({
@@ -16,15 +16,8 @@ function FavoriteItem({
   post: Post;
   onUnlike: (postId: number) => void;
 }) {
-  // 가격 포맷팅
-  // Before: price === 0 → "0 덩" (나눔인데 가격처럼 표시)
-  // After: price === 0 → "나눔"
-  const formatPrice = (price: number | null, currencyType: string | null) => {
-    if (price === null) return "가격 미정";
-    if (price === 0) return "나눔";
-    if (currencyType === "MILE_TICKET") return `마일 티켓 ${price}장`;
-    return `${price.toLocaleString()} 덩`;
-  };
+  // Before: 로컬 formatPrice 사용 → 공유 함수(postApi.ts)와 포맷 불일치
+  // After: 공유 formatPrice import하여 일관된 가격 표시
 
   // 거래 상태 배지
   const getStatusBadge = (status: string) => {

--- a/apps/web/src/lib/chatApi.ts
+++ b/apps/web/src/lib/chatApi.ts
@@ -20,6 +20,8 @@ export interface ChatRoom {
   status: string;
   scheduledTradeAt: string | null;
   createdAt: string;
+  // 현재 사용자가 게시글 작성자인지 여부 (거래 액션 버튼 표시용)
+  isPostOwner: boolean;
 }
 
 // 채팅방 목록 응답 타입

--- a/apps/web/src/lib/postApi.ts
+++ b/apps/web/src/lib/postApi.ts
@@ -70,7 +70,10 @@ export interface PostCreateRequest {
 }
 
 // 게시글 수정 요청 타입
+// Before: postType 누락 → 백엔드 @NotBlank 검증 실패로 수정 불가
+// After: postType 필수 필드로 추가
 export interface PostUpdateRequest {
+  postType: 'SELL' | 'BUY';
   categoryId?: number;
   itemName?: string;
   currencyType?: 'BELL' | 'MILE_TICKET';


### PR DESCRIPTION
## Summary
- 홈화면/검색에서 거래 완료(COMPLETED) 게시글 숨김
- 게시글 수정 시 postType 누락으로 400 에러 발생하던 문제 수정
- 예약중(RESERVED) 상태에서 약속 변경 버튼 추가
- 관심목록에서 가격 0원을 "나눔"으로 표시
- 예약/취소 시 게시글 상태도 함께 변경 (채팅 목록 반영)
- 거래 액션 버튼(약속잡기, 거래완료, 예약취소)을 게시글 작성자에게만 표시
- CodeRabbit 리뷰 반영 (AppointmentModal 분 올림, afterCommit 브로드캐스트)

## Test plan
- [ ] 홈화면에서 거래 완료 게시글이 보이지 않는지 확인
- [ ] 게시글 수정 후 수정하기 버튼이 정상 동작하는지 확인
- [ ] 약속 잡기 후 채팅 목록에서 "예약중" 배지로 변경되는지 확인
- [ ] 예약 취소 후 채팅 목록에서 "판매중" 배지로 복구되는지 확인
- [ ] 채팅을 건 사람(구매자)에게 거래 버튼이 보이지 않는지 확인
- [ ] 게시글 작성자에게만 약속잡기/거래완료/예약취소 버튼이 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 게시글 작성자 전용으로 “약속 변경” 기능이 추가되었습니다.
  * 거래 액션 버튼이 게시글 작성자에게만 표시되도록 권한 기반 표시가 개선되었습니다.

* **개선사항**
  * 게시글 수정 시 거래 유형(SELL/BUY) 정보가 업데이트 요청에 포함됩니다.
  * 즐겨찾기 목록의 가격 표기가 공통 포맷으로 통일되어 일관성이 향상되었습니다.

* **기타**
  * 무료 나눔 상품은 가격이 "나눔"으로 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->