### PR TITLE
feat: Add settings page, blocked users management, and account deletion

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -33,7 +33,15 @@
       "Bash(railway logs:*)",
       "Bash(railway domain:*)",
       "Bash(gh pr create:*)",
-      "Bash(./gradlew test:*)"
+      "Bash(./gradlew test:*)",
+      "Bash(gh api:*)",
+      "Bash(gh issue list:*)",
+      "Bash(gh pr reopen:*)",
+      "Bash(gh pr view:*)",
+      "Bash(xargs cat)",
+      "Bash(gh issue view 130 --repo AC-trading/ac-trading --json title,body)",
+      "Bash(gh issue edit 130 --repo AC-trading/ac-trading --title \"fix: Profile nickname validation missing on frontend - save fails for 1-char or invalid input\")",
+      "Bash(gh issue view 127 --json title,body,state)"
     ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ nul
 
 # Temp files
 tmpclaude-*
+
+google-play-service-account.json

--- a/apps/web/src/app/account-delete/page.tsx
+++ b/apps/web/src/app/account-delete/page.tsx
@@ -1,16 +1,52 @@
-import { Metadata } from "next";
-import Link from "next/link";
+"use client";
 
-export const metadata: Metadata = {
-  title: "계정 삭제 요청 - 거동숲",
-  description: "거동숲 계정 및 데이터 삭제 요청 안내",
-};
+import Link from "next/link";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useAuth } from "@/context/AuthContext";
+
+if (!process.env.NEXT_PUBLIC_API_URL) throw new Error('NEXT_PUBLIC_API_URL 환경 변수가 설정되지 않았습니다.');
+const API_URL = process.env.NEXT_PUBLIC_API_URL;
 
 const SUPPORT_EMAIL =
   process.env.NEXT_PUBLIC_SUPPORT_EMAIL || "seulhuioh0710@gmail.com";
 
