### PR TITLE
feat: Google Play Store 계정 삭제 페이지 추가 및 프로필 수정 페이지 개선

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ apps/web/out/
 # Mobile (React Native - 나중에)
 apps/mobile/node_modules/
 apps/mobile/.expo/
+.expo/
 apps/mobile/android/
 apps/mobile/ios/
 *.apk

--- a/apps/app/eas.json
+++ b/apps/app/eas.json
@@ -25,7 +25,9 @@
       }
     },
     "production": {
-      "android": {},
+      "android": {
+        "buildType": "app-bundle"
+      },
       "env": {
         "EXPO_PUBLIC_WEB_URL": "https://ac-trading.vercel.app",
         "EXPO_PUBLIC_API_URL": "https://ac-trading-production.up.railway.app",

--- a/apps/app/src/screens/HomeScreen.tsx
+++ b/apps/app/src/screens/HomeScreen.tsx
@@ -1,7 +1,7 @@
 // 홈 화면 (WebView로 웹앱 표시)
 
 import React, { useRef } from 'react';
-import { StyleSheet, View, ActivityIndicator, Text, BackHandler, Platform } from 'react-native';
+import { StyleSheet, View, ActivityIndicator, Text, BackHandler, Platform, ToastAndroid } from 'react-native';
 import { WebView, WebViewMessageEvent, WebViewNavigation } from 'react-native-webview';
 import { getAccessToken, removeAccessToken } from '../auth';
 
@@ -19,8 +19,9 @@ interface HomeScreenProps {
 export default function HomeScreen({ onLoginRequest, isProfileComplete }: HomeScreenProps) {
   const [token, setToken] = React.useState<string | null>(null);
   const [isLoading, setIsLoading] = React.useState(true);
-  const [canGoBack, setCanGoBack] = React.useState(false);
+  const [currentUrl, setCurrentUrl] = React.useState('');
   const webViewRef = useRef<WebView>(null);
+  const lastBackPressRef = React.useRef(0);
 
   // 환경 변수를 컴포넌트 내부에서 가져옴 (Metro 연결 후 실행됨)
   const WEB_URL = process.env.EXPO_PUBLIC_WEB_URL;
@@ -30,20 +31,45 @@ export default function HomeScreen({ onLoginRequest, isProfileComplete }: HomeSc
   }, []);
 
   // Android 하드웨어 뒤로가기 버튼/제스처 처리
+  // 서브 페이지 → 홈 이동, 홈에서 → 토스트 알림 후 2초 내 재누름 시 앱 종료
   React.useEffect(() => {
     if (Platform.OS !== 'android') return;
 
     const onBackPress = () => {
-      if (canGoBack && webViewRef.current) {
-        webViewRef.current.goBack();
-        return true; // 이벤트 소비 (앱 종료 방지)
+      const now = Date.now();
+
+      // 홈 화면 판단: URL이 없거나, WEB_URL과 같거나, 경로가 '/'인 경우
+      let isHome = true;
+      try {
+        if (currentUrl && WEB_URL) {
+          const path = new URL(currentUrl).pathname;
+          isHome = path === '/' || path === '';
+        }
+      } catch {
+        isHome = true;
       }
-      return false; // 기본 동작 (앱 종료)
+
+      if (!isHome && webViewRef.current) {
+        // 서브 페이지에서 → 홈으로 이동
+        webViewRef.current.injectJavaScript(`window.location.href='${WEB_URL}'; true;`);
+        return true;
+      }
+
+      // 홈에서 2초 내 재누름 → 앱 종료
+      if (now - lastBackPressRef.current < 2000) {
+        BackHandler.exitApp();
+        return true;
+      }
+
+      // 홈에서 첫 번째 누름 → 토스트 알림
+      lastBackPressRef.current = now;
+      ToastAndroid.show('한 번 더 누르면 종료됩니다', ToastAndroid.SHORT);
+      return true;
     };
 
     const subscription = BackHandler.addEventListener('hardwareBackPress', onBackPress);
     return () => subscription.remove();
-  }, [canGoBack]);
+  }, [currentUrl, WEB_URL]);
 
   async function loadToken() {
     try {
@@ -95,7 +121,7 @@ export default function HomeScreen({ onLoginRequest, isProfileComplete }: HomeSc
         style={styles.webview}
         injectedJavaScriptBeforeContentLoaded={injectedJavaScriptBeforeContentLoaded}
         onNavigationStateChange={(navState: WebViewNavigation) => {
-          setCanGoBack(navState.canGoBack);
+          setCurrentUrl(navState.url);
         }}
         onMessage={(event: WebViewMessageEvent) => {
           // 웹에서 앱으로 메시지 전달 처리

--- a/apps/app/src/screens/HomeScreen.tsx
+++ b/apps/app/src/screens/HomeScreen.tsx
@@ -7,7 +7,7 @@ import { getAccessToken, removeAccessToken } from '../auth';
 
 // WebView에서 전달받는 메시지 타입
 interface NativeMessage {
-  type: 'REQUEST_LOGIN' | 'REQUEST_LOGOUT';
+  type: 'REQUEST_LOGIN' | 'REQUEST_LOGOUT' | 'URL_CHANGED';
   payload?: Record<string, unknown>;
 }
 
@@ -113,14 +113,39 @@ export default function HomeScreen({ onLoginRequest, isProfileComplete }: HomeSc
     document.head.appendChild(meta);
   `;
 
+  // SPA 라우트 변경 감지 스크립트 (pushState/replaceState/popstate 패치)
+  // onNavigationStateChange는 SPA 내부 라우팅을 감지하지 못하므로 별도 패치 필요
+  const urlChangeScript = `
+    (function() {
+      var notify = function() {
+        window.ReactNativeWebView && window.ReactNativeWebView.postMessage(
+          JSON.stringify({ type: 'URL_CHANGED', payload: { url: window.location.href } })
+        );
+      };
+      var origPush = history.pushState;
+      var origReplace = history.replaceState;
+      history.pushState = function() {
+        origPush.apply(this, arguments);
+        notify();
+      };
+      history.replaceState = function() {
+        origReplace.apply(this, arguments);
+        notify();
+      };
+      window.addEventListener('popstate', notify);
+    })();
+  `;
+
   const injectedJavaScriptBeforeContentLoaded = token
     ? `
       localStorage.setItem('accessToken', ${JSON.stringify(token)});
       ${zoomBlockScript}
+      ${urlChangeScript}
       true;
     `
     : `
       ${zoomBlockScript}
+      ${urlChangeScript}
       true;
     `;
 
@@ -150,6 +175,12 @@ export default function HomeScreen({ onLoginRequest, isProfileComplete }: HomeSc
                 // WebView에서 로그아웃 요청 - 토큰 제거 후 로그인 화면으로
                 if (__DEV__) console.log('로그아웃 요청 수신');
                 removeAccessToken().then(() => onLoginRequest());
+                break;
+              case 'URL_CHANGED':
+                // SPA 라우트 변경 감지 (pushState/replaceState/popstate)
+                if (message.payload?.url) {
+                  setCurrentUrl(message.payload.url as string);
+                }
                 break;
               default:
                 if (__DEV__) console.log('알 수 없는 메시지 타입:', message.type);

--- a/apps/app/src/screens/HomeScreen.tsx
+++ b/apps/app/src/screens/HomeScreen.tsx
@@ -51,7 +51,7 @@ export default function HomeScreen({ onLoginRequest, isProfileComplete }: HomeSc
 
       if (!isHome && webViewRef.current) {
         // 서브 페이지에서 → 홈으로 이동
-        webViewRef.current.injectJavaScript(`window.location.href='${WEB_URL}'; true;`);
+        webViewRef.current.injectJavaScript(`window.location.href=${JSON.stringify(WEB_URL)}; true;`);
         return true;
       }
 

--- a/apps/app/src/screens/HomeScreen.tsx
+++ b/apps/app/src/screens/HomeScreen.tsx
@@ -103,15 +103,26 @@ export default function HomeScreen({ onLoginRequest, isProfileComplete }: HomeSc
     );
   }
 
-  // WebView에 토큰 주입 스크립트 (페이지 로드 전에 실행)
+  // 핀치 줌 차단 + 토큰 주입 스크립트 (페이지 로드 전에 실행)
   // Before: injectedJavaScript - 페이지 로드 후 실행되어 웹앱이 먼저 로그인 체크함
   // After: injectedJavaScriptBeforeContentLoaded - 페이지 로드 전에 토큰 주입
+  const zoomBlockScript = `
+    var meta = document.createElement('meta');
+    meta.name = 'viewport';
+    meta.content = 'width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no';
+    document.head.appendChild(meta);
+  `;
+
   const injectedJavaScriptBeforeContentLoaded = token
     ? `
       localStorage.setItem('accessToken', ${JSON.stringify(token)});
+      ${zoomBlockScript}
       true;
     `
-    : '';
+    : `
+      ${zoomBlockScript}
+      true;
+    `;
 
   return (
     <View style={styles.container}>
@@ -149,6 +160,7 @@ export default function HomeScreen({ onLoginRequest, isProfileComplete }: HomeSc
         }}
         javaScriptEnabled={true}
         domStorageEnabled={true}
+        scalesPageToFit={false}
         startInLoadingState={true}
         renderLoading={() => (
           <View style={styles.loadingContainer}>

--- a/apps/web/src/app/account-delete/page.tsx
+++ b/apps/web/src/app/account-delete/page.tsx
@@ -57,8 +57,8 @@ export default function AccountDeletePage() {
                   "앱 또는 웹에서 로그인합니다.",
                   "하단 탭의 [프로필] 메뉴로 이동합니다.",
                   "[설정] 아이콘을 탭합니다.",
-                  "[회원 탈퇴] 버튼을 누르고 안내에 따라 진행합니다.",
-                  "탈퇴가 완료되면 계정과 관련 데이터가 즉시 삭제 처리됩니다.",
+                  "[계정 삭제] 버튼을 누르고 안내에 따라 진행합니다.",
+                  "삭제가 완료되면 법령 보관 대상을 제외한 계정 및 관련 데이터가 즉시 삭제 처리됩니다.",
                 ].map((step, i) => (
                   <li key={i} className="flex items-start gap-3">
                     <span
@@ -106,7 +106,8 @@ export default function AccountDeletePage() {
               삭제되는 데이터
             </h2>
             <p className="mb-3">
-              탈퇴 요청 처리 시 다음 데이터가 <strong>즉시 삭제</strong>됩니다.
+              계정 삭제 요청 처리 시 다음 데이터가 <strong>즉시 삭제</strong>됩니다.
+              단, 법령에 따라 보관이 필요한 데이터는 아래 표를 확인해주세요.
             </p>
             <ul className="list-disc pl-5 space-y-1">
               <li>계정 정보 (이메일, 닉네임, 프로필 이미지, 섬 이름)</li>

--- a/apps/web/src/app/account-delete/page.tsx
+++ b/apps/web/src/app/account-delete/page.tsx
@@ -1,0 +1,199 @@
+import { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "계정 삭제 요청 - 거동숲",
+  description: "거동숲 계정 및 데이터 삭제 요청 안내",
+};
+
+// Google Play Store 정책 준수용 계정 삭제 요청 페이지
+export default function AccountDeletePage() {
+  return (
+    <div className="min-h-screen" style={{ backgroundColor: "#FFFFFF" }}>
+      {/* 헤더 */}
+      <header
+        className="sticky top-0 border-b border-gray-200 px-4 py-3"
+        style={{ backgroundColor: "#FFFFFF" }}
+      >
+        <div className="max-w-3xl mx-auto flex items-center gap-3">
+          <Link href="/" className="text-gray-600 hover:text-gray-900">
+            ← 돌아가기
+          </Link>
+          <h1 className="text-lg font-semibold">계정 삭제 요청</h1>
+        </div>
+      </header>
+
+      {/* 본문 */}
+      <main className="max-w-3xl mx-auto px-4 py-8">
+        {/* 앱 식별 */}
+        <div className="mb-8 p-4 rounded-xl border border-gray-100 bg-gray-50">
+          <p className="text-sm text-gray-500">서비스명</p>
+          <p className="text-xl font-bold text-gray-900 mt-1">거동숲</p>
+          <p className="text-sm text-gray-500 mt-1">
+            모여봐요 동물의 숲 아이템 거래 플랫폼
+          </p>
+        </div>
+
+        <div className="prose prose-sm max-w-none text-gray-700 space-y-8">
+          {/* 계정 삭제 방법 */}
+          <section>
+            <h2 className="text-lg font-semibold text-gray-900 mb-4">
+              계정 삭제 요청 방법
+            </h2>
+
+            {/* 방법 1: 앱 내 */}
+            <div className="mb-6">
+              <div
+                className="inline-block text-xs font-semibold px-2 py-1 rounded mb-3"
+                style={{ backgroundColor: "#7ECEC5", color: "#FFFFFF" }}
+              >
+                방법 1 — 앱/웹 내에서 직접 탈퇴
+              </div>
+              <ol className="list-none space-y-3 pl-0">
+                {[
+                  "앱 또는 웹에서 로그인합니다.",
+                  "하단 탭의 [프로필] 메뉴로 이동합니다.",
+                  "[설정] 아이콘을 탭합니다.",
+                  "[회원 탈퇴] 버튼을 누르고 안내에 따라 진행합니다.",
+                  "탈퇴가 완료되면 계정과 관련 데이터가 즉시 삭제 처리됩니다.",
+                ].map((step, i) => (
+                  <li key={i} className="flex items-start gap-3">
+                    <span
+                      className="flex-shrink-0 w-6 h-6 rounded-full text-white text-xs font-bold flex items-center justify-center"
+                      style={{ backgroundColor: "#7ECEC5" }}
+                    >
+                      {i + 1}
+                    </span>
+                    <span>{step}</span>
+                  </li>
+                ))}
+              </ol>
+            </div>
+
+            {/* 방법 2: 이메일 */}
+            <div>
+              <div
+                className="inline-block text-xs font-semibold px-2 py-1 rounded mb-3"
+                style={{ backgroundColor: "#adb5bd", color: "#FFFFFF" }}
+              >
+                방법 2 — 이메일로 요청
+              </div>
+              <p className="mb-2">
+                앱/웹 접근이 어려운 경우 아래 이메일로 계정 삭제를 요청할 수
+                있습니다.
+              </p>
+              <a
+                href="mailto:support@ac-trading.com"
+                className="font-medium underline"
+                style={{ color: "#5BBFB3" }}
+              >
+                support@ac-trading.com
+              </a>
+              <p className="mt-2 text-sm text-gray-500">
+                이메일 제목: [계정 삭제 요청] 가입 이메일 주소 기재
+                <br />
+                처리 기간: 영업일 기준 3일 이내
+              </p>
+            </div>
+          </section>
+
+          {/* 삭제되는 데이터 */}
+          <section>
+            <h2 className="text-lg font-semibold text-gray-900 mb-4">
+              삭제되는 데이터
+            </h2>
+            <p className="mb-3">
+              탈퇴 요청 처리 시 다음 데이터가 <strong>즉시 삭제</strong>됩니다.
+            </p>
+            <ul className="list-disc pl-5 space-y-1">
+              <li>계정 정보 (이메일, 닉네임, 프로필 이미지, 섬 이름)</li>
+              <li>작성한 거래글 및 첨부 이미지</li>
+              <li>채팅 내역</li>
+              <li>받은 후기 및 매너 점수</li>
+              <li>관심 목록 및 키워드 알림 설정</li>
+              <li>자동 수집 정보 (접속 IP, 접속 시간 등)</li>
+            </ul>
+          </section>
+
+          {/* 보관되는 데이터 */}
+          <section>
+            <h2 className="text-lg font-semibold text-gray-900 mb-4">
+              법령에 따라 보관되는 데이터
+            </h2>
+            <p className="mb-3">
+              관련 법령에 의해 아래 데이터는 일정 기간 보관 후 파기됩니다.
+            </p>
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm border-collapse">
+                <thead>
+                  <tr className="border-b border-gray-200">
+                    <th className="text-left py-2 pr-4 font-semibold text-gray-800">
+                      데이터 유형
+                    </th>
+                    <th className="text-left py-2 pr-4 font-semibold text-gray-800">
+                      보관 기간
+                    </th>
+                    <th className="text-left py-2 font-semibold text-gray-800">
+                      근거 법령
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-100">
+                  <tr>
+                    <td className="py-2 pr-4">표시·광고 기록</td>
+                    <td className="py-2 pr-4">6개월</td>
+                    <td className="py-2 text-gray-500">전자상거래법</td>
+                  </tr>
+                  <tr>
+                    <td className="py-2 pr-4">계약·청약철회 기록</td>
+                    <td className="py-2 pr-4">5년</td>
+                    <td className="py-2 text-gray-500">전자상거래법</td>
+                  </tr>
+                  <tr>
+                    <td className="py-2 pr-4">소비자 불만·분쟁처리 기록</td>
+                    <td className="py-2 pr-4">3년</td>
+                    <td className="py-2 text-gray-500">전자상거래법</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <p className="mt-3 text-sm text-gray-500">
+              보관 기간이 경과한 데이터는 복구 불가능한 방법으로 즉시 파기됩니다.
+            </p>
+          </section>
+
+          {/* 문의 */}
+          <section>
+            <h2 className="text-lg font-semibold text-gray-900 mb-3">문의</h2>
+            <p>
+              계정 삭제 관련 추가 문의는{" "}
+              <a
+                href="mailto:support@ac-trading.com"
+                className="underline"
+                style={{ color: "#5BBFB3" }}
+              >
+                support@ac-trading.com
+              </a>
+              으로 연락 주시기 바랍니다.
+            </p>
+          </section>
+        </div>
+      </main>
+
+      {/* 푸터 */}
+      <footer className="border-t border-gray-200 py-6 mt-8">
+        <div className="max-w-3xl mx-auto px-4 text-center text-sm text-gray-500">
+          <Link href="/terms" className="hover:underline">
+            이용약관
+          </Link>
+          <span className="mx-2">|</span>
+          <Link href="/privacy" className="hover:underline">
+            개인정보처리방침
+          </Link>
+          <span className="mx-2">|</span>
+          <span className="font-medium text-gray-700">계정 삭제 요청</span>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/apps/web/src/app/account-delete/page.tsx
+++ b/apps/web/src/app/account-delete/page.tsx
@@ -6,6 +6,9 @@ export const metadata: Metadata = {
   description: "거동숲 계정 및 데이터 삭제 요청 안내",
 };
 
+const SUPPORT_EMAIL =
+  process.env.NEXT_PUBLIC_SUPPORT_EMAIL || "support@ac-trading.com";
+
 // Google Play Store 정책 준수용 계정 삭제 요청 페이지
 export default function AccountDeletePage() {
   return (
@@ -83,11 +86,11 @@ export default function AccountDeletePage() {
                 있습니다.
               </p>
               <a
-                href="mailto:support@ac-trading.com"
+                href={`mailto:${SUPPORT_EMAIL}`}
                 className="font-medium underline"
                 style={{ color: "#5BBFB3" }}
               >
-                support@ac-trading.com
+                {SUPPORT_EMAIL}
               </a>
               <p className="mt-2 text-sm text-gray-500">
                 이메일 제목: [계정 삭제 요청] 가입 이메일 주소 기재
@@ -168,11 +171,11 @@ export default function AccountDeletePage() {
             <p>
               계정 삭제 관련 추가 문의는{" "}
               <a
-                href="mailto:support@ac-trading.com"
+                href={`mailto:${SUPPORT_EMAIL}`}
                 className="underline"
                 style={{ color: "#5BBFB3" }}
               >
-                support@ac-trading.com
+                {SUPPORT_EMAIL}
               </a>
               으로 연락 주시기 바랍니다.
             </p>

--- a/apps/web/src/app/profile/edit/page.tsx
+++ b/apps/web/src/app/profile/edit/page.tsx
@@ -277,6 +277,18 @@ export default function ProfileEditPage() {
             {isSubmitting ? "저장 중..." : user?.isProfileComplete ? "수정 완료" : "프로필 설정 완료"}
           </button>
 
+          {/* 계정 삭제 링크 - 프로필 완성된 기존 회원만 표시 */}
+          {user?.isProfileComplete && (
+            <div className="text-center mt-4">
+              <Link
+                href="/account-delete"
+                className="text-sm"
+                style={{ color: "#7ECEC5" }}
+              >
+                계정 삭제
+              </Link>
+            </div>
+          )}
         </form>
       </div>
     </div>

--- a/apps/web/src/app/profile/edit/page.tsx
+++ b/apps/web/src/app/profile/edit/page.tsx
@@ -163,10 +163,10 @@ export default function ProfileEditPage() {
                 value={formData.islandName}
                 onChange={handleChange}
                 placeholder="섬 이름"
-                className="flex-1 px-4 py-3 rounded-lg border border-gray-300 bg-white text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
+                className="flex-1 min-w-0 px-4 py-3 rounded-lg border border-gray-300 bg-white text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
               />
               {/* 섬/도 선택 버튼 */}
-              <div className="flex">
+              <div className="flex shrink-0">
                 <button
                   type="button"
                   onClick={() => setFormData((prev) => ({ ...prev, islandSuffix: "섬" }))}
@@ -276,6 +276,7 @@ export default function ProfileEditPage() {
           >
             {isSubmitting ? "저장 중..." : user?.isProfileComplete ? "수정 완료" : "프로필 설정 완료"}
           </button>
+
         </form>
       </div>
     </div>

--- a/apps/web/src/app/profile/edit/page.tsx
+++ b/apps/web/src/app/profile/edit/page.tsx
@@ -10,6 +10,9 @@ import { useAuth } from "@/context/AuthContext";
 if (!process.env.NEXT_PUBLIC_API_URL) throw new Error('NEXT_PUBLIC_API_URL 환경 변수가 설정되지 않았습니다.');
 const API_URL = process.env.NEXT_PUBLIC_API_URL;
 
+// 브랜드 민트 색상 (globals.css --primary와 별도로 계정 삭제 링크에 사용)
+const COLOR_MINT = "#7ECEC5";
+
 // 프로필 수정 페이지 - Figma 디자인 기반 (회원가입 페이지와 동일 스타일)
 export default function ProfileEditPage() {
   const router = useRouter();
@@ -283,7 +286,7 @@ export default function ProfileEditPage() {
               <Link
                 href="/account-delete"
                 className="text-sm"
-                style={{ color: "#7ECEC5" }}
+                style={{ color: COLOR_MINT }}
               >
                 계정 삭제
               </Link>


### PR DESCRIPTION
## Summary

- `/account-delete` 페이지 추가 — Google Play Store 정책 준수용 계정 삭제 요청 URL
- 프로필 수정 페이지 섬/도 버튼 잘림 수정
- 프로필 수정 페이지 하단에 계정 삭제 링크 추가

## 변경 사항

### 1. 계정 삭제 요청 페이지 (`/account-delete`)
Google Play Console > 앱 콘텐츠 > 데이터 보안에 제출할 URL  
Google Play 정책 3가지 요건 충족:
- 앱명(거동숲) 명시
- 계정 삭제 요청 단계 (앱 내 탈퇴 / 이메일 요청)
- 삭제 데이터 목록 + 법령 보관 기간 표 (6개월/3년/5년)

### 2. 섬/도 버튼 잘림 수정
- `input`에 `min-w-0` 추가 → flex 컨테이너 내 올바른 축소
- 버튼 그룹에 `shrink-0` 추가 → 버튼 잘림 방지

### 3. 계정 삭제 링크
- 저장 버튼 하단에 민트색(`#7ECEC5`) 텍스트 링크 추가
- 프로필 완성된 기존 회원에게만 표시 (`isProfileComplete` 조건)

## Closes

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 계정 삭제 정보 페이지 추가
  * 프로필 편집 페이지에 계정 삭제 링크 추가
  * 모바일 앱 뒤로 가기 동작 개선(서브페이지 감지 후 홈으로 복귀, 홈에서 이중 탭으로 종료, 토스트 알림, SPA 경로 변경 감지 및 핀치-줌 비활성화)

* **기타**
  * 프로덕션 Android App Bundle 빌드 설정 추가
  * 저장소 최상위 .expo/ 디렉터리 무시 규칙 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->