### PR TITLE
fix: 앱 로그아웃 시 네이티브 로그인 화면 미전환 버그 수정

### DIFF
--- a/apps/web/src/context/AuthContext.tsx
+++ b/apps/web/src/context/AuthContext.tsx
@@ -167,7 +167,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     // Before: WebView에서 홈으로 리다이렉트만 수행 → 네이티브 토큰 미제거로 로그인 상태 유지
     // After: 네이티브 앱에 로그아웃 요청 → 토큰 제거 후 로그인 화면으로 전환
     if (isWebView()) {
-      requestNativeLogout();
+      // 네이티브 로그아웃 요청 실패 시 홈으로 리다이렉트 - CodeRabbit 리뷰 반영
+      if (!requestNativeLogout()) {
+        window.location.href = '/';
+      }
       return;
     }
 

--- a/apps/web/src/context/AuthContext.tsx
+++ b/apps/web/src/context/AuthContext.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { createContext, useContext, useState, useEffect, useCallback, ReactNode } from 'react';
-import { isWebView } from '@/lib/nativeBridge';
+import { isWebView, requestNativeLogout } from '@/lib/nativeBridge';
 
 // 사용자 정보 타입
 interface User {
@@ -164,13 +164,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setAccessToken(null);
     setUser(null);
 
-    // Before: 무조건 Cognito 로그아웃 리다이렉트 - WebView에서 Invalid Request 에러 발생
-    // After: WebView에서는 Cognito 로그아웃 스킵 (앱이 자체 세션 관리)
-    // WebView 환경에서는 Cognito 로그아웃 스킵
-    // 앱은 네이티브 SDK로 세션을 관리하므로 웹 Cognito 세션 정리 불필요
+    // Before: WebView에서 홈으로 리다이렉트만 수행 → 네이티브 토큰 미제거로 로그인 상태 유지
+    // After: 네이티브 앱에 로그아웃 요청 → 토큰 제거 후 로그인 화면으로 전환
     if (isWebView()) {
-      // WebView에서는 홈으로 이동만 수행
-      window.location.href = '/';
+      requestNativeLogout();
       return;
     }
 


### PR DESCRIPTION
## 문제

앱에서 프로필 탭 → 로그아웃 버튼을 누르면 **SDK 로그인 화면으로 이동하지 않고, 로그인된 상태로 홈 화면으로 이동**하는 버그.

## 원인 분석

### 로그아웃 흐름 (수정 전)

```
[사용자] 로그아웃 클릭
    ↓
[Web - AuthContext.tsx logout()]
    ↓ localStorage 토큰 제거
    ↓ 백엔드 /api/auth/logout 호출 (쿠키 삭제)
    ↓
[WebView 분기] window.location.href = '/'  ← ❌ 홈으로 리다이렉트만 수행
    ↓
[네이티브 앱] REQUEST_LOGOUT 메시지를 받지 못함
    ↓ SecureStore의 accessToken이 그대로 남아있음
    ↓ isAuthenticated = true 유지
    ↓
[결과] 웹뷰가 홈 페이지를 다시 로드하고, 네이티브 앱이 저장된 토큰을 재주입 → 로그인 상태 유지
```

### 핵심 원인

`AuthContext.tsx`의 `logout()` 함수에서 WebView 환경일 때:
- `window.location.href = '/'`로 **웹 페이지만 홈으로 리다이렉트**
- **네이티브 앱에 `REQUEST_LOGOUT` 메시지를 보내지 않음**
- 결과적으로 네이티브 앱의 `SecureStore`에 토큰이 남아있어 로그인 상태가 유지됨

이미 `nativeBridge.ts`에 `requestNativeLogout()` 함수가 구현되어 있고, `HomeScreen.tsx`에서 `REQUEST_LOGOUT` 수신 시 토큰 제거 + 로그인 화면 전환 로직도 구현되어 있었지만, **`logout()`에서 호출하지 않고 있었음**.

## 수정 내용

### `apps/web/src/context/AuthContext.tsx`

```typescript
// Before: 홈으로 리다이렉트만 수행 → 네이티브 토큰 미제거
if (isWebView()) {
  window.location.href = '/';
  return;
}

// After: 네이티브 앱에 로그아웃 요청 → 토큰 제거 후 로그인 화면 전환
if (isWebView()) {
  requestNativeLogout();
  return;
}
```

### 수정 후 흐름

```
[사용자] 로그아웃 클릭
    ↓
[Web - AuthContext.tsx logout()]
    ↓ localStorage 토큰 제거
    ↓ 백엔드 /api/auth/logout 호출 (쿠키 삭제)
    ↓
[WebView 분기] requestNativeLogout()  ← ✅ 네이티브 앱에 메시지 전송
    ↓
[네이티브 앱 - HomeScreen.tsx] REQUEST_LOGOUT 수신
    ↓ SecureStore에서 accessToken 제거
    ↓ onLoginRequest() 호출
    ↓
[결과] LoginScreen(SDK 로그인 화면)으로 전환
```

## 영향 범위

- **앱(WebView) 환경**: 로그아웃 → 네이티브 SDK 로그인 화면으로 정상 전환
- **웹 브라우저 환경**: 변경 없음 (기존 Cognito 로그아웃 흐름 유지)

## Test plan

- [ ] 앱에서 프로필 탭 → 로그아웃 → SDK 로그인 화면으로 이동 확인
- [ ] 로그아웃 후 다시 로그인 정상 작동 확인
- [ ] 웹 브라우저에서 로그아웃 시 Cognito 로그아웃 흐름 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * WebView 환경에서 로그아웃 흐름을 개선하여 기본적으로 네이티브 로그아웃을 우선 호출하고, 실패 시에만 웹으로 대체 리디렉션하여 보다 안정적이고 예측 가능한 로그아웃 환경 제공
  * 불필요한 웹 리디렉션을 줄여 사용자 경험 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->