-// Google Play Store 정책 준수용 계정 삭제 요청 페이지
+// Google Play Store 정책 준수용 계정 삭제 페이지
 export default function AccountDeletePage() {
+  const router = useRouter();
+  const { accessToken, logout } = useAuth();
+  const [showConfirm, setShowConfirm] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleDelete = async () => {
+    if (!accessToken) {
+      router.push("/login");
+      return;
+    }
+    setIsDeleting(true);
+    setError(null);
+    try {
+      const res = await fetch(`${API_URL}/api/users/me/delete`, {
+        method: "POST",
+        credentials: "include",
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+      if (res.ok) {
+        await logout();
+      } else {
+        const data = await res.json().catch(() => null);
+        setError(data?.message || "계정 삭제에 실패했습니다. 다시 시도해주세요.");
+        setShowConfirm(false);
+      }
+    } catch {
+      setError("네트워크 오류가 발생했습니다. 다시 시도해주세요.");
+      setShowConfirm(false);
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
   return (
     <div className="min-h-screen" style={{ backgroundColor: "#FFFFFF" }}>
       {/* 헤더 */}
@@ -19,10 +55,10 @@ export default function AccountDeletePage() {
         style={{ backgroundColor: "#FFFFFF" }}
       >
         <div className="max-w-3xl mx-auto flex items-center gap-3">
-          <Link href="/" className="text-gray-600 hover:text-gray-900">
+          <Link href="/settings" className="text-gray-600 hover:text-gray-900">
             ← 돌아가기
           </Link>
-          <h1 className="text-lg font-semibold">계정 삭제 요청</h1>
+          <h1 className="text-lg font-semibold">계정 삭제</h1>
         </div>
       </header>
 
@@ -41,10 +77,10 @@ export default function AccountDeletePage() {
           {/* 계정 삭제 방법 */}
           <section>
             <h2 className="text-lg font-semibold text-gray-900 mb-4">
-              계정 삭제 요청 방법
+              계정 삭제 방법
             </h2>
 
-            {/* 방법 1: 앱 내 */}
+            {/* 방법 1: 앱/웹 내 */}
             <div className="mb-6">
               <div
                 className="inline-block text-xs font-semibold px-2 py-1 rounded mb-3"
@@ -56,9 +92,10 @@ export default function AccountDeletePage() {
                 {[
                   "앱 또는 웹에서 로그인합니다.",
                   "하단 탭의 [프로필] 메뉴로 이동합니다.",
-                  "[설정] 아이콘을 탭합니다.",
-                  "[계정 삭제] 버튼을 누르고 안내에 따라 진행합니다.",
-                  "삭제가 완료되면 법령 보관 대상을 제외한 계정 및 관련 데이터가 즉시 삭제 처리됩니다.",
+                  "우측 상단 설정 아이콘을 탭합니다.",
+                  "[탈퇴하기]를 누릅니다.",
+                  "이 페이지 하단의 [탈퇴하기] 버튼을 누르고 확인합니다.",
+                  "탈퇴가 완료되면 법령 보관 대상을 제외한 계정 및 관련 데이터가 즉시 삭제됩니다.",
                 ].map((step, i) => (
                   <li key={i} className="flex items-start gap-3">
                     <span
@@ -106,7 +143,7 @@ export default function AccountDeletePage() {
               삭제되는 데이터
             </h2>
             <p className="mb-3">
-              계정 삭제 요청 처리 시 다음 데이터가 <strong>즉시 삭제</strong>됩니다.
+              계정 삭제 시 다음 데이터가 <strong>즉시 삭제</strong>됩니다.
               단, 법령에 따라 보관이 필요한 데이터는 아래 표를 확인해주세요.
             </p>
             <ul className="list-disc pl-5 space-y-1">
@@ -182,6 +219,23 @@ export default function AccountDeletePage() {
             </p>
           </section>
         </div>
+
+        {/* 에러 메시지 */}
+        {error && (
+          <div className="mt-6 p-3 rounded-lg bg-red-50 border border-red-200">
+            <p className="text-red-600 text-sm">{error}</p>
+          </div>
+        )}
+
+        {/* 탈퇴하기 버튼 */}
+        <div className="mt-10 mb-4">
+          <button
+            onClick={() => setShowConfirm(true)}
+            className="w-full py-3 rounded-lg border border-red-300 text-red-500 font-semibold hover:bg-red-50 transition-colors"
+          >
+            탈퇴하기
+          </button>
+        </div>
       </main>
 
       {/* 푸터 */}
@@ -195,9 +249,39 @@ export default function AccountDeletePage() {
             개인정보처리방침
           </Link>
           <span className="mx-2">|</span>
-          <span className="font-medium text-gray-700">계정 삭제 요청</span>
+          <span className="font-medium text-gray-700">계정 삭제</span>
         </div>
       </footer>
+
+      {/* 탈퇴 확인 모달 */}
+      {showConfirm && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+          <div className="bg-white rounded-2xl mx-6 w-full max-w-sm overflow-hidden">
+            <div className="px-6 py-6 text-center">
+              <p className="text-base font-semibold text-gray-900">정말 탈퇴하시겠습니까?</p>
+              <p className="mt-2 text-sm text-gray-500">
+                계정 및 모든 데이터가 삭제되며 복구할 수 없습니다.
+              </p>
+            </div>
+            <div className="flex border-t border-gray-100">
+              <button
+                onClick={() => setShowConfirm(false)}
+                disabled={isDeleting}
+                className="flex-1 py-4 text-sm text-gray-500 hover:bg-gray-50 transition-colors border-r border-gray-100 disabled:opacity-50"
+              >
+                아니오
+              </button>
+              <button
+                onClick={handleDelete}
+                disabled={isDeleting}
+                className="flex-1 py-4 text-sm font-semibold text-red-500 hover:bg-red-50 transition-colors disabled:opacity-50"
+              >
+                {isDeleting ? "처리 중..." : "예, 탈퇴합니다"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/app/profile/edit/page.tsx
+++ b/apps/web/src/app/profile/edit/page.tsx
@@ -215,6 +215,7 @@ export default function ProfileEditPage() {
               placeholder="이름을 입력하세요"
               className="w-full px-4 py-3 rounded-lg border border-gray-300 bg-white text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
             />
+            <p className="text-xs mt-1 text-gray-400">2~50자로 입력해주세요.</p>
           </div>
 
           {/* 반구 - 신규 유저만 수정 가능 */}
@@ -274,7 +275,7 @@ export default function ProfileEditPage() {
           {/* 저장 버튼 */}
           <button
             type="submit"
-            disabled={!isIslandNameValid || !formData.name || isSubmitting}
+            disabled={!isIslandNameValid || formData.name.trim().length < 2 || isSubmitting}
             className="w-full py-3 rounded-lg bg-primary text-white font-semibold hover:bg-primary-dark transition-colors disabled:opacity-50 disabled:cursor-not-allowed mt-6"
           >
             {isSubmitting ? "저장 중..." : user?.isProfileComplete ? "수정 완료" : "프로필 설정 완료"}

--- a/apps/web/src/app/profile/edit/page.tsx
+++ b/apps/web/src/app/profile/edit/page.tsx
@@ -213,6 +213,7 @@ export default function ProfileEditPage() {
               value={formData.name}
               onChange={handleChange}
               placeholder="이름을 입력하세요"
+              maxLength={50}
               className="w-full px-4 py-3 rounded-lg border border-gray-300 bg-white text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
             />
             <p className="text-xs mt-1 text-gray-400">2~50자로 입력해주세요.</p>

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -50,9 +50,9 @@ export default function ProfilePage() {
       <Header
         showLocation
         rightElement={
-          <button className="p-1 hover:bg-gray-100 rounded-full transition-colors">
+          <Link href="/settings" className="p-1 hover:bg-gray-100 rounded-full transition-colors">
             <SettingsIcon className="text-black" />
-          </button>
+          </Link>
         }
       />
 

--- a/apps/web/src/app/profile/setup/page.tsx
+++ b/apps/web/src/app/profile/setup/page.tsx
@@ -180,6 +180,7 @@ export default function ProfileSetupPage() {
               value={formData.name}
               onChange={handleChange}
               placeholder="이름을 입력하세요"
+              maxLength={50}
               className="w-full px-4 py-3 rounded-lg border border-gray-300 bg-white text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
             />
             <p className="text-xs mt-1 text-gray-400">2~50자로 입력해주세요.</p>

--- a/apps/web/src/app/profile/setup/page.tsx
+++ b/apps/web/src/app/profile/setup/page.tsx
@@ -182,6 +182,7 @@ export default function ProfileSetupPage() {
               placeholder="이름을 입력하세요"
               className="w-full px-4 py-3 rounded-lg border border-gray-300 bg-white text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
             />
+            <p className="text-xs mt-1 text-gray-400">2~50자로 입력해주세요.</p>
           </div>
 
           {/* 반구 */}
@@ -252,7 +253,7 @@ export default function ProfileSetupPage() {
           {/* 시작하기 버튼 */}
           <button
             type="submit"
-            disabled={!formData.islandName.trim() || !formData.name.trim() || !agreedToTerms || isSubmitting}
+            disabled={!formData.islandName.trim() || formData.name.trim().length < 2 || !agreedToTerms || isSubmitting}
             className="w-full py-3 rounded-lg bg-primary text-white font-semibold hover:bg-primary-dark transition-colors disabled:opacity-50 disabled:cursor-not-allowed mt-6"
           >
             {isSubmitting ? "설정 중..." : "시작하기"}

--- a/apps/web/src/app/settings/blocked/page.tsx
+++ b/apps/web/src/app/settings/blocked/page.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, useEffect, useCallback } from "react";
+import { MobileLayout } from "@/components/common";
+import { ChevronLeftIcon } from "@/components/icons";
+import { useAuth } from "@/context/AuthContext";
+
+if (!process.env.NEXT_PUBLIC_API_URL) throw new Error('NEXT_PUBLIC_API_URL 환경 변수가 설정되지 않았습니다.');
+const API_URL = process.env.NEXT_PUBLIC_API_URL;
+
+interface BlockedUser {
+  id: number;
+  blockedUserId: number;
+  blockedUserNickname: string;
+  createdAt: string;
+}
+
+// 차단 사용자 목록 관리 페이지
+export default function BlockedUsersPage() {
+  const router = useRouter();
+  const { accessToken } = useAuth();
+  const [blockedUsers, setBlockedUsers] = useState<BlockedUser[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [confirmTarget, setConfirmTarget] = useState<BlockedUser | null>(null);
+  const [isUnblocking, setIsUnblocking] = useState(false);
+
+  const fetchBlockedUsers = useCallback(async () => {
+    if (!accessToken) return;
+    try {
+      const res = await fetch(`${API_URL}/api/blocks`, {
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setBlockedUsers(data.blocks ?? []);
+      }
+    } catch (err) {
+      console.error("차단 목록 조회 실패:", err);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [accessToken]);
+
+  useEffect(() => {
+    fetchBlockedUsers();
+  }, [fetchBlockedUsers]);
+
+  const handleUnblock = async () => {
+    if (!confirmTarget || !accessToken) return;
+    setIsUnblocking(true);
+    try {
+      const res = await fetch(`${API_URL}/api/blocks/${confirmTarget.blockedUserId}`, {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+      if (res.ok) {
+        setBlockedUsers((prev) => prev.filter((u) => u.blockedUserId !== confirmTarget.blockedUserId));
+      }
+    } catch (err) {
+      console.error("차단 해제 실패:", err);
+    } finally {
+      setIsUnblocking(false);
+      setConfirmTarget(null);
+    }
+  };
+
+  return (
+    <MobileLayout>
+      {/* 헤더 */}
+      <header className="sticky top-0 z-40 bg-white border-b border-gray-100">
+        <div className="flex items-center h-14 px-4 gap-2">
+          <button
+            onClick={() => router.back()}
+            className="p-1 -ml-1 hover:bg-gray-100 rounded-full transition-colors"
+          >
+            <ChevronLeftIcon className="text-black" />
+          </button>
+          <h1 className="font-semibold text-lg text-black">차단 사용자 관리</h1>
+        </div>
+      </header>
+
+      {/* 목록 */}
+      {isLoading ? (
+        <div className="flex items-center justify-center py-20">
+          <div className="animate-spin rounded-full h-8 w-8 border-2 border-primary border-t-transparent" />
+        </div>
+      ) : blockedUsers.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-20 text-gray-400">
+          <p className="text-sm">차단한 사용자가 없습니다.</p>
+        </div>
+      ) : (
+        <ul className="divide-y divide-gray-100">
+          {blockedUsers.map((user) => (
+            <li key={user.id}>
+              <button
+                onClick={() => setConfirmTarget(user)}
+                className="w-full flex items-center justify-between px-4 py-4 hover:bg-gray-50 transition-colors text-left"
+              >
+                <span className="text-black">{user.blockedUserNickname}</span>
+                <span className="text-xs text-gray-400">차단 해제</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {/* 차단 해제 확인 모달 */}
+      {confirmTarget && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+          <div className="bg-white rounded-2xl mx-6 w-full max-w-sm overflow-hidden">
+            <div className="px-6 py-6 text-center">
+              <p className="text-base font-semibold text-gray-900">
+                {confirmTarget.blockedUserNickname}
+              </p>
+              <p className="mt-2 text-sm text-gray-500">차단을 해제하시겠습니까?</p>
+            </div>
+            <div className="flex border-t border-gray-100">
+              <button
+                onClick={() => setConfirmTarget(null)}
+                className="flex-1 py-4 text-sm text-gray-500 hover:bg-gray-50 transition-colors border-r border-gray-100"
+              >
+                아니오
+              </button>
+              <button
+                onClick={handleUnblock}
+                disabled={isUnblocking}
+                className="flex-1 py-4 text-sm font-semibold text-primary hover:bg-gray-50 transition-colors disabled:opacity-50"
+              >
+                {isUnblocking ? "처리 중..." : "예"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </MobileLayout>
+  );
+}

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -59,15 +59,6 @@ export default function SettingsPage() {
           <ChevronRightIcon className="text-gray-400" />
         </Link>
 
-        {/* 오픈소스 라이선스 */}
-        <Link
-          href="/settings/licenses"
-          className="flex items-center justify-between px-4 py-4 hover:bg-gray-50 transition-colors"
-        >
-          <span className="text-black">오픈소스 라이선스</span>
-          <ChevronRightIcon className="text-gray-400" />
-        </Link>
-
         {/* 로그아웃 */}
         <button
           onClick={handleLogout}

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { MobileLayout } from "@/components/common";
+import { ChevronLeftIcon, ChevronRightIcon } from "@/components/icons";
+import { useAuth } from "@/context/AuthContext";
+
+// 설정 페이지
+export default function SettingsPage() {
+  const router = useRouter();
+  const { logout } = useAuth();
+
+  const handleLogout = async () => {
+    await logout();
+  };
+
+  return (
+    <MobileLayout>
+      {/* 헤더 */}
+      <header className="sticky top-0 z-40 bg-white border-b border-gray-100">
+        <div className="flex items-center h-14 px-4 gap-2">
+          <button
+            onClick={() => router.back()}
+            className="p-1 -ml-1 hover:bg-gray-100 rounded-full transition-colors"
+          >
+            <ChevronLeftIcon className="text-black" />
+          </button>
+          <h1 className="font-semibold text-lg text-black">설정</h1>
+        </div>
+      </header>
+
+      {/* 메뉴 */}
+      <div className="divide-y divide-gray-100">
+        {/* 내 계정 */}
+        <Link
+          href="/profile/edit"
+          className="flex items-center justify-between px-4 py-4 hover:bg-gray-50 transition-colors"
+        >
+          <span className="text-black">내 계정</span>
+          <ChevronRightIcon className="text-gray-400" />
+        </Link>
+
+        {/* 차단 사용자 관리 */}
+        <Link
+          href="/settings/blocked"
+          className="flex items-center justify-between px-4 py-4 hover:bg-gray-50 transition-colors"
+        >
+          <span className="text-black">차단 사용자 관리</span>
+          <ChevronRightIcon className="text-gray-400" />
+        </Link>
+
+        {/* 공지사항 */}
+        <Link
+          href="/settings/notice"
+          className="flex items-center justify-between px-4 py-4 hover:bg-gray-50 transition-colors"
+        >
+          <span className="text-black">공지사항</span>
+          <ChevronRightIcon className="text-gray-400" />
+        </Link>
+
+        {/* 오픈소스 라이선스 */}
+        <Link
+          href="/settings/licenses"
+          className="flex items-center justify-between px-4 py-4 hover:bg-gray-50 transition-colors"
+        >
+          <span className="text-black">오픈소스 라이선스</span>
+          <ChevronRightIcon className="text-gray-400" />
+        </Link>
+
+        {/* 로그아웃 */}
+        <button
+          onClick={handleLogout}
+          className="w-full flex items-center justify-between px-4 py-4 hover:bg-gray-50 transition-colors text-left"
+        >
+          <span className="text-black">로그아웃</span>
+        </button>
+
+        {/* 탈퇴하기 */}
+        <Link
+          href="/account-delete"
+          className="flex items-center justify-between px-4 py-4 hover:bg-gray-50 transition-colors"
+        >
+          <span className="text-red-500">탈퇴하기</span>
+        </Link>
+      </div>
+    </MobileLayout>
+  );
+}


### PR DESCRIPTION
## Summary
- 설정 페이지(`/settings`) 추가 — 내 계정, 차단 사용자 관리, 공지사항, 로그아웃, 탈퇴하기
- 프로필 헤더 설정 아이콘 → `/settings` 링크 연결
- 차단 사용자 관리 페이지(`/settings/blocked`) — 목록 조회 및 차단 해제 확인 모달
- 계정 삭제 페이지 탈퇴하기 버튼 추가 — 확인 모달 후 `POST /api/users/me/delete` 호출
- 닉네임 최소 2자 유효성 검사 및 `maxLength={50}` 추가 (profile/edit, profile/setup)

Closes #127
Closes #130

## Test plan
- [ ] 프로필 탭 설정 아이콘 클릭 → `/settings` 이동 확인
- [ ] 설정 > 내 계정 → 프로필 수정 페이지 이동 확인
- [ ] 설정 > 차단 사용자 관리 → 차단 목록 표시 확인
- [ ] 차단 유저 클릭 → 차단 해제 모달 (예/아니오) 확인
- [ ] 설정 > 로그아웃 동작 확인
- [ ] 설정 > 탈퇴하기 → 계정 삭제 페이지 → 탈퇴하기 버튼 → 확인 모달 → 실제 탈퇴 확인
- [ ] 닉네임 1자 입력 시 저장 버튼 비활성화 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)