### PR TITLE
feat: 신규 유저 프로필 설정 페이지 및 리다이렉트

### DIFF
--- a/apps/app/App.tsx
+++ b/apps/app/App.tsx
@@ -11,6 +11,8 @@ import { getCurrentUser, refreshToken } from './src/api/auth';
 export default function App() {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
+  // 프로필 완성 여부 (기본값 true → 기존 유저에 영향 없음)
+  const [isProfileComplete, setIsProfileComplete] = useState(true);
 
   useEffect(() => {
     checkAuthStatus();
@@ -28,7 +30,8 @@ export default function App() {
 
       // 토큰 유효성 검증: 사용자 정보 조회 시도
       try {
-        await getCurrentUser(token);
+        const userData = await getCurrentUser(token);
+        setIsProfileComplete(userData.isProfileComplete);
         setIsAuthenticated(true);
       } catch (error) {
         // 토큰이 만료/무효한 경우 갱신 시도
@@ -53,8 +56,19 @@ export default function App() {
     }
   }
 
-  // 로그인 성공 핸들러
-  function handleLoginSuccess() {
+  // 로그인 성공 핸들러 - 프로필 완성 여부도 확인
+  async function handleLoginSuccess() {
+    try {
+      const token = await getAccessToken();
+      if (token) {
+        const userData = await getCurrentUser(token);
+        setIsProfileComplete(userData.isProfileComplete);
+      }
+    } catch {
+      // 조회 실패해도 로그인은 진행 (프로필 설정은 웹에서도 가능)
+      if (__DEV__) console.log('프로필 정보 조회 실패, 기본값 사용');
+      setIsProfileComplete(true);
+    }
     setIsAuthenticated(true);
   }
 
@@ -79,7 +93,7 @@ export default function App() {
     <SafeAreaProvider>
       <SafeAreaView style={styles.container} edges={['top', 'bottom']}>
         {isAuthenticated ? (
-          <HomeScreen onLoginRequest={handleLoginRequest} />
+          <HomeScreen onLoginRequest={handleLoginRequest} isProfileComplete={isProfileComplete} />
         ) : (
           <LoginScreen onLoginSuccess={handleLoginSuccess} />
         )}

--- a/apps/app/App.tsx
+++ b/apps/app/App.tsx
@@ -39,6 +39,13 @@ export default function App() {
         try {
           const tokenResponse = await refreshToken();
           await saveAccessToken(tokenResponse.accessToken);
+          // 갱신된 토큰으로 프로필 완성 여부 재확인 - CodeRabbit 리뷰 반영
+          try {
+            const userData = await getCurrentUser(tokenResponse.accessToken);
+            setIsProfileComplete(userData.isProfileComplete);
+          } catch {
+            if (__DEV__) console.log('갱신 후 프로필 조회 실패, 기본값 사용');
+          }
           setIsAuthenticated(true);
         } catch (refreshError) {
           // 갱신도 실패하면 로그아웃 처리

--- a/apps/app/src/screens/HomeScreen.tsx
+++ b/apps/app/src/screens/HomeScreen.tsx
@@ -13,9 +13,10 @@ interface NativeMessage {
 
 interface HomeScreenProps {
   onLoginRequest: () => void;
+  isProfileComplete: boolean;
 }
 
-export default function HomeScreen({ onLoginRequest }: HomeScreenProps) {
+export default function HomeScreen({ onLoginRequest, isProfileComplete }: HomeScreenProps) {
   const [token, setToken] = React.useState<string | null>(null);
   const [isLoading, setIsLoading] = React.useState(true);
   const [canGoBack, setCanGoBack] = React.useState(false);
@@ -90,7 +91,7 @@ export default function HomeScreen({ onLoginRequest }: HomeScreenProps) {
     <View style={styles.container}>
       <WebView
         ref={webViewRef}
-        source={{ uri: WEB_URL }}
+        source={{ uri: isProfileComplete ? WEB_URL : `${WEB_URL}/profile/setup` }}
         style={styles.webview}
         injectedJavaScriptBeforeContentLoaded={injectedJavaScriptBeforeContentLoaded}
         onNavigationStateChange={(navState: WebViewNavigation) => {

--- a/apps/web/src/app/auth/callback/page.tsx
+++ b/apps/web/src/app/auth/callback/page.tsx
@@ -47,7 +47,7 @@ function CallbackHandler() {
             const userData = await res.json();
             // 프로필 미완성 시 프로필 설정 페이지로 리다이렉트
             if (!userData.isProfileComplete) {
-              router.push('/profile/edit');
+              router.push('/profile/setup');
               return;
             }
           }

--- a/apps/web/src/app/profile/setup/page.tsx
+++ b/apps/web/src/app/profile/setup/page.tsx
@@ -1,0 +1,264 @@
+"use client";
+
+import Image from "next/image";
+import { useRouter } from "next/navigation";
+import { useState, useEffect } from "react";
+import { useAuth } from "@/context/AuthContext";
+
+if (!process.env.NEXT_PUBLIC_API_URL) throw new Error('NEXT_PUBLIC_API_URL 환경 변수가 설정되지 않았습니다.');
+const API_URL = process.env.NEXT_PUBLIC_API_URL;
+
+// 신규 유저 프로필 설정 페이지 - /profile/edit 기반, 개인정보 이용 동의 추가
+export default function ProfileSetupPage() {
+  const router = useRouter();
+  const { user, accessToken, isLoading, refreshUser } = useAuth();
+  const [formData, setFormData] = useState({
+    islandName: "",
+    islandSuffix: "섬" as "섬" | "도",
+    name: "",
+    hemisphere: "NORTH",
+    dreamAddress: "",
+  });
+  const [agreedToTerms, setAgreedToTerms] = useState(false);
+  const [isIslandNameValid, setIsIslandNameValid] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // 로그인 확인
+  useEffect(() => {
+    if (!isLoading && !accessToken) {
+      router.push("/login");
+    }
+  }, [isLoading, accessToken, router]);
+
+  // 이미 프로필 완성된 유저는 홈으로 리다이렉트
+  useEffect(() => {
+    if (!isLoading && user?.isProfileComplete) {
+      router.push("/");
+    }
+  }, [isLoading, user, router]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+
+    // 섬 이름 유효성 검사 (접미사 제외 1자 이상)
+    if (name === "islandName") {
+      setIsIslandNameValid(value.length >= 1);
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      // 섬 이름 + 접미사(섬/도) 결합
+      const trimmedName = formData.islandName.trim();
+      const fullIslandName = trimmedName + formData.islandSuffix;
+
+      if (!trimmedName) {
+        setError("섬 이름을 입력해주세요.");
+        setIsSubmitting(false);
+        return;
+      }
+
+      const res = await fetch(`${API_URL}/api/users/me/profile-setup`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${accessToken}`,
+        },
+        body: JSON.stringify({
+          nickname: formData.name.trim(),
+          islandName: fullIslandName,
+          dreamAddress: formData.dreamAddress || null,
+          hemisphere: formData.hemisphere,
+        }),
+      });
+
+      if (res.ok) {
+        // 프로필 정보 갱신 후 홈으로 이동
+        await refreshUser();
+        router.push("/");
+      } else {
+        const errorData = await res.json().catch(() => null);
+        setError(errorData?.message || "프로필 저장에 실패했습니다.");
+      }
+    } catch (err) {
+      console.error("프로필 저장 실패:", err);
+      setError("네트워크 오류가 발생했습니다.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  // 로딩 중
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-white flex items-center justify-center">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-white flex flex-col">
+      {/* 헤더 - 프로필 설정 타이틀 */}
+      <div className="p-4">
+        <h1 className="text-lg font-bold text-gray-800">프로필 설정</h1>
+        <p className="text-sm text-gray-500 mt-1">거래를 시작하기 전에 프로필을 설정해주세요</p>
+      </div>
+
+      {/* 프로필 설정 폼 */}
+      <div className="flex-1 flex flex-col items-center px-8 pt-4">
+        {/* 프로필 이미지 */}
+        <div className="mb-4 flex flex-col items-center">
+          <Image
+            src={process.env.NEXT_PUBLIC_ICON_ISLAND || "/icons/island.png"}
+            alt="프로필 이미지"
+            width={112}
+            height={112}
+            className="rounded-full object-cover border-4 border-gray-200"
+          />
+        </div>
+
+        {/* 입력 폼 */}
+        <form onSubmit={handleSubmit} className="w-full max-w-sm space-y-4">
+          {/* 섬 이름 */}
+          <div>
+            <label className="block text-gray-800 font-medium mb-1">섬 이름</label>
+            <div className="flex gap-2">
+              <input
+                type="text"
+                name="islandName"
+                value={formData.islandName}
+                onChange={handleChange}
+                placeholder="섬 이름"
+                className="flex-1 px-4 py-3 rounded-lg border border-gray-300 bg-white text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
+              />
+              {/* 섬/도 선택 버튼 */}
+              <div className="flex">
+                <button
+                  type="button"
+                  onClick={() => setFormData((prev) => ({ ...prev, islandSuffix: "섬" }))}
+                  className={`px-4 py-3 rounded-l-lg text-sm font-medium border transition-colors ${
+                    formData.islandSuffix === "섬"
+                      ? "border-primary bg-primary/10 text-primary border-r-0"
+                      : "border-gray-300 text-gray-700 hover:border-gray-400 border-r-0"
+                  }`}
+                >
+                  섬
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setFormData((prev) => ({ ...prev, islandSuffix: "도" }))}
+                  className={`px-4 py-3 rounded-r-lg text-sm font-medium border transition-colors ${
+                    formData.islandSuffix === "도"
+                      ? "border-primary bg-primary/10 text-primary"
+                      : "border-gray-300 text-gray-700 hover:border-gray-400"
+                  }`}
+                >
+                  도
+                </button>
+              </div>
+            </div>
+            {formData.islandName && (
+              <p className="text-sm mt-1 text-gray-500">
+                &quot;{formData.islandName}{formData.islandSuffix}&quot;(으)로 저장됩니다.
+              </p>
+            )}
+          </div>
+
+          {/* 이름 */}
+          <div>
+            <label className="block text-gray-800 font-medium mb-1">이름</label>
+            <input
+              type="text"
+              name="name"
+              value={formData.name}
+              onChange={handleChange}
+              placeholder="이름을 입력하세요"
+              className="w-full px-4 py-3 rounded-lg border border-gray-300 bg-white text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
+            />
+          </div>
+
+          {/* 반구 */}
+          <div>
+            <label className="block text-gray-800 font-medium mb-1">반구</label>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={() => setFormData((prev) => ({ ...prev, hemisphere: "NORTH" }))}
+                className={`flex-1 py-3 rounded-lg text-sm font-medium border transition-colors ${
+                  formData.hemisphere === "NORTH"
+                    ? "border-primary bg-primary/10 text-primary"
+                    : "border-gray-300 text-gray-700 hover:border-gray-400"
+                }`}
+              >
+                북반구
+              </button>
+              <button
+                type="button"
+                onClick={() => setFormData((prev) => ({ ...prev, hemisphere: "SOUTH" }))}
+                className={`flex-1 py-3 rounded-lg text-sm font-medium border transition-colors ${
+                  formData.hemisphere === "SOUTH"
+                    ? "border-primary bg-primary/10 text-primary"
+                    : "border-gray-300 text-gray-700 hover:border-gray-400"
+                }`}
+              >
+                남반구
+              </button>
+            </div>
+          </div>
+
+          {/* 꿈번지 */}
+          <div>
+            <label className="block text-gray-800 font-medium mb-1">꿈번지 (선택)</label>
+            <input
+              type="text"
+              name="dreamAddress"
+              value={formData.dreamAddress}
+              onChange={handleChange}
+              placeholder="DA-0000-0000-0000"
+              className="w-full px-4 py-3 rounded-lg border border-gray-300 bg-white text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
+            />
+          </div>
+
+          {/* 개인정보 이용 동의 */}
+          <div className="pt-2">
+            <label className="flex items-start gap-3 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={agreedToTerms}
+                onChange={(e) => setAgreedToTerms(e.target.checked)}
+                className="mt-1 w-5 h-5 rounded border-gray-300 text-primary focus:ring-primary cursor-pointer"
+              />
+              <span className="text-sm text-gray-700">
+                <span className="font-medium">[필수]</span> 개인정보 수집 및 이용에 동의합니다.
+                닉네임, 섬 이름 등 프로필 정보는 거래 서비스 제공을 위해 수집되며, 회원 탈퇴 시 삭제됩니다.
+              </span>
+            </label>
+          </div>
+
+          {/* 에러 메시지 */}
+          {error && (
+            <div className="p-3 rounded-lg bg-red-50 border border-red-200">
+              <p className="text-red-600 text-sm">{error}</p>
+            </div>
+          )}
+
+          {/* 시작하기 버튼 */}
+          <button
+            type="submit"
+            disabled={!isIslandNameValid || !formData.name || !agreedToTerms || isSubmitting}
+            className="w-full py-3 rounded-lg bg-primary text-white font-semibold hover:bg-primary-dark transition-colors disabled:opacity-50 disabled:cursor-not-allowed mt-6"
+          >
+            {isSubmitting ? "설정 중..." : "시작하기"}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/profile/setup/page.tsx
+++ b/apps/web/src/app/profile/setup/page.tsx
@@ -20,7 +20,6 @@ export default function ProfileSetupPage() {
     dreamAddress: "",
   });
   const [agreedToTerms, setAgreedToTerms] = useState(false);
-  const [isIslandNameValid, setIsIslandNameValid] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -41,11 +40,6 @@ export default function ProfileSetupPage() {
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
     const { name, value } = e.target;
     setFormData((prev) => ({ ...prev, [name]: value }));
-
-    // 섬 이름 유효성 검사 (접미사 제외 1자 이상)
-    if (name === "islandName") {
-      setIsIslandNameValid(value.length >= 1);
-    }
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -60,6 +54,12 @@ export default function ProfileSetupPage() {
 
       if (!trimmedName) {
         setError("섬 이름을 입력해주세요.");
+        setIsSubmitting(false);
+        return;
+      }
+
+      if (!formData.name.trim()) {
+        setError("이름을 입력해주세요.");
         setIsSubmitting(false);
         return;
       }
@@ -252,7 +252,7 @@ export default function ProfileSetupPage() {
           {/* 시작하기 버튼 */}
           <button
             type="submit"
-            disabled={!isIslandNameValid || !formData.name || !agreedToTerms || isSubmitting}
+            disabled={!formData.islandName.trim() || !formData.name.trim() || !agreedToTerms || isSubmitting}
             className="w-full py-3 rounded-lg bg-primary text-white font-semibold hover:bg-primary-dark transition-colors disabled:opacity-50 disabled:cursor-not-allowed mt-6"
           >
             {isSubmitting ? "설정 중..." : "시작하기"}


### PR DESCRIPTION
## Summary
- 네이티브 SDK(Google/Kakao) 로그인 시 신규 유저가 프로필 설정 없이 홈으로 이동하는 버그 수정
- `/profile/setup` 페이지 신규 생성 (개인정보 이용 동의 체크박스 포함)
- App.tsx에서 로그인 후 `isProfileComplete` 체크하여 신규 유저는 프로필 설정 페이지로 리다이렉트

## 변경 내용
- **apps/app/App.tsx**: 로그인 성공 후 `/api/users/me` 호출하여 프로필 완성 여부 확인, `isProfileComplete` prop을 HomeScreen에 전달
- **apps/app/src/screens/HomeScreen.tsx**: `isProfileComplete`가 false이면 WebView를 `/profile/setup`으로 로드
- **apps/web/src/app/profile/setup/page.tsx**: 신규 유저 전용 프로필 설정 페이지 (섬 이름, 닉네임, 반구, 꿈번지 + 개인정보 동의)
- **apps/web/src/app/auth/callback/page.tsx**: 웹 Cognito 로그인 리다이렉트 경로도 `/profile/setup`으로 통일

## Test plan
- [ ] 새 계정으로 Google/Kakao 네이티브 SDK 로그인 → `/profile/setup` 페이지 표시 확인
- [ ] 개인정보 동의 미체크 시 "시작하기" 버튼 비활성 확인
- [ ] 프로필 설정 완료 후 홈(`/`)으로 이동 확인
- [ ] 기존 유저(프로필 완성)로 로그인 시 바로 홈으로 이동 확인
- [ ] 앱 재시작 시 기존 유저는 프로필 설정 스킵 확인
- [ ] ⚠️ 앱 코드 변경으로 **EAS 빌드 필요**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 새 사용자용 프로필 설정 페이지가 추가되었습니다.
  * 섬 이름(접미사 선택), 닉네임, 반구, 꿈의 주소 입력과 필수 개인정보 동의가 포함된 폼이 제공됩니다.
  * 프로필 미완료 시 앱이 자동으로 프로필 설정 화면으로 이동합니다.
* **개선**
  * 로그인 흐름에서 프로필 정보 조회 실패 시에도 정상 진입되도록 오류 처리가 강화되었습니다.
* **동작 변경**
  * 프로필 미완료 사용자의 리다이렉트 대상이 프로필 설정 페이지로 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->