### PR TITLE
fix: Android 뒤로가기 홈 이동 + 더블탭 종료 & 핀치 줌 차단

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ apps/web/out/
 # Mobile (React Native - 나중에)
 apps/mobile/node_modules/
 apps/mobile/.expo/
+.expo/
 apps/mobile/android/
 apps/mobile/ios/
 *.apk

--- a/apps/app/src/screens/HomeScreen.tsx
+++ b/apps/app/src/screens/HomeScreen.tsx
@@ -1,7 +1,7 @@
 // 홈 화면 (WebView로 웹앱 표시)
 
 import React, { useRef } from 'react';
-import { StyleSheet, View, ActivityIndicator, Text, BackHandler, Platform } from 'react-native';
+import { StyleSheet, View, ActivityIndicator, Text, BackHandler, Platform, ToastAndroid } from 'react-native';
 import { WebView, WebViewMessageEvent, WebViewNavigation } from 'react-native-webview';
 import { getAccessToken, removeAccessToken } from '../auth';
 
@@ -19,8 +19,9 @@ interface HomeScreenProps {
 export default function HomeScreen({ onLoginRequest, isProfileComplete }: HomeScreenProps) {
   const [token, setToken] = React.useState<string | null>(null);
   const [isLoading, setIsLoading] = React.useState(true);
-  const [canGoBack, setCanGoBack] = React.useState(false);
+  const [currentUrl, setCurrentUrl] = React.useState('');
   const webViewRef = useRef<WebView>(null);
+  const lastBackPressRef = React.useRef(0);
 
   // 환경 변수를 컴포넌트 내부에서 가져옴 (Metro 연결 후 실행됨)
   const WEB_URL = process.env.EXPO_PUBLIC_WEB_URL;
@@ -30,20 +31,45 @@ export default function HomeScreen({ onLoginRequest, isProfileComplete }: HomeSc
   }, []);
 
   // Android 하드웨어 뒤로가기 버튼/제스처 처리
+  // 서브 페이지 → 홈 이동, 홈에서 → 토스트 알림 후 2초 내 재누름 시 앱 종료
   React.useEffect(() => {
     if (Platform.OS !== 'android') return;
 
     const onBackPress = () => {
-      if (canGoBack && webViewRef.current) {
-        webViewRef.current.goBack();
-        return true; // 이벤트 소비 (앱 종료 방지)
+      const now = Date.now();
+
+      // 홈 화면 판단: URL이 없거나, WEB_URL과 같거나, 경로가 '/'인 경우
+      let isHome = true;
+      try {
+        if (currentUrl && WEB_URL) {
+          const path = new URL(currentUrl).pathname;
+          isHome = path === '/' || path === '';
+        }
+      } catch {
+        isHome = true;
       }
-      return false; // 기본 동작 (앱 종료)
+
+      if (!isHome && webViewRef.current) {
+        // 서브 페이지에서 → 홈으로 이동
+        webViewRef.current.injectJavaScript(`window.location.href='${WEB_URL}'; true;`);
+        return true;
+      }
+
+      // 홈에서 2초 내 재누름 → 앱 종료
+      if (now - lastBackPressRef.current < 2000) {
+        BackHandler.exitApp();
+        return true;
+      }
+
+      // 홈에서 첫 번째 누름 → 토스트 알림
+      lastBackPressRef.current = now;
+      ToastAndroid.show('한 번 더 누르면 종료됩니다', ToastAndroid.SHORT);
+      return true;
     };
 
     const subscription = BackHandler.addEventListener('hardwareBackPress', onBackPress);
     return () => subscription.remove();
-  }, [canGoBack]);
+  }, [currentUrl, WEB_URL]);
 
   async function loadToken() {
     try {
@@ -95,7 +121,7 @@ export default function HomeScreen({ onLoginRequest, isProfileComplete }: HomeSc
         style={styles.webview}
         injectedJavaScriptBeforeContentLoaded={injectedJavaScriptBeforeContentLoaded}
         onNavigationStateChange={(navState: WebViewNavigation) => {
-          setCanGoBack(navState.canGoBack);
+          setCurrentUrl(navState.url);
         }}
         onMessage={(event: WebViewMessageEvent) => {
           // 웹에서 앱으로 메시지 전달 처리

--- a/apps/app/src/screens/HomeScreen.tsx
+++ b/apps/app/src/screens/HomeScreen.tsx
@@ -7,7 +7,7 @@ import { getAccessToken, removeAccessToken } from '../auth';
 
 // WebView에서 전달받는 메시지 타입
 interface NativeMessage {
-  type: 'REQUEST_LOGIN' | 'REQUEST_LOGOUT';
+  type: 'REQUEST_LOGIN' | 'REQUEST_LOGOUT' | 'URL_CHANGED';
   payload?: Record<string, unknown>;
 }
 
@@ -113,14 +113,39 @@ export default function HomeScreen({ onLoginRequest, isProfileComplete }: HomeSc
     document.head.appendChild(meta);
   `;
 
+  // SPA 라우트 변경 감지 스크립트 (pushState/replaceState/popstate 패치)
+  // onNavigationStateChange는 SPA 내부 라우팅을 감지하지 못하므로 별도 패치 필요
+  const urlChangeScript = `
+    (function() {
+      var notify = function() {
+        window.ReactNativeWebView && window.ReactNativeWebView.postMessage(
+          JSON.stringify({ type: 'URL_CHANGED', payload: { url: window.location.href } })
+        );
+      };
+      var origPush = history.pushState;
+      var origReplace = history.replaceState;
+      history.pushState = function() {
+        origPush.apply(this, arguments);
+        notify();
+      };
+      history.replaceState = function() {
+        origReplace.apply(this, arguments);
+        notify();
+      };
+      window.addEventListener('popstate', notify);
+    })();
+  `;
+
   const injectedJavaScriptBeforeContentLoaded = token
     ? `
       localStorage.setItem('accessToken', ${JSON.stringify(token)});
       ${zoomBlockScript}
+      ${urlChangeScript}
       true;
     `
     : `
       ${zoomBlockScript}
+      ${urlChangeScript}
       true;
     `;
 
@@ -150,6 +175,12 @@ export default function HomeScreen({ onLoginRequest, isProfileComplete }: HomeSc
                 // WebView에서 로그아웃 요청 - 토큰 제거 후 로그인 화면으로
                 if (__DEV__) console.log('로그아웃 요청 수신');
                 removeAccessToken().then(() => onLoginRequest());
+                break;
+              case 'URL_CHANGED':
+                // SPA 라우트 변경 감지 (pushState/replaceState/popstate)
+                if (message.payload?.url) {
+                  setCurrentUrl(message.payload.url as string);
+                }
                 break;
               default:
                 if (__DEV__) console.log('알 수 없는 메시지 타입:', message.type);

--- a/apps/app/src/screens/HomeScreen.tsx
+++ b/apps/app/src/screens/HomeScreen.tsx
@@ -51,7 +51,7 @@ export default function HomeScreen({ onLoginRequest, isProfileComplete }: HomeSc
 
       if (!isHome && webViewRef.current) {
         // 서브 페이지에서 → 홈으로 이동
-        webViewRef.current.injectJavaScript(`window.location.href='${WEB_URL}'; true;`);
+        webViewRef.current.injectJavaScript(`window.location.href=${JSON.stringify(WEB_URL)}; true;`);
         return true;
       }
 

--- a/apps/app/src/screens/HomeScreen.tsx
+++ b/apps/app/src/screens/HomeScreen.tsx
@@ -103,15 +103,26 @@ export default function HomeScreen({ onLoginRequest, isProfileComplete }: HomeSc
     );
   }
 
-  // WebView에 토큰 주입 스크립트 (페이지 로드 전에 실행)
+  // 핀치 줌 차단 + 토큰 주입 스크립트 (페이지 로드 전에 실행)
   // Before: injectedJavaScript - 페이지 로드 후 실행되어 웹앱이 먼저 로그인 체크함
   // After: injectedJavaScriptBeforeContentLoaded - 페이지 로드 전에 토큰 주입
+  const zoomBlockScript = `
+    var meta = document.createElement('meta');
+    meta.name = 'viewport';
+    meta.content = 'width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no';
+    document.head.appendChild(meta);
+  `;
+
   const injectedJavaScriptBeforeContentLoaded = token
     ? `
       localStorage.setItem('accessToken', ${JSON.stringify(token)});
+      ${zoomBlockScript}
       true;
     `
-    : '';
+    : `
+      ${zoomBlockScript}
+      true;
+    `;
 
   return (
     <View style={styles.container}>
@@ -149,6 +160,7 @@ export default function HomeScreen({ onLoginRequest, isProfileComplete }: HomeSc
         }}
         javaScriptEnabled={true}
         domStorageEnabled={true}
+        scalesPageToFit={false}
         startInLoadingState={true}
         renderLoading={() => (
           <View style={styles.loadingContainer}>


### PR DESCRIPTION
## Summary
- Android 뒤로가기 버튼/제스처 동작을 변경하여 UX 개선
- WebView 핀치 줌(확대 제스처)을 차단하여 의도치 않은 화면 확대 방지
- 루트 `.expo/` 디렉토리를 `.gitignore`에 추가

## 문제점

### 1. 뒤로가기 버튼이 WebView 히스토리를 따라감
기존에는 Android 뒤로가기 버튼/제스처를 누르면 WebView의 브라우저 히스토리(`canGoBack`)를 기반으로 이전 페이지로 이동했습니다.

```typescript
// Before: WebView 히스토리 기반 뒤로가기
const onBackPress = () => {
  if (canGoBack && webViewRef.current) {
    webViewRef.current.goBack(); // 브라우저 히스토리 뒤로가기
    return true;
  }
  return false; // 히스토리 없으면 바로 앱 종료
};
```

**문제**: 유저가 여러 페이지를 탐색한 후 뒤로가기를 누르면 방문했던 모든 페이지를 역순으로 거쳐야 했고, 히스토리가 없으면 확인 없이 앱이 즉시 종료되었습니다.

### 2. WebView에서 핀치 줌이 가능함
WebView에 별도의 줌 제한이 없어서, 홈화면이나 다른 페이지에서 핀치 제스처로 화면이 확대되는 문제가 있었습니다.

## 해결 방법

### 1. 뒤로가기 버튼 로직 변경 (`HomeScreen.tsx`)

3단계 동작으로 변경:

| 현재 위치 | 동작 | 결과 |
|-----------|------|------|
| 서브 페이지 (`/posts/123`, `/chat` 등) | 뒤로가기 1회 | 홈 화면(`/`)으로 이동 |
| 홈 화면 (`/`) | 뒤로가기 1회 | "한 번 더 누르면 종료됩니다" 토스트 표시 |
| 홈 화면 (`/`) | 2초 내 뒤로가기 재누름 | 앱 종료 (`BackHandler.exitApp()`) |

```typescript
// After: 홈 이동 → 토스트 → 더블탭 종료
const onBackPress = () => {
  const now = Date.now();

  // URL pathname으로 홈 화면 판단
  let isHome = true;
  try {
    if (currentUrl && WEB_URL) {
      const path = new URL(currentUrl).pathname;
      isHome = path === '/' || path === '';
    }
  } catch {
    isHome = true;
  }

  // 서브 페이지 → 홈으로 이동
  if (!isHome && webViewRef.current) {
    webViewRef.current.injectJavaScript(`window.location.href='${WEB_URL}'; true;`);
    return true;
  }

  // 홈에서 2초 내 재누름 → 앱 종료
  if (now - lastBackPressRef.current < 2000) {
    BackHandler.exitApp();
    return true;
  }

  // 홈에서 첫 번째 누름 → 토스트 알림
  lastBackPressRef.current = now;
  ToastAndroid.show('한 번 더 누르면 종료됩니다', ToastAndroid.SHORT);
  return true;
};
```

**핵심 변경점:**
- `canGoBack` state → `currentUrl` state로 변경 (URL 기반 홈 판단)
- `webViewRef.current.goBack()` → `injectJavaScript(window.location.href=...)` (히스토리 대신 홈으로 직접 이동)
- `lastBackPressRef` (useRef)로 마지막 누른 시간 추적, 2초 타임아웃 적용
- `ToastAndroid.show()`로 네이티브 토스트 알림 표시

### 2. 핀치 줌 차단 (`HomeScreen.tsx`)

두 가지 방법을 동시 적용:

**a) viewport meta 태그 주입** — `injectedJavaScriptBeforeContentLoaded`에 viewport 제한 스크립트 추가:
```javascript
var meta = document.createElement('meta');
meta.name = 'viewport';
meta.content = 'width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no';
document.head.appendChild(meta);
```

**b) WebView prop 추가:**
```tsx
<WebView scalesPageToFit={false} ... />
```

토큰 유무와 관계없이 항상 줌 차단 스크립트가 실행되도록 분기 처리했습니다.

## 변경된 파일
- `apps/app/src/screens/HomeScreen.tsx` — 뒤로가기 로직 + 핀치 줌 차단
- `.gitignore` — 루트 `.expo/` 디렉토리 추가

## Test plan
- [ ] 서브 페이지(게시글 상세, 채팅 등)에서 뒤로가기 → 홈 화면으로 이동 확인
- [ ] 홈 화면에서 뒤로가기 → "한 번 더 누르면 종료됩니다" 토스트 표시 확인
- [ ] 홈에서 2초 내 뒤로가기 재누름 → 앱 종료 확인
- [ ] 2초 경과 후 다시 누르면 토스트만 표시 (종료 안 됨) 확인
- [ ] 홈 화면에서 핀치 줌 시도 → 확대 안 되는지 확인
- [ ] 서브 페이지에서 핀치 줌 시도 → 확대 안 되는지 확인
- [ ] 토큰 없는 상태(프로필 설정 페이지)에서도 줌 차단 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * Android 뒤로가기 동작 개선: 홈에서는 2초 내 두 번 누르면 앱 종료, 하위 페이지에서는 이전 화면으로 이동
  * 핀치-줌 및 페이지 스케일링 비활성화로 일관된 화면 표시

* **기타**
  * 프로젝트 루트의 Expo 자산(.expo/)을 버전관리에서 제외하도록 설정 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->